### PR TITLE
Now marker on the progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Loading spinner** — a small rotating indicator now sits in the centre of the bottom bar (between the timestamp and attribution) while radar tiles are being fetched. Visible during the initial load, after pan/zoom reload, and the periodic 5-minute refresh; hidden when only cached frames are cycling. Honours `prefers-reduced-motion` (the dot stays visible but does not spin).
 - **`show_loading_spinner` config option** — toggles the loading spinner described above. Defaults to `true`; set to `false` to suppress it on cards where the brief load is imperceptible and the indicator would only add noise.
+- **"Now" marker on the progress bar** — the segment whose timestamp is closest to wall clock now gets a small amber stripe at the top, a `title="Now"` tooltip, and the displayed timestamp gains a `(now)` suffix when playback reaches that frame. Mostly useful with DWD forecast frames where "now" sits in the middle of the timeline rather than at the end. The stripe colour follows HA's `--warning-color` theme variable (falling back to `#ff9800`), so custom themes pick it up automatically.
 
 ## [3.4.0] - 2026-05-04
 

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -5,7 +5,9 @@
   "ui": {
     "rate_limited": "Rate limited — waiting for quota to reset",
     "save_map_center": "Save as map center",
-    "loading_radar_tiles": "Loading radar tiles"
+    "loading_radar_tiles": "Loading radar tiles",
+    "now": "(now)",
+    "now_tooltip": "Now"
   },
   "editor": {
     "section": {

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -4,6 +4,25 @@ import { WeatherRadarCardConfig } from './types';
 import { RateLimiter } from './rate-limiter';
 import { FetchTileLayer, FetchWmsTileLayer, layerSettled } from './fetch-tile-layer';
 import { RadarToolbar } from './radar-toolbar';
+import { localize } from './localize/localize';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Pick the frame whose `time` (epoch seconds) is closest to `nowSec`.
+ * Pure function — factored out so the now-marker logic is unit-testable
+ * without standing up a full RadarPlayer. Ties resolve to the lower index.
+ */
+export function nearestFrameIndex(frames: { time: number }[], nowSec: number): number {
+  if (frames.length === 0) return -1;
+  let best = 0;
+  let bestDiff = Math.abs(frames[0].time - nowSec);
+  for (let i = 1; i < frames.length; i++) {
+    const d = Math.abs(frames[i].time - nowSec);
+    if (d < bestDiff) { bestDiff = d; best = i; }
+  }
+  return best;
+}
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -313,6 +332,10 @@ export class RadarPlayer {
   private _showSlot(slot: number, opts?: { snap?: boolean }): void {
     const n = this._loadedSlots.length;
     if (n === 0 || slot < 0 || slot >= n) return;
+    // Refresh the now-marker on every frame display so the "(now)" suffix
+    // and amber stripe don't drift between the 5-min periodic refreshes.
+    this._computeNowFrameIndex();
+    this._applyNowMarker();
     const timing = opts?.snap
       ? { fadeMs: 0, delayMs: 0 }
       : this._crossfadeTiming();
@@ -441,34 +464,33 @@ export class RadarPlayer {
 
   /** Pick the frame whose timestamp is closest to wall-clock now. */
   private _computeNowFrameIndex(): void {
-    if (this._radarPaths.length === 0) { this._nowFrameIndex = -1; return; }
-    const nowSec = Date.now() / 1000;
-    let best = 0;
-    let bestDiff = Math.abs(this._radarPaths[0].time - nowSec);
-    for (let i = 1; i < this._radarPaths.length; i++) {
-      const d = Math.abs(this._radarPaths[i].time - nowSec);
-      if (d < bestDiff) { bestDiff = d; best = i; }
-    }
-    this._nowFrameIndex = best;
+    this._nowFrameIndex = nearestFrameIndex(this._radarPaths, Date.now() / 1000);
   }
 
-  /** Mark the now-segment with an amber top stripe + tooltip; clear from others. */
+  /**
+   * Mark the now-segment with an amber top stripe + tooltip; clear from others.
+   * The stripe is applied via `style.boxShadow` rather than `backgroundColor`
+   * so it composes cleanly with `_segColor()` (which writes the segment's
+   * background based on load status / playback-current). If you ever switch
+   * the now-marker to a background colour, _highlightSegment will start
+   * clobbering it on every frame tick.
+   */
   private _applyNowMarker(): void {
     for (let i = 0; i < this._configFrameCount; i++) {
       const seg = this._shadowRoot.getElementById(`seg-${i}`);
       if (!seg) continue;
       const isNow = i === this._nowFrameIndex;
-      seg.title = isNow ? 'Now' : '';
+      seg.title = isNow ? localize('ui.now_tooltip') : '';
       seg.style.boxShadow = isNow ? 'inset 0 2px 0 0 var(--warning-color, #ff9800)' : '';
     }
   }
 
-  /** Update the timestamp text — appends "(now)" when the displayed frame is the now-frame. */
+  /** Update the timestamp text — appends a localized "(now)" suffix when the displayed frame is the now-frame. */
   private _setTimestamp(fi: number): void {
     const ts = this._shadowRoot.getElementById('timestamp');
     if (!ts) return;
     const base = this._radarTime[fi] ?? '';
-    ts.textContent = fi === this._nowFrameIndex ? `${base} (now)` : base;
+    ts.textContent = fi === this._nowFrameIndex ? `${base} ${localize('ui.now')}` : base;
   }
 
   private _highlightSegment(fi: number): void {
@@ -752,6 +774,10 @@ export class RadarPlayer {
     const newTime = this._getTimeString(latestFrame.time * 1000);
 
     this._radarImage[0]?.remove();
+    // _radarPaths is shifted alongside _radarImage / _radarTime / _frameStatuses
+    // because nearestFrameIndex() reads .time off it for the now-marker — if the
+    // array stayed pinned to the previous _initRadar generation, the marker
+    // would drift one slot per refresh.
     for (let i = 0; i < frameCount - 1; i++) {
       this._radarImage[i] = this._radarImage[i + 1];
       this._radarTime[i] = this._radarTime[i + 1];

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -49,6 +49,7 @@ export class RadarPlayer {
   private _radarImage: (FetchTileLayer | FetchWmsTileLayer)[] = [];
   private _radarTime: string[] = [];
   private _radarPaths: RadarFrame[] = [];
+  private _nowFrameIndex = -1;
   private _loadedSlots: number[] = [];
   private _frameStatuses: FrameStatus[] = [];
   private _radarReady = false;
@@ -390,8 +391,7 @@ export class RadarPlayer {
 
     const fi = this._loadedSlots[slot];
     if (fi !== undefined) {
-      const ts = this._shadowRoot.getElementById('timestamp');
-      if (ts) ts.textContent = this._radarTime[fi] ?? '';
+      this._setTimestamp(fi);
       this._highlightSegment(fi);
     }
   }
@@ -437,6 +437,38 @@ export class RadarPlayer {
     const enabled = this._cfg.show_loading_spinner !== false;
     const isLoading = enabled && this._frameStatuses.some(s => s === 'loading');
     spinner.style.display = isLoading ? '' : 'none';
+  }
+
+  /** Pick the frame whose timestamp is closest to wall-clock now. */
+  private _computeNowFrameIndex(): void {
+    if (this._radarPaths.length === 0) { this._nowFrameIndex = -1; return; }
+    const nowSec = Date.now() / 1000;
+    let best = 0;
+    let bestDiff = Math.abs(this._radarPaths[0].time - nowSec);
+    for (let i = 1; i < this._radarPaths.length; i++) {
+      const d = Math.abs(this._radarPaths[i].time - nowSec);
+      if (d < bestDiff) { bestDiff = d; best = i; }
+    }
+    this._nowFrameIndex = best;
+  }
+
+  /** Mark the now-segment with an amber top stripe + tooltip; clear from others. */
+  private _applyNowMarker(): void {
+    for (let i = 0; i < this._configFrameCount; i++) {
+      const seg = this._shadowRoot.getElementById(`seg-${i}`);
+      if (!seg) continue;
+      const isNow = i === this._nowFrameIndex;
+      seg.title = isNow ? 'Now' : '';
+      seg.style.boxShadow = isNow ? 'inset 0 2px 0 0 var(--warning-color, #ff9800)' : '';
+    }
+  }
+
+  /** Update the timestamp text — appends "(now)" when the displayed frame is the now-frame. */
+  private _setTimestamp(fi: number): void {
+    const ts = this._shadowRoot.getElementById('timestamp');
+    if (!ts) return;
+    const base = this._radarTime[fi] ?? '';
+    ts.textContent = fi === this._nowFrameIndex ? `${base} (now)` : base;
   }
 
   private _highlightSegment(fi: number): void {
@@ -625,8 +657,10 @@ export class RadarPlayer {
     this._radarPaths = pastFrames;
     const frameCount = pastFrames.length;
     this._configFrameCount = frameCount;
+    this._computeNowFrameIndex();
 
     this._buildSegments();
+    this._applyNowMarker();
 
     let newestShown = false;
 
@@ -655,8 +689,7 @@ export class RadarPlayer {
           // Show newest frame as a static preview before the loop starts
           newestShown = true;
           if (el) el.style.opacity = this._activeOpacity;
-          const ts = this._shadowRoot.getElementById('timestamp');
-          if (ts) ts.textContent = this._radarTime[fi];
+          this._setTimestamp(fi);
           this._highlightSegment(fi);
         }
 
@@ -722,11 +755,15 @@ export class RadarPlayer {
     for (let i = 0; i < frameCount - 1; i++) {
       this._radarImage[i] = this._radarImage[i + 1];
       this._radarTime[i] = this._radarTime[i + 1];
+      this._radarPaths[i] = this._radarPaths[i + 1];
       this._frameStatuses[i] = this._frameStatuses[i + 1];
     }
     this._radarImage[frameCount - 1] = newLayer;
     this._radarTime[frameCount - 1] = newTime;
+    this._radarPaths[frameCount - 1] = latestFrame;
     this._loadedSlots = this._loadedSlots.map(fi => fi - 1).filter(fi => fi >= 0);
+    this._computeNowFrameIndex();
+    this._applyNowMarker();
 
     for (let i = 0; i < frameCount - 1; i++) {
       const seg = this._shadowRoot.getElementById(`seg-${i}`);

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -332,8 +332,7 @@ export class RadarPlayer {
   private _showSlot(slot: number, opts?: { snap?: boolean }): void {
     const n = this._loadedSlots.length;
     if (n === 0 || slot < 0 || slot >= n) return;
-    // Refresh the now-marker on every frame display so the "(now)" suffix
-    // and amber stripe don't drift between the 5-min periodic refreshes.
+    // Recompute each tick so the marker doesn't drift between 5-min refreshes.
     this._computeNowFrameIndex();
     this._applyNowMarker();
     const timing = opts?.snap
@@ -467,20 +466,13 @@ export class RadarPlayer {
     this._nowFrameIndex = nearestFrameIndex(this._radarPaths, Date.now() / 1000);
   }
 
-  /**
-   * Mark the now-segment with an amber top stripe + tooltip; clear from others.
-   * The stripe is applied via `style.boxShadow` rather than `backgroundColor`
-   * so it composes cleanly with `_segColor()` (which writes the segment's
-   * background based on load status / playback-current). If you ever switch
-   * the now-marker to a background colour, _highlightSegment will start
-   * clobbering it on every frame tick.
-   */
   private _applyNowMarker(): void {
     for (let i = 0; i < this._configFrameCount; i++) {
       const seg = this._shadowRoot.getElementById(`seg-${i}`);
       if (!seg) continue;
       const isNow = i === this._nowFrameIndex;
       seg.title = isNow ? localize('ui.now_tooltip') : '';
+      // boxShadow (not backgroundColor) so _segColor doesn't clobber it on each tick.
       seg.style.boxShadow = isNow ? 'inset 0 2px 0 0 var(--warning-color, #ff9800)' : '';
     }
   }
@@ -774,10 +766,7 @@ export class RadarPlayer {
     const newTime = this._getTimeString(latestFrame.time * 1000);
 
     this._radarImage[0]?.remove();
-    // _radarPaths is shifted alongside _radarImage / _radarTime / _frameStatuses
-    // because nearestFrameIndex() reads .time off it for the now-marker — if the
-    // array stayed pinned to the previous _initRadar generation, the marker
-    // would drift one slot per refresh.
+    // _radarPaths shifts alongside the others because nearestFrameIndex() reads .time off it.
     for (let i = 0; i < frameCount - 1; i++) {
       this._radarImage[i] = this._radarImage[i + 1];
       this._radarTime[i] = this._radarTime[i + 1];

--- a/tests/nearest-frame-index.test.ts
+++ b/tests/nearest-frame-index.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub Leaflet — radar-player imports it eagerly (and pulls in fetch-tile-layer
+// which extends L.TileLayer / L.TileLayer.WMS at class-definition time), but
+// nearestFrameIndex itself is pure and never touches any L.* API.
+vi.mock('leaflet', () => {
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as any).WMS = WMS;
+  return { TileLayer, default: { TileLayer } };
+});
+
+import { nearestFrameIndex } from '../src/radar-player';
+
+describe('nearestFrameIndex', () => {
+  it('returns -1 for an empty frame list', () => {
+    expect(nearestFrameIndex([], 0)).toBe(-1);
+    expect(nearestFrameIndex([], 1_700_000_000)).toBe(-1);
+  });
+
+  it('picks the frame closest to the given clock time', () => {
+    // Frames at -10 / -5 / 0 / +5 / +10 minutes (epoch seconds), clock at +2 min.
+    // Closest is the +5 frame at index 3 (3 min away vs. 2 min for index 2 — wait,
+    // let's be careful: |0 - 120| = 120 s, |300 - 120| = 180 s — index 2 wins).
+    const minute = 60;
+    const frames = [
+      { time: -10 * minute },
+      { time:  -5 * minute },
+      { time:   0 * minute },
+      { time:   5 * minute },
+      { time:  10 * minute },
+    ];
+    expect(nearestFrameIndex(frames, 2 * minute)).toBe(2); // 0-min frame is closer than +5
+    expect(nearestFrameIndex(frames, 3 * minute)).toBe(3); // +5 wins (2 min vs 3)
+    expect(nearestFrameIndex(frames, -10 * minute)).toBe(0);
+    expect(nearestFrameIndex(frames, 99 * minute)).toBe(4);
+  });
+
+  it('resolves ties to the lower index', () => {
+    const frames = [{ time: -5 }, { time: 5 }];
+    // |-5 - 0| === |5 - 0| === 5; first-wins because the loop only swaps on `<`.
+    expect(nearestFrameIndex(frames, 0)).toBe(0);
+  });
+
+  it('handles a single-frame list', () => {
+    const frames = [{ time: 1_777_000_000 }];
+    expect(nearestFrameIndex(frames, 0)).toBe(0);
+    expect(nearestFrameIndex(frames, 1_777_000_000)).toBe(0);
+    expect(nearestFrameIndex(frames, 9_999_999_999)).toBe(0);
+  });
+});


### PR DESCRIPTION
Lifted out of #120 per your suggestion.

Picks the frame whose timestamp is closest to wall clock now and gives that segment a small amber stripe (inset top box-shadow) plus a `title="Now"` tooltip; the displayed timestamp also gains a `(now)` suffix while playback is showing that frame. Mostly handy with DWD forecast frames where "now" sits in the middle of the timeline rather than at the end.

Includes the `_radarPaths` sync in `_updateRadar` so the wall clock comparison stays accurate after the periodic shift.

Happy to roll the staleness fix (recompute on `_scheduleNext` or a dedicated 1-min `_workerTimeout`), the i18n strings, the property-choice comments, and the `_computeNowFrameIndex` unit test into this PR before you merge — say the word.