### PR TITLE
perf(radar): keep tile layers attached on pan/zoom; spinner + zoom-pin

### DIFF
--- a/src/fetch-tile-layer.ts
+++ b/src/fetch-tile-layer.ts
@@ -90,6 +90,30 @@ function createFetchTile(
   return tile;
 }
 
+// _updateOpacity body shared by FetchTileLayer and FetchWmsTileLayer when
+// animationOwnsOpacity is set. Forces each loaded tile to opacity 1 (skipping
+// Leaflet's 200ms fade) and marks them active. Without active, _pruneTiles
+// treats current-but-not-active tiles as still loading and retains their
+// ancestor levels indefinitely.
+function applyOwnedOpacity(layer: FetchTileLayer | FetchWmsTileLayer): void {
+  const tiles = (layer as any)._tiles as Record<string, { el: HTMLElement; loaded?: number; active?: boolean }> | undefined;
+  if (tiles) {
+    for (const key in tiles) {
+      const tile = tiles[key];
+      if (!tile?.el) continue;
+      tile.el.style.opacity = '1';
+      if (tile.loaded) tile.active = true;
+    }
+  }
+  // .leaflet-fade-anim starts tile-container divs at opacity:0; force to 1.
+  const container = (layer as any)._container as HTMLElement | undefined;
+  if (container) {
+    container.querySelectorAll<HTMLElement>('.leaflet-tile-container').forEach(
+      (el) => { el.style.opacity = '1'; },
+    );
+  }
+}
+
 export class FetchTileLayer extends L.TileLayer {
   _tilePending = 0;
   _tileFailed = 0;
@@ -106,30 +130,12 @@ export class FetchTileLayer extends L.TileLayer {
     return createFetchTile.call(this, coords as Coords, done);
   }
 
-  // Leaflet's _updateOpacity (a) writes container.style.opacity, fighting our CSS
-  // animation, and (b) fades individual tile <img> elements from 0→1 over 200ms.
-  // When animationOwnsOpacity is set we skip (a) but still do (b) — otherwise
-  // every tile stays at opacity:0 permanently.
   _updateOpacity(): void {
     if (!(this.options as FetchTileOptions).animationOwnsOpacity) {
       (L.TileLayer.prototype as any)._updateOpacity?.call(this);
       return;
     }
-    // Set each tile img to fully visible (bypass the 200ms fade-in).
-    const tiles = (this as any)._tiles as Record<string, { el: HTMLElement }> | undefined;
-    if (tiles) {
-      for (const key in tiles) {
-        const tile = tiles[key];
-        if (tile?.el) tile.el.style.opacity = '1';
-      }
-    }
-    // Also ensure tile-container divs are visible (CSS starts them at opacity:0).
-    const container = (this as any)._container as HTMLElement | undefined;
-    if (container) {
-      container.querySelectorAll<HTMLElement>('.leaflet-tile-container').forEach(
-        (el) => { el.style.opacity = '1'; },
-      );
-    }
+    applyOwnedOpacity(this);
   }
 }
 
@@ -163,19 +169,7 @@ export class FetchWmsTileLayer extends L.TileLayer.WMS {
       (L.TileLayer.WMS.prototype as any)._updateOpacity?.call(this);
       return;
     }
-    const tiles = (this as any)._tiles as Record<string, { el: HTMLElement }> | undefined;
-    if (tiles) {
-      for (const key in tiles) {
-        const tile = tiles[key];
-        if (tile?.el) tile.el.style.opacity = '1';
-      }
-    }
-    const container = (this as any)._container as HTMLElement | undefined;
-    if (container) {
-      container.querySelectorAll<HTMLElement>('.leaflet-tile-container').forEach(
-        (el) => { el.style.opacity = '1'; },
-      );
-    }
+    applyOwnedOpacity(this);
   }
 }
 

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -106,6 +106,12 @@ export class RadarPlayer {
   // Toolbar reference (set externally after toolbar is created)
   toolbar: RadarToolbar | null = null;
 
+  // Highest native tile zoom requested in this session. Bumped on zoom-in
+  // via _onZoomEnd, never lowered. Passed as minNativeZoom on each layer
+  // so zoom-out reuses cached high-res tiles instead of fetching at the
+  // lower native zoom.
+  private _pinnedNativeZoom = 0;
+
   constructor(opts: RadarPlayerOptions) {
     this._map = opts.map;
     this._shadowRoot = opts.shadowRoot;
@@ -114,7 +120,29 @@ export class RadarPlayer {
     this._noaaLimiter = opts.noaaLimiter;
     this._dwdLimiter = opts.dwdLimiter;
     this._startWorker();
+    this._pinnedNativeZoom = Math.min(
+      this._map.getZoom(),
+      this._sourceMaxNativeZoom(),
+    );
+    this._map.on('zoomend', this._onZoomEnd);
   }
+
+  private _sourceMaxNativeZoom(): number {
+    // Must match the maxNativeZoom set per source in _createLayer.
+    return (this._cfg.data_source ?? 'RainViewer') === 'DWD' ? 8 : 7;
+  }
+
+  private _onZoomEnd = (): void => {
+    if (!this._map) return;
+    const newPin = Math.min(this._map.getZoom(), this._sourceMaxNativeZoom());
+    if (newPin <= this._pinnedNativeZoom) return;
+    this._pinnedNativeZoom = newPin;
+    // Leaflet reads minNativeZoom each time _clampZoom runs; updating the
+    // option on existing layers is enough, no redraw needed.
+    for (const layer of this._radarImage) {
+      if (layer) (layer.options as any).minNativeZoom = newPin;
+    }
+  };
 
   // ── Config helpers ───────────────────────────────────────────────────────
 
@@ -176,6 +204,7 @@ export class RadarPlayer {
   clear(): void {
     this._stopLoop();
     this._clearLayers();
+    this._map?.off('zoomend', this._onZoomEnd);
     if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
     this._worker?.terminate();
     this._worker = null;
@@ -678,6 +707,7 @@ export class RadarPlayer {
         // mean fewer requests for the same coverage on large maps.
         tileSize,
         zoomOffset,
+        minNativeZoom: this._pinnedNativeZoom,
         // NOAA's 4 km MRMS native; cap to keep upscaled appearance.
         maxNativeZoom: 7 + Math.max(0, -zoomOffset),
         rateLimiter: this._noaaLimiter,
@@ -708,6 +738,7 @@ export class RadarPlayer {
         // count proportionally — see _radarTileSize() for the picker.
         tileSize,
         zoomOffset,
+        minNativeZoom: this._pinnedNativeZoom,
         // DWD's 1 km grid supports zoom 8; bump for larger tiles.
         maxNativeZoom: 8 + Math.max(0, -zoomOffset),
         rateLimiter: this._dwdLimiter,
@@ -723,6 +754,7 @@ export class RadarPlayer {
       detectRetina: false,
       tileSize,
       zoomOffset,
+      minNativeZoom: this._pinnedNativeZoom,
       // RainViewer publishes tiles up to native zoom 7 at 256px;
       // higher native zoom available with bigger tiles.
       maxNativeZoom: 7 + Math.max(0, -zoomOffset),

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -207,12 +207,21 @@ export class RadarPlayer {
     }
 
     // _scheduleUpdate's timer keeps running through the pause; if it fired
-    // while navPaused was true it set _doRadarUpdate. Pick that up now.
+    // while navPaused was true it set _doRadarUpdate. Pick that up now;
+    // _updateRadar restarts the loop from its load callback.
     if (this._doRadarUpdate) {
       this._doRadarUpdate = false;
       void this._updateRadar();
-    } else if (this.run) {
-      this._startLoop(this._currentSlot);
+      return;
+    }
+
+    // Resume without re-showing the current slot. _stopLoop already left
+    // the displayed layer at active opacity via _settleVisibility; routing
+    // through _showSlot would snap it to 0 and fade back in, producing a
+    // visible flash on every move.
+    if (this.run) {
+      this._loopGen++;
+      this._scheduleNext(this._loopGen);
     }
   }
 

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -190,15 +190,30 @@ export class RadarPlayer {
   onNavPaused(): void {
     this.navPaused = true;
     this._stopLoop();
-    for (let i = 0; i < this._configFrameCount; i++) this._setSegment(i, 'empty');
-    this._showRateLimitBanner(false);
   }
 
   async onNavSettled(frameCount: number): Promise<void> {
     this.navPaused = false;
-    this._clearLayers();
-    this._configFrameCount = frameCount;
-    await this._initRadar();
+
+    // Full re-init only when state needs rebuilding: initial load not yet
+    // complete, or frame_count changed. Pan, zoom, and programmatic view
+    // changes leave layers attached — Leaflet fetches only the tiles
+    // entering the new viewport.
+    if (!this._radarReady || this._configFrameCount !== frameCount) {
+      this._clearLayers();
+      this._configFrameCount = frameCount;
+      await this._initRadar();
+      return;
+    }
+
+    // _scheduleUpdate's timer keeps running through the pause; if it fired
+    // while navPaused was true it set _doRadarUpdate. Pick that up now.
+    if (this._doRadarUpdate) {
+      this._doRadarUpdate = false;
+      void this._updateRadar();
+    } else if (this.run) {
+      this._startLoop(this._currentSlot);
+    }
   }
 
   onVisibilityHidden(): void {

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -512,7 +512,12 @@ export class RadarPlayer {
     const spinner = this._shadowRoot.getElementById('loading-spinner');
     if (!spinner) return;
     const enabled = this._cfg.show_loading_spinner !== false;
-    const isLoading = enabled && this._frameStatuses.some(s => s === 'loading');
+    // _frameStatuses covers initial load and periodic refresh;
+    // _tilePending catches pan/zoom on attached layers, where edge-tile
+    // fetches don't go through _setSegment(loading).
+    const segLoading = this._frameStatuses.some(s => s === 'loading');
+    const tileLoading = this._radarImage.some(l => (l?._tilePending ?? 0) > 0);
+    const isLoading = enabled && (segLoading || tileLoading);
     spinner.style.display = isLoading ? '' : 'none';
   }
 
@@ -695,9 +700,15 @@ export class RadarPlayer {
   private _createLayer(frame: RadarFrame): FetchTileLayer | FetchWmsTileLayer {
     const dataSource = this._cfg.data_source ?? 'RainViewer';
     const { size: tileSize, zoomOffset } = this._radarTileSize();
+    // Drive the spinner from each layer's load events, so pan/zoom edge
+    // fetches on attached layers light it up too (not just frame status).
+    const wireSpinner = (l: FetchTileLayer | FetchWmsTileLayer): typeof l => {
+      l.on('loading load', () => this._updateLoadingSpinner());
+      return l;
+    };
     if (dataSource === 'NOAA') {
       const isoTime = new Date(frame.time * 1000).toISOString().split('.')[0] + 'Z';
-      return new FetchWmsTileLayer(NOAA_WMS_URL, {
+      return wireSpinner(new FetchWmsTileLayer(NOAA_WMS_URL, {
         layers: NOAA_WMS_LAYER,
         format: 'image/png',
         transparent: true,
@@ -713,7 +724,7 @@ export class RadarPlayer {
         rateLimiter: this._noaaLimiter,
         on429: () => this._onRateLimited(),
         animationOwnsOpacity: true,
-      } as any);
+      } as any));
     }
     if (dataSource === 'DWD') {
       const isoTime = new Date(frame.time * 1000).toISOString().split('.')[0] + 'Z';
@@ -728,7 +739,7 @@ export class RadarPlayer {
         );
         this._dwdSwapLogged = true;
       }
-      return new FetchWmsTileLayer(DWD_WMS_URL, {
+      return wireSpinner(new FetchWmsTileLayer(DWD_WMS_URL, {
         layers: layerName,
         format: 'image/png',
         transparent: true,
@@ -744,13 +755,13 @@ export class RadarPlayer {
         rateLimiter: this._dwdLimiter,
         on429: () => this._onRateLimited(),
         animationOwnsOpacity: true,
-      } as any);
+      } as any));
     }
     const snow = this._cfg.show_snow ? 1 : 0;
     const host = frame.host ?? 'https://tilecache.rainviewer.com';
     // RainViewer encodes tile size as a path segment (256/512/1024/2048).
     // Build the URL with whichever size we picked for this map.
-    return new FetchTileLayer(`${host}${frame.path}/${tileSize}/{z}/{x}/{y}/2/1_${snow}.png`, {
+    return wireSpinner(new FetchTileLayer(`${host}${frame.path}/${tileSize}/{z}/{x}/{y}/2/1_${snow}.png`, {
       detectRetina: false,
       tileSize,
       zoomOffset,
@@ -761,7 +772,7 @@ export class RadarPlayer {
       rateLimiter: this._rainviewerLimiter,
       on429: () => this._onRateLimited(),
       animationOwnsOpacity: true,
-    } as any);
+    } as any));
   }
 
   // Format date and time as separate parts. The bottom-row template


### PR DESCRIPTION
Stop tearing down the radar layer stack on every map nav. Today, `moveend`/`zoomend` triggers `_clearLayers + _initRadar`, which removes every layer, re-fetches the timestamp index, and reloads tiles from scratch. Leaflet's `TileLayer` already handles incremental loading on pan/zoom (only new tiles entering the viewport are fetched), so the existing path is fighting Leaflet rather than using it.

Four commits, one concern each. The first keeps tile layers attached across pan/zoom/resize: `onNavSettled` takes a no-teardown path when state is intact (`_radarReady && _configFrameCount === frameCount`); the periodic `_scheduleUpdate` still refreshes timestamps every 5 min. The second avoids a layer flash on resume; the naive resume path called `_startLoop(currentSlot)`, which routes through `_showSlot` and snaps the layer to opacity 0 before fading it back in, reading as a flash on every pan. Now `_loopGen++` and `_scheduleNext` directly. It belongs to this PR because the flash only exists with no-teardown.

The third pins the native tile zoom on zoom-in so zoom-out reuses cached tiles. `_pinnedNativeZoom` tracks the highest zoom requested in the session, bumped on `zoomend` (never lowered), passed as `minNativeZoom` on every layer. Zoom-out keeps the higher native tiles cached; only edge tiles fetch. Trade-off worth flagging: zoom-out by N levels needs ~4ⁿ more tiles than the lower-native fetch would. For typical use within ±1 to 2 levels that's negligible, and the existing `on429` handler catches the rare large zoom-out burst.

The fourth shows the spinner during pan/zoom tile fetches. Without it, pan/zoom on already-attached layers fetches edge tiles silently because nothing calls `_setSegment(loading)`. Added a `_tilePending > 0` check across layers plus `loading`/`load` listeners via a small `wireSpinner` helper. Belongs to this PR because the gap only matters once layers stay attached.

Stacks on #130. Without it, ancestor tiles from prior zooms accumulate as the loop cycles and the no-teardown win is lost again to stacked levels. `src/radar-player.ts` only. Rebased on top of v3.5.0 so it sits cleanly with the dynamic tile-size selector, the `smooth_overlap` knob, and the source-agnostic time-range refactor.