### PR TITLE
Drop Leaflet white text shadow on dark map scale

### DIFF
--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -795,6 +795,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       #bottom-container a { color: var(--primary-color); }
       .map-dark .leaflet-control-scale-line {
         color: #bbb; border-color: #bbb; background: rgba(0,0,0,0.5);
+        text-shadow: none;
       }
       .save-center-btn {
         position: absolute; bottom: 48px; left: 50%; transform: translateX(-50%);


### PR DESCRIPTION
Lifted out of #120 per your suggestion. One liner.

Leaflet's default `.leaflet-control-scale-line` sets `text-shadow: 1px 1px #fff` for readability on light basemaps. On dark and satellite styles that white shadow shows up as a faint duplicate of the scale label. Adds `text-shadow: none` to our `.map-dark` override so the duplicate disappears.