### PR TITLE
fix: map z-index, timestamp wrapping, LitElement rendering — v3.0.2

### DIFF
--- a/dist/weather-radar-card.js
+++ b/dist/weather-radar-card.js
@@ -14601,26 +14601,26 @@ var leafletSrcExports = requireLeafletSrc();
 var leafletCss = "/* required styles */\r\n\r\n.leaflet-pane,\r\n.leaflet-tile,\r\n.leaflet-marker-icon,\r\n.leaflet-marker-shadow,\r\n.leaflet-tile-container,\r\n.leaflet-pane > svg,\r\n.leaflet-pane > canvas,\r\n.leaflet-zoom-box,\r\n.leaflet-image-layer,\r\n.leaflet-layer {\r\n\tposition: absolute;\r\n\tleft: 0;\r\n\ttop: 0;\r\n\t}\r\n.leaflet-container {\r\n\toverflow: hidden;\r\n\t}\r\n.leaflet-tile,\r\n.leaflet-marker-icon,\r\n.leaflet-marker-shadow {\r\n\t-webkit-user-select: none;\r\n\t   -moz-user-select: none;\r\n\t        user-select: none;\r\n\t  -webkit-user-drag: none;\r\n\t}\r\n/* Prevents IE11 from highlighting tiles in blue */\r\n.leaflet-tile::selection {\r\n\tbackground: transparent;\r\n}\r\n/* Safari renders non-retina tile on retina better with this, but Chrome is worse */\r\n.leaflet-safari .leaflet-tile {\r\n\timage-rendering: -webkit-optimize-contrast;\r\n\t}\r\n/* hack that prevents hw layers \"stretching\" when loading new tiles */\r\n.leaflet-safari .leaflet-tile-container {\r\n\twidth: 1600px;\r\n\theight: 1600px;\r\n\t-webkit-transform-origin: 0 0;\r\n\t}\r\n.leaflet-marker-icon,\r\n.leaflet-marker-shadow {\r\n\tdisplay: block;\r\n\t}\r\n/* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */\r\n/* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */\r\n.leaflet-container .leaflet-overlay-pane svg {\r\n\tmax-width: none !important;\r\n\tmax-height: none !important;\r\n\t}\r\n.leaflet-container .leaflet-marker-pane img,\r\n.leaflet-container .leaflet-shadow-pane img,\r\n.leaflet-container .leaflet-tile-pane img,\r\n.leaflet-container img.leaflet-image-layer,\r\n.leaflet-container .leaflet-tile {\r\n\tmax-width: none !important;\r\n\tmax-height: none !important;\r\n\twidth: auto;\r\n\tpadding: 0;\r\n\t}\r\n\r\n.leaflet-container img.leaflet-tile {\r\n\t/* See: https://bugs.chromium.org/p/chromium/issues/detail?id=600120 */\r\n\tmix-blend-mode: plus-lighter;\r\n}\r\n\r\n.leaflet-container.leaflet-touch-zoom {\r\n\t-ms-touch-action: pan-x pan-y;\r\n\ttouch-action: pan-x pan-y;\r\n\t}\r\n.leaflet-container.leaflet-touch-drag {\r\n\t-ms-touch-action: pinch-zoom;\r\n\t/* Fallback for FF which doesn't support pinch-zoom */\r\n\ttouch-action: none;\r\n\ttouch-action: pinch-zoom;\r\n}\r\n.leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {\r\n\t-ms-touch-action: none;\r\n\ttouch-action: none;\r\n}\r\n.leaflet-container {\r\n\t-webkit-tap-highlight-color: transparent;\r\n}\r\n.leaflet-container a {\r\n\t-webkit-tap-highlight-color: rgba(51, 181, 229, 0.4);\r\n}\r\n.leaflet-tile {\r\n\tfilter: inherit;\r\n\tvisibility: hidden;\r\n\t}\r\n.leaflet-tile-loaded {\r\n\tvisibility: inherit;\r\n\t}\r\n.leaflet-zoom-box {\r\n\twidth: 0;\r\n\theight: 0;\r\n\t-moz-box-sizing: border-box;\r\n\t     box-sizing: border-box;\r\n\tz-index: 800;\r\n\t}\r\n/* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */\r\n.leaflet-overlay-pane svg {\r\n\t-moz-user-select: none;\r\n\t}\r\n\r\n.leaflet-pane         { z-index: 400; }\r\n\r\n.leaflet-tile-pane    { z-index: 200; }\r\n.leaflet-overlay-pane { z-index: 400; }\r\n.leaflet-shadow-pane  { z-index: 500; }\r\n.leaflet-marker-pane  { z-index: 600; }\r\n.leaflet-tooltip-pane   { z-index: 650; }\r\n.leaflet-popup-pane   { z-index: 700; }\r\n\r\n.leaflet-map-pane canvas { z-index: 100; }\r\n.leaflet-map-pane svg    { z-index: 200; }\r\n\r\n.leaflet-vml-shape {\r\n\twidth: 1px;\r\n\theight: 1px;\r\n\t}\r\n.lvml {\r\n\tbehavior: url(#default#VML);\r\n\tdisplay: inline-block;\r\n\tposition: absolute;\r\n\t}\r\n\r\n\r\n/* control positioning */\r\n\r\n.leaflet-control {\r\n\tposition: relative;\r\n\tz-index: 800;\r\n\tpointer-events: visiblePainted; /* IE 9-10 doesn't have auto */\r\n\tpointer-events: auto;\r\n\t}\r\n.leaflet-top,\r\n.leaflet-bottom {\r\n\tposition: absolute;\r\n\tz-index: 1000;\r\n\tpointer-events: none;\r\n\t}\r\n.leaflet-top {\r\n\ttop: 0;\r\n\t}\r\n.leaflet-right {\r\n\tright: 0;\r\n\t}\r\n.leaflet-bottom {\r\n\tbottom: 0;\r\n\t}\r\n.leaflet-left {\r\n\tleft: 0;\r\n\t}\r\n.leaflet-control {\r\n\tfloat: left;\r\n\tclear: both;\r\n\t}\r\n.leaflet-right .leaflet-control {\r\n\tfloat: right;\r\n\t}\r\n.leaflet-top .leaflet-control {\r\n\tmargin-top: 10px;\r\n\t}\r\n.leaflet-bottom .leaflet-control {\r\n\tmargin-bottom: 10px;\r\n\t}\r\n.leaflet-left .leaflet-control {\r\n\tmargin-left: 10px;\r\n\t}\r\n.leaflet-right .leaflet-control {\r\n\tmargin-right: 10px;\r\n\t}\r\n\r\n\r\n/* zoom and fade animations */\r\n\r\n.leaflet-fade-anim .leaflet-popup {\r\n\topacity: 0;\r\n\t-webkit-transition: opacity 0.2s linear;\r\n\t   -moz-transition: opacity 0.2s linear;\r\n\t        transition: opacity 0.2s linear;\r\n\t}\r\n.leaflet-fade-anim .leaflet-map-pane .leaflet-popup {\r\n\topacity: 1;\r\n\t}\r\n.leaflet-zoom-animated {\r\n\t-webkit-transform-origin: 0 0;\r\n\t    -ms-transform-origin: 0 0;\r\n\t        transform-origin: 0 0;\r\n\t}\r\nsvg.leaflet-zoom-animated {\r\n\twill-change: transform;\r\n}\r\n\r\n.leaflet-zoom-anim .leaflet-zoom-animated {\r\n\t-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);\r\n\t   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);\r\n\t        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);\r\n\t}\r\n.leaflet-zoom-anim .leaflet-tile,\r\n.leaflet-pan-anim .leaflet-tile {\r\n\t-webkit-transition: none;\r\n\t   -moz-transition: none;\r\n\t        transition: none;\r\n\t}\r\n\r\n.leaflet-zoom-anim .leaflet-zoom-hide {\r\n\tvisibility: hidden;\r\n\t}\r\n\r\n\r\n/* cursors */\r\n\r\n.leaflet-interactive {\r\n\tcursor: pointer;\r\n\t}\r\n.leaflet-grab {\r\n\tcursor: -webkit-grab;\r\n\tcursor:    -moz-grab;\r\n\tcursor:         grab;\r\n\t}\r\n.leaflet-crosshair,\r\n.leaflet-crosshair .leaflet-interactive {\r\n\tcursor: crosshair;\r\n\t}\r\n.leaflet-popup-pane,\r\n.leaflet-control {\r\n\tcursor: auto;\r\n\t}\r\n.leaflet-dragging .leaflet-grab,\r\n.leaflet-dragging .leaflet-grab .leaflet-interactive,\r\n.leaflet-dragging .leaflet-marker-draggable {\r\n\tcursor: move;\r\n\tcursor: -webkit-grabbing;\r\n\tcursor:    -moz-grabbing;\r\n\tcursor:         grabbing;\r\n\t}\r\n\r\n/* marker & overlays interactivity */\r\n.leaflet-marker-icon,\r\n.leaflet-marker-shadow,\r\n.leaflet-image-layer,\r\n.leaflet-pane > svg path,\r\n.leaflet-tile-container {\r\n\tpointer-events: none;\r\n\t}\r\n\r\n.leaflet-marker-icon.leaflet-interactive,\r\n.leaflet-image-layer.leaflet-interactive,\r\n.leaflet-pane > svg path.leaflet-interactive,\r\nsvg.leaflet-image-layer.leaflet-interactive path {\r\n\tpointer-events: visiblePainted; /* IE 9-10 doesn't have auto */\r\n\tpointer-events: auto;\r\n\t}\r\n\r\n/* visual tweaks */\r\n\r\n.leaflet-container {\r\n\tbackground: #ddd;\r\n\toutline-offset: 1px;\r\n\t}\r\n.leaflet-container a {\r\n\tcolor: #0078A8;\r\n\t}\r\n.leaflet-zoom-box {\r\n\tborder: 2px dotted #38f;\r\n\tbackground: rgba(255,255,255,0.5);\r\n\t}\r\n\r\n\r\n/* general typography */\r\n.leaflet-container {\r\n\tfont-family: \"Helvetica Neue\", Arial, Helvetica, sans-serif;\r\n\tfont-size: 12px;\r\n\tfont-size: 0.75rem;\r\n\tline-height: 1.5;\r\n\t}\r\n\r\n\r\n/* general toolbar styles */\r\n\r\n.leaflet-bar {\r\n\tbox-shadow: 0 1px 5px rgba(0,0,0,0.65);\r\n\tborder-radius: 4px;\r\n\t}\r\n.leaflet-bar a {\r\n\tbackground-color: #fff;\r\n\tborder-bottom: 1px solid #ccc;\r\n\twidth: 26px;\r\n\theight: 26px;\r\n\tline-height: 26px;\r\n\tdisplay: block;\r\n\ttext-align: center;\r\n\ttext-decoration: none;\r\n\tcolor: black;\r\n\t}\r\n.leaflet-bar a,\r\n.leaflet-control-layers-toggle {\r\n\tbackground-position: 50% 50%;\r\n\tbackground-repeat: no-repeat;\r\n\tdisplay: block;\r\n\t}\r\n.leaflet-bar a:hover,\r\n.leaflet-bar a:focus {\r\n\tbackground-color: #f4f4f4;\r\n\t}\r\n.leaflet-bar a:first-child {\r\n\tborder-top-left-radius: 4px;\r\n\tborder-top-right-radius: 4px;\r\n\t}\r\n.leaflet-bar a:last-child {\r\n\tborder-bottom-left-radius: 4px;\r\n\tborder-bottom-right-radius: 4px;\r\n\tborder-bottom: none;\r\n\t}\r\n.leaflet-bar a.leaflet-disabled {\r\n\tcursor: default;\r\n\tbackground-color: #f4f4f4;\r\n\tcolor: #bbb;\r\n\t}\r\n\r\n.leaflet-touch .leaflet-bar a {\r\n\twidth: 30px;\r\n\theight: 30px;\r\n\tline-height: 30px;\r\n\t}\r\n.leaflet-touch .leaflet-bar a:first-child {\r\n\tborder-top-left-radius: 2px;\r\n\tborder-top-right-radius: 2px;\r\n\t}\r\n.leaflet-touch .leaflet-bar a:last-child {\r\n\tborder-bottom-left-radius: 2px;\r\n\tborder-bottom-right-radius: 2px;\r\n\t}\r\n\r\n/* zoom control */\r\n\r\n.leaflet-control-zoom-in,\r\n.leaflet-control-zoom-out {\r\n\tfont: bold 18px 'Lucida Console', Monaco, monospace;\r\n\ttext-indent: 1px;\r\n\t}\r\n\r\n.leaflet-touch .leaflet-control-zoom-in, .leaflet-touch .leaflet-control-zoom-out  {\r\n\tfont-size: 22px;\r\n\t}\r\n\r\n\r\n/* layers control */\r\n\r\n.leaflet-control-layers {\r\n\tbox-shadow: 0 1px 5px rgba(0,0,0,0.4);\r\n\tbackground: #fff;\r\n\tborder-radius: 5px;\r\n\t}\r\n.leaflet-control-layers-toggle {\r\n\tbackground-image: url(images/layers.png);\r\n\twidth: 36px;\r\n\theight: 36px;\r\n\t}\r\n.leaflet-retina .leaflet-control-layers-toggle {\r\n\tbackground-image: url(images/layers-2x.png);\r\n\tbackground-size: 26px 26px;\r\n\t}\r\n.leaflet-touch .leaflet-control-layers-toggle {\r\n\twidth: 44px;\r\n\theight: 44px;\r\n\t}\r\n.leaflet-control-layers .leaflet-control-layers-list,\r\n.leaflet-control-layers-expanded .leaflet-control-layers-toggle {\r\n\tdisplay: none;\r\n\t}\r\n.leaflet-control-layers-expanded .leaflet-control-layers-list {\r\n\tdisplay: block;\r\n\tposition: relative;\r\n\t}\r\n.leaflet-control-layers-expanded {\r\n\tpadding: 6px 10px 6px 6px;\r\n\tcolor: #333;\r\n\tbackground: #fff;\r\n\t}\r\n.leaflet-control-layers-scrollbar {\r\n\toverflow-y: scroll;\r\n\toverflow-x: hidden;\r\n\tpadding-right: 5px;\r\n\t}\r\n.leaflet-control-layers-selector {\r\n\tmargin-top: 2px;\r\n\tposition: relative;\r\n\ttop: 1px;\r\n\t}\r\n.leaflet-control-layers label {\r\n\tdisplay: block;\r\n\tfont-size: 13px;\r\n\tfont-size: 1.08333em;\r\n\t}\r\n.leaflet-control-layers-separator {\r\n\theight: 0;\r\n\tborder-top: 1px solid #ddd;\r\n\tmargin: 5px -10px 5px -6px;\r\n\t}\r\n\r\n/* Default icon URLs */\r\n.leaflet-default-icon-path { /* used only in path-guessing heuristic, see L.Icon.Default */\r\n\tbackground-image: url(images/marker-icon.png);\r\n\t}\r\n\r\n\r\n/* attribution and scale controls */\r\n\r\n.leaflet-container .leaflet-control-attribution {\r\n\tbackground: #fff;\r\n\tbackground: rgba(255, 255, 255, 0.8);\r\n\tmargin: 0;\r\n\t}\r\n.leaflet-control-attribution,\r\n.leaflet-control-scale-line {\r\n\tpadding: 0 5px;\r\n\tcolor: #333;\r\n\tline-height: 1.4;\r\n\t}\r\n.leaflet-control-attribution a {\r\n\ttext-decoration: none;\r\n\t}\r\n.leaflet-control-attribution a:hover,\r\n.leaflet-control-attribution a:focus {\r\n\ttext-decoration: underline;\r\n\t}\r\n.leaflet-attribution-flag {\r\n\tdisplay: inline !important;\r\n\tvertical-align: baseline !important;\r\n\twidth: 1em;\r\n\theight: 0.6669em;\r\n\t}\r\n.leaflet-left .leaflet-control-scale {\r\n\tmargin-left: 5px;\r\n\t}\r\n.leaflet-bottom .leaflet-control-scale {\r\n\tmargin-bottom: 5px;\r\n\t}\r\n.leaflet-control-scale-line {\r\n\tborder: 2px solid #777;\r\n\tborder-top: none;\r\n\tline-height: 1.1;\r\n\tpadding: 2px 5px 1px;\r\n\twhite-space: nowrap;\r\n\t-moz-box-sizing: border-box;\r\n\t     box-sizing: border-box;\r\n\tbackground: rgba(255, 255, 255, 0.8);\r\n\ttext-shadow: 1px 1px #fff;\r\n\t}\r\n.leaflet-control-scale-line:not(:first-child) {\r\n\tborder-top: 2px solid #777;\r\n\tborder-bottom: none;\r\n\tmargin-top: -2px;\r\n\t}\r\n.leaflet-control-scale-line:not(:first-child):not(:last-child) {\r\n\tborder-bottom: 2px solid #777;\r\n\t}\r\n\r\n.leaflet-touch .leaflet-control-attribution,\r\n.leaflet-touch .leaflet-control-layers,\r\n.leaflet-touch .leaflet-bar {\r\n\tbox-shadow: none;\r\n\t}\r\n.leaflet-touch .leaflet-control-layers,\r\n.leaflet-touch .leaflet-bar {\r\n\tborder: 2px solid rgba(0,0,0,0.2);\r\n\tbackground-clip: padding-box;\r\n\t}\r\n\r\n\r\n/* popup */\r\n\r\n.leaflet-popup {\r\n\tposition: absolute;\r\n\ttext-align: center;\r\n\tmargin-bottom: 20px;\r\n\t}\r\n.leaflet-popup-content-wrapper {\r\n\tpadding: 1px;\r\n\ttext-align: left;\r\n\tborder-radius: 12px;\r\n\t}\r\n.leaflet-popup-content {\r\n\tmargin: 13px 24px 13px 20px;\r\n\tline-height: 1.3;\r\n\tfont-size: 13px;\r\n\tfont-size: 1.08333em;\r\n\tmin-height: 1px;\r\n\t}\r\n.leaflet-popup-content p {\r\n\tmargin: 17px 0;\r\n\tmargin: 1.3em 0;\r\n\t}\r\n.leaflet-popup-tip-container {\r\n\twidth: 40px;\r\n\theight: 20px;\r\n\tposition: absolute;\r\n\tleft: 50%;\r\n\tmargin-top: -1px;\r\n\tmargin-left: -20px;\r\n\toverflow: hidden;\r\n\tpointer-events: none;\r\n\t}\r\n.leaflet-popup-tip {\r\n\twidth: 17px;\r\n\theight: 17px;\r\n\tpadding: 1px;\r\n\r\n\tmargin: -10px auto 0;\r\n\tpointer-events: auto;\r\n\r\n\t-webkit-transform: rotate(45deg);\r\n\t   -moz-transform: rotate(45deg);\r\n\t    -ms-transform: rotate(45deg);\r\n\t        transform: rotate(45deg);\r\n\t}\r\n.leaflet-popup-content-wrapper,\r\n.leaflet-popup-tip {\r\n\tbackground: white;\r\n\tcolor: #333;\r\n\tbox-shadow: 0 3px 14px rgba(0,0,0,0.4);\r\n\t}\r\n.leaflet-container a.leaflet-popup-close-button {\r\n\tposition: absolute;\r\n\ttop: 0;\r\n\tright: 0;\r\n\tborder: none;\r\n\ttext-align: center;\r\n\twidth: 24px;\r\n\theight: 24px;\r\n\tfont: 16px/24px Tahoma, Verdana, sans-serif;\r\n\tcolor: #757575;\r\n\ttext-decoration: none;\r\n\tbackground: transparent;\r\n\t}\r\n.leaflet-container a.leaflet-popup-close-button:hover,\r\n.leaflet-container a.leaflet-popup-close-button:focus {\r\n\tcolor: #585858;\r\n\t}\r\n.leaflet-popup-scrolled {\r\n\toverflow: auto;\r\n\t}\r\n\r\n.leaflet-oldie .leaflet-popup-content-wrapper {\r\n\t-ms-zoom: 1;\r\n\t}\r\n.leaflet-oldie .leaflet-popup-tip {\r\n\twidth: 24px;\r\n\tmargin: 0 auto;\r\n\r\n\t-ms-filter: \"progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)\";\r\n\tfilter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);\r\n\t}\r\n\r\n.leaflet-oldie .leaflet-control-zoom,\r\n.leaflet-oldie .leaflet-control-layers,\r\n.leaflet-oldie .leaflet-popup-content-wrapper,\r\n.leaflet-oldie .leaflet-popup-tip {\r\n\tborder: 1px solid #999;\r\n\t}\r\n\r\n\r\n/* div icon */\r\n\r\n.leaflet-div-icon {\r\n\tbackground: #fff;\r\n\tborder: 1px solid #666;\r\n\t}\r\n\r\n\r\n/* Tooltip */\r\n/* Base styles for the element that has a tooltip */\r\n.leaflet-tooltip {\r\n\tposition: absolute;\r\n\tpadding: 6px;\r\n\tbackground-color: #fff;\r\n\tborder: 1px solid #fff;\r\n\tborder-radius: 3px;\r\n\tcolor: #222;\r\n\twhite-space: nowrap;\r\n\t-webkit-user-select: none;\r\n\t-moz-user-select: none;\r\n\t-ms-user-select: none;\r\n\tuser-select: none;\r\n\tpointer-events: none;\r\n\tbox-shadow: 0 1px 3px rgba(0,0,0,0.4);\r\n\t}\r\n.leaflet-tooltip.leaflet-interactive {\r\n\tcursor: pointer;\r\n\tpointer-events: auto;\r\n\t}\r\n.leaflet-tooltip-top:before,\r\n.leaflet-tooltip-bottom:before,\r\n.leaflet-tooltip-left:before,\r\n.leaflet-tooltip-right:before {\r\n\tposition: absolute;\r\n\tpointer-events: none;\r\n\tborder: 6px solid transparent;\r\n\tbackground: transparent;\r\n\tcontent: \"\";\r\n\t}\r\n\r\n/* Directions */\r\n\r\n.leaflet-tooltip-bottom {\r\n\tmargin-top: 6px;\r\n}\r\n.leaflet-tooltip-top {\r\n\tmargin-top: -6px;\r\n}\r\n.leaflet-tooltip-bottom:before,\r\n.leaflet-tooltip-top:before {\r\n\tleft: 50%;\r\n\tmargin-left: -6px;\r\n\t}\r\n.leaflet-tooltip-top:before {\r\n\tbottom: 0;\r\n\tmargin-bottom: -12px;\r\n\tborder-top-color: #fff;\r\n\t}\r\n.leaflet-tooltip-bottom:before {\r\n\ttop: 0;\r\n\tmargin-top: -12px;\r\n\tmargin-left: -6px;\r\n\tborder-bottom-color: #fff;\r\n\t}\r\n.leaflet-tooltip-left {\r\n\tmargin-left: -6px;\r\n}\r\n.leaflet-tooltip-right {\r\n\tmargin-left: 6px;\r\n}\r\n.leaflet-tooltip-left:before,\r\n.leaflet-tooltip-right:before {\r\n\ttop: 50%;\r\n\tmargin-top: -6px;\r\n\t}\r\n.leaflet-tooltip-left:before {\r\n\tright: 0;\r\n\tmargin-right: -12px;\r\n\tborder-left-color: #fff;\r\n\t}\r\n.leaflet-tooltip-right:before {\r\n\tleft: 0;\r\n\tmargin-left: -12px;\r\n\tborder-right-color: #fff;\r\n\t}\r\n\r\n/* Printing */\r\n\r\n@media print {\r\n\t/* Prevent printers from removing background-images of controls. */\r\n\t.leaflet-control {\r\n\t\t-webkit-print-color-adjust: exact;\r\n\t\tprint-color-adjust: exact;\r\n\t\t}\r\n\t}\r\n";
 
 let WeatherRadarCardEditor = class WeatherRadarCardEditor extends i {
-    hass;
-    _config;
-    _helpers;
-    _initialized = false;
+    constructor() {
+        super(...arguments);
+        this._initialized = false;
+        this._boundCenterUpdate = (e) => {
+            const ev = e;
+            if (!this._config)
+                return;
+            this._config = {
+                ...this._config,
+                center_latitude: ev.detail.center_latitude,
+                center_longitude: ev.detail.center_longitude,
+                zoom_level: ev.detail.zoom_level,
+            };
+            ne(this, 'config-changed', { config: this._config });
+        };
+    }
     setConfig(config) {
         this._config = config;
         this.loadCardHelpers();
     }
-    _boundCenterUpdate = (e) => {
-        const ev = e;
-        if (!this._config)
-            return;
-        this._config = {
-            ...this._config,
-            center_latitude: ev.detail.center_latitude,
-            center_longitude: ev.detail.center_longitude,
-            zoom_level: ev.detail.zoom_level,
-        };
-        ne(this, 'config-changed', { config: this._config });
-    };
     connectedCallback() {
         super.connectedCallback();
         window.addEventListener('weather-radar-center-update', this._boundCenterUpdate);
@@ -15179,7 +15179,7 @@ let WeatherRadarCardEditor = class WeatherRadarCardEditor extends i {
         }
         ne(this, 'config-changed', { config: this._config });
     }
-    static styles = i$3 `
+    static { this.styles = i$3 `
     ha-select,
     ha-selector,
     ha-textfield {
@@ -15232,7 +15232,7 @@ let WeatherRadarCardEditor = class WeatherRadarCardEditor extends i {
       padding: 0 16px 8px 16px;
       background: var(--secondary-background-color);
     }
-  `;
+  `; }
 };
 __decorate([
     n({ attribute: false })
@@ -15247,7 +15247,7 @@ WeatherRadarCardEditor = __decorate([
     t$1('weather-radar-card-editor')
 ], WeatherRadarCardEditor);
 
-const CARD_VERSION = '3.0.1';
+const CARD_VERSION = '3.0.2';
 
 var common$2 = {
 	version: "Version",
@@ -15323,11 +15323,10 @@ function localize(string, search = '', replace = '') {
  * the rate limit.
  */
 class RateLimiter {
-    _maxPerMinute;
-    _window = [];
-    _cache = new Set();
     constructor(_maxPerMinute) {
         this._maxPerMinute = _maxPerMinute;
+        this._window = [];
+        this._cache = new Set();
     }
     _prune() {
         const cutoff = Date.now() - 60_000;
@@ -15434,9 +15433,12 @@ function createFetchTile(coords, done) {
     return tile;
 }
 class FetchTileLayer extends leafletSrcExports.TileLayer {
-    _tilePending = 0;
-    _tileFailed = 0;
-    _tileLoaded = 0;
+    constructor() {
+        super(...arguments);
+        this._tilePending = 0;
+        this._tileFailed = 0;
+        this._tileLoaded = 0;
+    }
     initialize(url, options) {
         this._tilePending = 0;
         this._tileFailed = 0;
@@ -15472,9 +15474,12 @@ class FetchTileLayer extends leafletSrcExports.TileLayer {
     }
 }
 class FetchWmsTileLayer extends leafletSrcExports.TileLayer.WMS {
-    _tilePending = 0;
-    _tileFailed = 0;
-    _tileLoaded = 0;
+    constructor() {
+        super(...arguments);
+        this._tilePending = 0;
+        this._tileFailed = 0;
+        this._tileLoaded = 0;
+    }
     initialize(url, options) {
         this._tilePending = 0;
         this._tileFailed = 0;
@@ -15525,11 +15530,10 @@ const ICON_BASE$1 = '/local/community/weather-radar-card/';
  * Leaflet bar control positioned at bottom-right.
  */
 class RadarToolbar extends leafletSrcExports.Control {
-    _opts;
-    _playBtn = null;
-    _playing = true;
     constructor(opts) {
         super({ position: 'bottomright' });
+        this._playBtn = null;
+        this._playing = true;
         this._opts = opts;
     }
     onAdd(_map) {
@@ -15576,39 +15580,33 @@ const NOAA_WMS_URL = 'https://mapservices.weather.noaa.gov/eventdriven/services/
 const NOAA_WMS_LAYER = 'radar_base_reflectivity_time';
 // ── RadarPlayer ──────────────────────────────────────────────────────────────
 class RadarPlayer {
-    // Playback state (readable by card)
-    run = true;
-    navPaused = false;
-    viewPaused = false;
-    // Private radar state
-    _map;
-    _shadowRoot;
-    _getConfig;
-    _rainviewerLimiter;
-    _noaaLimiter;
-    _radarImage = [];
-    _radarTime = [];
-    _radarPaths = [];
-    _loadedSlots = [];
-    _frameStatuses = [];
-    _radarReady = false;
-    _frameGeneration = 0;
-    _configFrameCount = 5;
-    _doRadarUpdate = false;
-    // Frame loop state — _loopGen is incremented to cancel in-flight timers
-    _currentSlot = 0;
-    _loopGen = 0;
-    // Web worker timer (used only for the periodic 5-min radar update)
-    _worker = null;
-    _workerBlobUrl = null;
-    _workerCallbacks = new Map();
-    _workerNextId = 0;
-    // Rate-limit state
-    _rateLimitTimer = null;
-    _isRateLimited = false;
-    // Toolbar reference (set externally after toolbar is created)
-    toolbar = null;
     constructor(opts) {
+        // Playback state (readable by card)
+        this.run = true;
+        this.navPaused = false;
+        this.viewPaused = false;
+        this._radarImage = [];
+        this._radarTime = [];
+        this._radarPaths = [];
+        this._loadedSlots = [];
+        this._frameStatuses = [];
+        this._radarReady = false;
+        this._frameGeneration = 0;
+        this._configFrameCount = 5;
+        this._doRadarUpdate = false;
+        // Frame loop state — _loopGen is incremented to cancel in-flight timers
+        this._currentSlot = 0;
+        this._loopGen = 0;
+        // Web worker timer (used only for the periodic 5-min radar update)
+        this._worker = null;
+        this._workerBlobUrl = null;
+        this._workerCallbacks = new Map();
+        this._workerNextId = 0;
+        // Rate-limit state
+        this._rateLimitTimer = null;
+        this._isRateLimited = false;
+        // Toolbar reference (set externally after toolbar is created)
+        this.toolbar = null;
         this._map = opts.map;
         this._shadowRoot = opts.shadowRoot;
         this._getConfig = opts.getConfig;
@@ -16268,35 +16266,34 @@ window.customCards.push({
     description: 'A rain radar card using tiled imagery from RainViewer and NOAA/NWS',
 });
 let WeatherRadarCard = class WeatherRadarCard extends i {
+    constructor() {
+        super(...arguments);
+        // ── HA properties ────────────────────────────────────────────────────────
+        this.isPanel = false;
+        // ── Map / player state ────────────────────────────────────────────────────
+        this._map = null;
+        this._townLayer = null;
+        this._toolbar = null;
+        this._marker = null;
+        this._rangeRings = [];
+        this._player = null;
+        this._pendingCenter = null;
+        this._userMoveInProgress = false;
+        this._navReloadTimer = null;
+        this._visObserver = null;
+        this._resizeObserver = null;
+        this._visibilityHandler = null;
+        this._navContainer = null;
+        this._markUserMove = null;
+        this._darkModeQuery = null;
+        this._darkModeHandler = null;
+        this._rainviewerLimiter = new RateLimiter(500);
+        this._noaaLimiter = new RateLimiter(120);
+    }
     static async getConfigElement() {
         return document.createElement('weather-radar-card-editor');
     }
     static getStubConfig() { return {}; }
-    // ── HA properties ────────────────────────────────────────────────────────
-    isPanel = false;
-    hass;
-    _config;
-    editMode;
-    // ── Map / player state ────────────────────────────────────────────────────
-    _map = null;
-    _townLayer = null;
-    _toolbar = null;
-    _marker = null;
-    _rangeRings = [];
-    _dynamicStyleEl;
-    _player = null;
-    _pendingCenter = null;
-    _userMoveInProgress = false;
-    _navReloadTimer = null;
-    _visObserver = null;
-    _resizeObserver = null;
-    _visibilityHandler = null;
-    _navContainer = null;
-    _markUserMove = null;
-    _darkModeQuery = null;
-    _darkModeHandler = null;
-    _rainviewerLimiter = new RateLimiter(500);
-    _noaaLimiter = new RateLimiter(120);
     // ── Helpers ───────────────────────────────────────────────────────────────
     _effectiveMapStyle() {
         const configured = this._config?.map_style?.toLowerCase();
@@ -16385,8 +16382,8 @@ let WeatherRadarCard = class WeatherRadarCard extends i {
         <div id="div-progress-bar" style="height:8px;cursor:pointer;display:${this._config.show_progress_bar === false ? 'none' : 'flex'};background:${dark ? '#1c1c1c' : '#fff'}"></div>
         <div id="bottom-container" class="${dark ? 'dark-links' : 'light-links'}"
              style="height:32px;background:${dark ? '#1c1c1c' : '#fff'};color:${dark ? '#ddd' : ''}">
-          <div id="timestampid" style="width:120px;height:32px;float:left;position:absolute">
-            <p id="timestamp" style="margin:0;padding:4px 8px;font-size:12px"></p>
+          <div id="timestampid" style="height:32px;float:left;position:absolute">
+            <p id="timestamp" style="margin:0;padding:4px 8px;font-size:12px;white-space:nowrap"></p>
           </div>
           <div id="attribution" style="font-size:10px;text-align:right;padding:4px 8px"></div>
         </div>
@@ -16712,7 +16709,7 @@ let WeatherRadarCard = class WeatherRadarCard extends i {
         this._resizeObserver.observe(mapEl);
     }
     // ── Styles ────────────────────────────────────────────────────────────────
-    static styles = [
+    static { this.styles = [
         r$5(leafletCss),
         i$3 `
       :host { display: block; isolation: isolate; }
@@ -16746,7 +16743,7 @@ let WeatherRadarCard = class WeatherRadarCard extends i {
         white-space: nowrap; box-shadow: 0 2px 6px rgba(0,0,0,0.3);
       }
     `,
-    ];
+    ]; }
 };
 __decorate([
     n({ type: Boolean, reflect: true })

--- a/dist/weather-radar-card.js
+++ b/dist/weather-radar-card.js
@@ -16715,7 +16715,7 @@ let WeatherRadarCard = class WeatherRadarCard extends i {
     static styles = [
         r$5(leafletCss),
         i$3 `
-      :host { display: block; }
+      :host { display: block; isolation: isolate; }
       ha-card { overflow: hidden; position: relative; }
       #mapid { width: 100%; position: relative; }
       .status-banner {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "2.4.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "2.4.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,1 @@
-export const CARD_VERSION = '3.0.1';
+export const CARD_VERSION = '3.0.2';

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -506,7 +506,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
   static styles = [
     unsafeCSS(leafletCss),
     css`
-      :host { display: block; }
+      :host { display: block; isolation: isolate; }
       ha-card { overflow: hidden; position: relative; }
       #mapid { width: 100%; position: relative; }
       .status-banner {

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -169,8 +169,8 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
         <div id="div-progress-bar" style="height:8px;cursor:pointer;display:${this._config.show_progress_bar === false ? 'none' : 'flex'};background:${dark ? '#1c1c1c' : '#fff'}"></div>
         <div id="bottom-container" class="${dark ? 'dark-links' : 'light-links'}"
              style="height:32px;background:${dark ? '#1c1c1c' : '#fff'};color:${dark ? '#ddd' : ''}">
-          <div id="timestampid" style="width:120px;height:32px;float:left;position:absolute">
-            <p id="timestamp" style="margin:0;padding:4px 8px;font-size:12px"></p>
+          <div id="timestampid" style="height:32px;float:left;position:absolute">
+            <p id="timestamp" style="margin:0;padding:4px 8px;font-size:12px;white-space:nowrap"></p>
           </div>
           <div id="attribution" style="font-size:10px;text-align:right;padding:4px 8px"></div>
         </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2022",
+    "useDefineForClassFields": false,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": [
       "es2022",
       "dom",


### PR DESCRIPTION
## Summary

Three bugs fixed, all present in 3.0.1 on master.

- **Map floats above HA navigation** (#95) — Leaflet's CSS sets `z-index:1000` on its control elements. Without an isolated stacking context on the shadow host, those values compete in the document stacking context and appear above HA's sidebar and navigation drawer. `isolation:isolate` on `:host` caps Leaflet's z-index scope inside the card.
- **Timestamp wraps to second line** — The locale-aware timestamp (`Intl.DateTimeFormat` with weekday, month, day, hour, minute) can exceed the old fixed 120 px container width. Removing the fixed width and adding `white-space:nowrap` keeps it on one line regardless of locale.
- **Card produces no DOM** — `target: es2022` in tsconfig defaulted `useDefineForClassFields` to `true`, causing native ES2022 class field semantics to shadow LitElement's `@property()` prototype accessors. `this._config = value` in `setConfig` set an own property instead of going through the reactive setter, so `requestUpdate` was never called and `render()` never fired. `useDefineForClassFields: false` restores the expected behaviour. Also updates `moduleResolution` from deprecated `node` (node10) to `bundler`.

## Test plan

- [x] Console logs `3.0.2` confirming correct version is loaded
- [x] Card renders — map and controls visible, no blank card
- [x] Map stays behind HA navigation drawer and sidebar on mobile and desktop
- [x] Timestamp displays on a single line in EN (12 h) and non-EN (24 h) locales
- [x] No regression on existing features (playback, recenter, zoom, marker, scale, range rings)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)