### PR TITLE
Add custom marker icons with user auto-detection

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -247,6 +247,73 @@ export class WeatherRadarCardEditor extends ScopedRegistryHost(LitElement) imple
             ></mwc-switch>
           </mwc-formfield>
         </div>
+        ${
+          config.show_marker === true
+            ? html`
+                <h3>Marker Icon</h3>
+                <div class="side-by-side">
+                  <mwc-select
+                    label="Icon Type"
+                    .configValue=${'marker_icon'}
+                    .value=${config.marker_icon || 'default'}
+                    @selected=${this._valueChangedString}
+                    @closed=${(ev) => ev.stopPropagation()}
+                  >
+                    <mwc-list-item value="default">Default (Home)</mwc-list-item>
+                    <mwc-list-item value="entity_picture">Entity Picture</mwc-list-item>
+                    <mwc-list-item value="mdi:account">MDI: Account</mwc-list-item>
+                    <mwc-list-item value="mdi:account-circle">MDI: Account Circle</mwc-list-item>
+                    <mwc-list-item value="mdi:map-marker">MDI: Map Marker</mwc-list-item>
+                    <mwc-list-item value="mdi:home">MDI: Home</mwc-list-item>
+                    <mwc-list-item value="mdi:car">MDI: Car</mwc-list-item>
+                    <mwc-list-item value="mdi:cellphone">MDI: Cellphone</mwc-list-item>
+                  </mwc-select>
+                </div>
+                ${config.marker_icon === 'entity_picture'
+                  ? html`
+                      <mwc-textfield
+                        label="Icon Entity (optional)"
+                        .value=${config.marker_icon_entity || ''}
+                        .configValue=${'marker_icon_entity'}
+                        @input=${this._valueChangedString}
+                        helper="Entity with picture (auto-detects from marker entity if empty)"
+                      ></mwc-textfield>
+                    `
+                  : ''}
+                <h4>Mobile Icon Overrides</h4>
+                <div class="side-by-side">
+                  <mwc-select
+                    label="Mobile Icon Type (optional)"
+                    .configValue=${'mobile_marker_icon'}
+                    .value=${config.mobile_marker_icon || ''}
+                    @selected=${this._valueChangedString}
+                    @closed=${(ev) => ev.stopPropagation()}
+                  >
+                    <mwc-list-item></mwc-list-item>
+                    <mwc-list-item value="default">Default (Home)</mwc-list-item>
+                    <mwc-list-item value="entity_picture">Entity Picture</mwc-list-item>
+                    <mwc-list-item value="mdi:account">MDI: Account</mwc-list-item>
+                    <mwc-list-item value="mdi:account-circle">MDI: Account Circle</mwc-list-item>
+                    <mwc-list-item value="mdi:map-marker">MDI: Map Marker</mwc-list-item>
+                    <mwc-list-item value="mdi:home">MDI: Home</mwc-list-item>
+                    <mwc-list-item value="mdi:car">MDI: Car</mwc-list-item>
+                    <mwc-list-item value="mdi:cellphone">MDI: Cellphone</mwc-list-item>
+                  </mwc-select>
+                </div>
+                ${config.mobile_marker_icon === 'entity_picture'
+                  ? html`
+                      <mwc-textfield
+                        label="Mobile Icon Entity (optional)"
+                        .value=${config.mobile_marker_icon_entity || ''}
+                        .configValue=${'mobile_marker_icon_entity'}
+                        @input=${this._valueChangedString}
+                        helper="Mobile override for entity with picture"
+                      ></mwc-textfield>
+                    `
+                  : ''}
+              `
+            : ''
+        }
         <div class="side-by-side">
           <mwc-formfield .label=${"Show Scale"}>
             <mwc-switch

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,11 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
   mobile_marker_latitude?: CoordinateConfig;
   mobile_center_longitude?: CoordinateConfig;
   mobile_center_latitude?: CoordinateConfig;
+  // Marker icon configuration
+  marker_icon?: string; // "default" | "entity_picture" | "mdi:icon-name"
+  marker_icon_entity?: string; // Entity ID for entity_picture source
+  mobile_marker_icon?: string; // Mobile override for marker icon type
+  mobile_marker_icon_entity?: string; // Mobile override for icon entity
   zoom_level: undefined;
   type: string;
   name?: string;


### PR DESCRIPTION
This PR is in reference to 58 submitted by @kovacsla.

- Add `marker_icon config:` `default`, `entity_picture`, or `mdi:* icon`
- Add `mobile_marker_icon` with `entity_picture` as default
- Auto-detect logged-in user's person entity and device tracker
- Auto-detect mobile coordinates from user's device tracker
- Mobile detection: HA app, screen width <=768px, or mobile UA
- Add visual editor fields for marker icon configuration


## ⚠️ IMPORTANT: Cache Clearing On Mobile

After updating the card, you **must clear the app cache** on mobile devices for changes to take effect.  

In the **HA Companion App** go to `Settings > Companion App > Debugging > Reset front end cache`

## New Configuration Options

| Option | Description | Default |
|--------|-------------|---------|
| `marker_icon` | Icon type for desktop: `"default"`, `"entity_picture"`, or `"mdi:<icon-name>"` | `"default"` |
| `marker_icon_entity` | Entity ID for entity_picture mode (auto-detects if not set) | - |
| `mobile_marker_icon` | Icon type for mobile devices | `"entity_picture"` |
| `mobile_marker_icon_entity` | Entity ID for mobile entity_picture mode (auto-detects if not set) | - |

**Available MDI icons:** `account`, `account-circle`, `map-marker`, `home`, `car`, `cellphone`

## Auto-Detection Features

### User Detection
- Automatically identifies the logged-in user via `hass.user.id`
- Finds their associated person entity (matching `user_id` attribute)
- Retrieves their `device_trackers` for location
- Retrieves their `entity_picture` for the marker icon

### Mobile Coordinate Auto-Detection
- When on mobile with no `mobile_*` coordinate config specified
- Automatically uses the logged-in user's primary device tracker
- Centers map and places marker at user's current location

### Mobile Detection Triggers
- Home Assistant Companion app
- Screen width <= 768px
- Mobile user agent (Android, iOS, etc.)

## Example Configurations

### Minimal config (full auto-detection on mobile)

```yaml
type: custom:weather-radar-card
show_marker: true
```

Each user sees their own location and profile picture on mobile.

### Desktop MDI icon, mobile auto-detected profile photo

```yaml
type: custom:weather-radar-card
show_marker: true
marker_icon: mdi:map-marker
```

### Explicit entity picture for specific person

```yaml
type: custom:weather-radar-card
show_marker: true
marker_icon: entity_picture
marker_icon_entity: person.john
```

### Different icons for desktop vs mobile

```yaml
type: custom:weather-radar-card
show_marker: true
marker_icon: mdi:home
mobile_marker_icon: mdi:account
```

## Requirements for Auto-Detection

For automatic user detection to work, each Home Assistant user needs:

1. A **person entity** with:
   - `user_id` attribute matching their HA user ID
   - `device_trackers` attribute with at least one tracker
   - `entity_picture` attribute (for profile photo)

2. The person entity is typically created automatically when you add a user to Home Assistant and assign them a person.

## Visual Editor

When "Show Marker" is enabled, new fields appear in the visual editor:

- **Icon Type** dropdown (Default, Entity Picture, MDI options)
- **Icon Entity** text field (shown when Entity Picture selected)
- **Mobile Icon Overrides** section with same options

