### PR TITLE
feat(dwd): wind overlay (barbs, arrows, streamlines)

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -3,3 +3,8 @@ export const CARD_VERSION = '3.6.0-alpha3';
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.
 export const BUILD_TIMESTAMP = '__BUILD_TIMESTAMP__';
+
+// Map layer z-index stacking (low → high). Markers (incl. wind overlay) default to ~600 in Leaflet.
+export const Z_BASEMAP = 0;
+export const Z_LABELS = 2;
+export const Z_RADAR_BASE = 100;       // current radar frame floor; +1 each crossfade

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -80,7 +80,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
   // Which sub-view of the editor is showing. Defaults to 'main' (the
   // top-level settings). Routing happens entirely in-memory — closing and
   // re-opening the editor returns to 'main', matching HA editor conventions.
-  @state() private _view: 'main' | 'markers' | 'overlays' = 'main';
+  @state() private _view: 'main' | 'markers' | 'overlays' | 'wind' = 'main';
 
   private _initialized = false;
 
@@ -144,6 +144,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
     if (!this._config) return html``;
     if (this._view === 'markers') return this._renderMarkersView(this._config);
     if (this._view === 'overlays') return this._renderOverlaysView(this._config);
+    if (this._view === 'wind') return this._renderWindView(this._config);
     return this._renderMainView(this._config);
   }
 
@@ -252,6 +253,16 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
           <span class="subpage-nav-summary">${this._overlaysSummary(config)}</span>
           <span class="subpage-nav-chevron">›</span>
         </button>
+        ${config.data_source === 'DWD' ? html`
+          <button
+            class="subpage-nav-row"
+            @click=${() => this._setView('wind')}
+          >
+            <span class="subpage-nav-label">${localize('editor.section.wind_overlay')}</span>
+            <span class="subpage-nav-summary">${this._windSummary(config)}</span>
+            <span class="subpage-nav-chevron">›</span>
+          </button>
+        ` : ''}
 
         <!-- DISPLAY -->
         <h3 class="section-header">${localize('editor.section.display')}</h3>
@@ -459,6 +470,81 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
     return parts.join(', ');
   }
 
+  // Right-hand summary for the Wind Overlay nav row. Stacks the active
+  // layers ("Barbs + Flow") so the user can see the current state without
+  // entering the subpage.
+  private _windSummary(config: WeatherRadarCardConfig): string {
+    const parts: string[] = [];
+    const style = config.dwd_wind ?? 'off';
+    if (style === 'barbs') parts.push(localize('editor.wind.summary_barbs'));
+    else if (style === 'arrows') parts.push(localize('editor.wind.summary_arrows'));
+    if (config.dwd_wind_flow === true) parts.push(localize('editor.wind.summary_flow'));
+    if (parts.length === 0) return localize('editor.wind.summary_off');
+    return parts.join(' + ');
+  }
+
+  private _renderWindView(config: WeatherRadarCardConfig): TemplateResult {
+    const style = config.dwd_wind ?? 'off';
+    return html`
+      <div class="values">
+        <button class="subpage-back" @click=${() => this._setView('main')}>
+          ‹ ${localize('editor.wind.back')}
+        </button>
+
+        <h3 class="section-header">${localize('editor.wind.header')}</h3>
+        <p class="section-description">${localize('editor.wind.description')}</p>
+
+        <ha-selector
+          .hass=${this.hass}
+          .selector=${{
+            select: {
+              mode: 'dropdown',
+              options: [
+                { value: 'off', label: localize('editor.wind.style_off') },
+                { value: 'barbs', label: localize('editor.wind.style_barbs') },
+                { value: 'arrows', label: localize('editor.wind.style_arrows') },
+              ],
+            },
+          }}
+          .value=${style}
+          .label=${localize('editor.wind.style_label')}
+          .configValue=${'dwd_wind'}
+          @value-changed=${this._handleSelectorChanged}
+        ></ha-selector>
+
+        ${style !== 'off' ? html`
+          <ha-selector
+            .hass=${this.hass}
+            .selector=${{ number: { min: 0.25, max: 4, step: 0.25, mode: 'slider' } }}
+            .value=${config.dwd_wind_density ?? 1}
+            .label=${localize('editor.wind.density_label')}
+            .helper=${localize('editor.wind.density_helper')}
+            .configValue=${'dwd_wind_density'}
+            @value-changed=${this._handleSelectorChanged}
+          ></ha-selector>
+          <ha-selector
+            .hass=${this.hass}
+            .selector=${{ number: { min: 0.5, max: 2, step: 0.25, mode: 'slider' } }}
+            .value=${config.dwd_wind_size ?? 1}
+            .label=${localize('editor.wind.size_label')}
+            .helper=${localize('editor.wind.size_helper')}
+            .configValue=${'dwd_wind_size'}
+            @value-changed=${this._handleSelectorChanged}
+          ></ha-selector>
+        ` : ''}
+
+        <label>
+          <ha-switch
+            .checked=${config.dwd_wind_flow === true}
+            .configValue=${'dwd_wind_flow'}
+            @change=${this._valueChangedSwitch}
+          ></ha-switch>
+          <span>${localize('editor.wind.flow_label')}</span>
+        </label>
+      </div>
+    `;
+  }
+
   private _renderOverlaysView(config: WeatherRadarCardConfig): TemplateResult {
     return html`
       <div class="values">
@@ -619,7 +705,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
     `;
   }
 
-  private _setView(view: 'main' | 'markers' | 'overlays'): void {
+  private _setView(view: 'main' | 'markers' | 'overlays' | 'wind'): void {
     this._view = view;
     // Scroll the editor pane back to the top so the user always lands at the
     // start of the new view, not part-way down where they were on the old one.

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -72,6 +72,7 @@
       "animation": "Animation",
       "appearance": "Aussehen",
       "overlays": "Gefahren-Overlays",
+      "wind_overlay": "Wind-Overlay",
       "markers_and_overlays": "Markierungen und Overlays"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Einschläge älter als (Minuten) ausblenden",
       "lightning_max_age_minutes_helper": "Karten-seitige Begrenzung. Standard 30. Ändert nicht die Max-Age-Einstellung der Blitzortung-Integration.",
       "lightning_label": "Blitze"
+    },
+    "wind": {
+      "back": "Zurück zu den Einstellungen",
+      "header": "Wind-Overlay (DWD ICON 10m)",
+      "description": "10-m-Wind aus dem ICON-Vorhersagemodell. Wähle einen statischen Stil und/oder animierte Stromlinien.",
+      "style_label": "Stil",
+      "style_off": "Aus",
+      "style_barbs": "Windfähnchen (meteorologisch)",
+      "style_arrows": "Windpfeile (in Windrichtung)",
+      "density_label": "Dichte",
+      "density_helper": "Höher = mehr Pfeile auf der Karte",
+      "size_label": "Größe",
+      "size_helper": "Höher = größere Pfeile",
+      "flow_label": "Animierte Stromlinien (Flow)",
+      "summary_off": "Aus",
+      "summary_barbs": "Fähnchen",
+      "summary_arrows": "Pfeile",
+      "summary_flow": "Flow"
     }
   }
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -72,6 +72,7 @@
       "animation": "Animation",
       "appearance": "Appearance",
       "overlays": "Hazard Overlays",
+      "wind_overlay": "Wind Overlay",
       "markers_and_overlays": "Markers and Overlays"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Hide strikes older than (minutes)",
       "lightning_max_age_minutes_helper": "Card-side cap. Default 30. Does not change the Blitzortung integration’s own max-age setting.",
       "lightning_label": "Lightning"
+    },
+    "wind": {
+      "back": "Back to settings",
+      "header": "Wind Overlay (DWD ICON 10m)",
+      "description": "10m wind from the ICON forecast model. Pick a static style and/or animated streamlines.",
+      "style_label": "Style",
+      "style_off": "Off",
+      "style_barbs": "Wind Barbs (meteorological)",
+      "style_arrows": "Wind Arrows (downwind)",
+      "density_label": "Density",
+      "density_helper": "Higher = more arrows on screen",
+      "size_label": "Size",
+      "size_helper": "Higher = larger arrows",
+      "flow_label": "Animated Streamlines (flow)",
+      "summary_off": "Off",
+      "summary_barbs": "Barbs",
+      "summary_arrows": "Arrows",
+      "summary_flow": "Flow"
     }
   }
 }

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -72,6 +72,7 @@
       "animation": "Animación",
       "appearance": "Apariencia",
       "overlays": "Capas de riesgo",
+      "wind_overlay": "Capa de viento",
       "markers_and_overlays": "Marcadores y capas"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Ocultar rayos más antiguos que (minutos)",
       "lightning_max_age_minutes_helper": "Límite del lado de la tarjeta. Predeterminado 30. No cambia la configuración de antigüedad máxima de la integración Blitzortung.",
       "lightning_label": "Rayos"
+    },
+    "wind": {
+      "back": "Volver a la configuración",
+      "header": "Capa de viento (DWD ICON 10m)",
+      "description": "Viento a 10 m del modelo de pronóstico ICON. Elige un estilo estático y/o líneas de flujo animadas.",
+      "style_label": "Estilo",
+      "style_off": "Desactivado",
+      "style_barbs": "Barbas (meteorológicas)",
+      "style_arrows": "Flechas (en sentido del viento)",
+      "density_label": "Densidad",
+      "density_helper": "Mayor = más flechas en pantalla",
+      "size_label": "Tamaño",
+      "size_helper": "Mayor = flechas más grandes",
+      "flow_label": "Líneas de flujo animadas",
+      "summary_off": "Desactivado",
+      "summary_barbs": "Barbas",
+      "summary_arrows": "Flechas",
+      "summary_flow": "Flujo"
     }
   }
 }

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -72,6 +72,7 @@
       "animation": "Animation",
       "appearance": "Apparence",
       "overlays": "Calques de risque",
+      "wind_overlay": "Couche vent",
       "markers_and_overlays": "Marqueurs et calques"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Masquer les impacts plus anciens que (minutes)",
       "lightning_max_age_minutes_helper": "Limite côté carte. Par défaut 30. Ne modifie pas le paramètre d’âge maximal de l’intégration Blitzortung.",
       "lightning_label": "Foudre"
+    },
+    "wind": {
+      "back": "Retour aux paramètres",
+      "header": "Couche vent (DWD ICON 10m)",
+      "description": "Vent à 10 m du modèle de prévision ICON. Choisissez un style statique et/ou des lignes de flux animées.",
+      "style_label": "Style",
+      "style_off": "Désactivé",
+      "style_barbs": "Barbules (météorologiques)",
+      "style_arrows": "Flèches (sous le vent)",
+      "density_label": "Densité",
+      "density_helper": "Plus élevé = plus de flèches à l'écran",
+      "size_label": "Taille",
+      "size_helper": "Plus élevé = flèches plus grandes",
+      "flow_label": "Lignes de flux animées",
+      "summary_off": "Désactivé",
+      "summary_barbs": "Barbules",
+      "summary_arrows": "Flèches",
+      "summary_flow": "Flux"
     }
   }
 }

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -72,6 +72,7 @@
       "animation": "Animazione",
       "appearance": "Aspetto",
       "overlays": "Sovrapposizioni di rischio",
+      "wind_overlay": "Layer del vento",
       "markers_and_overlays": "Marcatori e sovrapposizioni"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Nascondi fulmini più vecchi di (minuti)",
       "lightning_max_age_minutes_helper": "Limite lato scheda. Predefinito 30. Non modifica l’impostazione di età massima dell’integrazione Blitzortung.",
       "lightning_label": "Fulmini"
+    },
+    "wind": {
+      "back": "Torna alle impostazioni",
+      "header": "Layer del vento (DWD ICON 10m)",
+      "description": "Vento a 10 m dal modello di previsione ICON. Scegli uno stile statico e/o linee di flusso animate.",
+      "style_label": "Stile",
+      "style_off": "Disattivato",
+      "style_barbs": "Barbe (meteorologiche)",
+      "style_arrows": "Frecce (sottovento)",
+      "density_label": "Densità",
+      "density_helper": "Maggiore = più frecce sullo schermo",
+      "size_label": "Dimensione",
+      "size_helper": "Maggiore = frecce più grandi",
+      "flow_label": "Linee di flusso animate",
+      "summary_off": "Disattivato",
+      "summary_barbs": "Barbe",
+      "summary_arrows": "Frecce",
+      "summary_flow": "Flusso"
     }
   }
 }

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -72,6 +72,7 @@
       "animation": "Animasjon",
       "appearance": "Utseende",
       "overlays": "Faresoner",
+      "wind_overlay": "Vindlag",
       "markers_and_overlays": "Markører og overlegg"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Skjul nedslag eldre enn (minutter)",
       "lightning_max_age_minutes_helper": "Kort-side begrensning. Standard 30. Endrer ikke maks-alder-innstillingen til Blitzortung-integrasjonen.",
       "lightning_label": "Lyn"
+    },
+    "wind": {
+      "back": "Tilbake til innstillinger",
+      "header": "Vindlag (DWD ICON 10m)",
+      "description": "10 m vind fra ICON-prognosemodellen. Velg en statisk stil og/eller animerte strømlinjer.",
+      "style_label": "Stil",
+      "style_off": "Av",
+      "style_barbs": "Vindbarber (meteorologiske)",
+      "style_arrows": "Vindpiler (medvinds)",
+      "density_label": "Tetthet",
+      "density_helper": "Høyere = flere piler på skjermen",
+      "size_label": "Størrelse",
+      "size_helper": "Høyere = større piler",
+      "flow_label": "Animerte strømlinjer",
+      "summary_off": "Av",
+      "summary_barbs": "Barber",
+      "summary_arrows": "Piler",
+      "summary_flow": "Strøm"
     }
   }
 }

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -72,6 +72,7 @@
       "animation": "Animatie",
       "appearance": "Uiterlijk",
       "overlays": "Risicolagen",
+      "wind_overlay": "Windlaag",
       "markers_and_overlays": "Markeringen en lagen"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Verberg inslagen ouder dan (minuten)",
       "lightning_max_age_minutes_helper": "Kaart-zijdige begrenzing. Standaard 30. Verandert de max-leeftijd-instelling van de Blitzortung-integratie niet.",
       "lightning_label": "Bliksem"
+    },
+    "wind": {
+      "back": "Terug naar instellingen",
+      "header": "Windlaag (DWD ICON 10m)",
+      "description": "10m wind uit het ICON-voorspellingsmodel. Kies een statische stijl en/of geanimeerde stroomlijnen.",
+      "style_label": "Stijl",
+      "style_off": "Uit",
+      "style_barbs": "Windveren (meteorologisch)",
+      "style_arrows": "Windpijlen (in windrichting)",
+      "density_label": "Dichtheid",
+      "density_helper": "Hoger = meer pijlen op het scherm",
+      "size_label": "Grootte",
+      "size_helper": "Hoger = grotere pijlen",
+      "flow_label": "Geanimeerde stroomlijnen",
+      "summary_off": "Uit",
+      "summary_barbs": "Veren",
+      "summary_arrows": "Pijlen",
+      "summary_flow": "Stroom"
     }
   }
 }

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -72,6 +72,7 @@
       "animation": "Animacja",
       "appearance": "Wygląd",
       "overlays": "Warstwy zagrożeń",
+      "wind_overlay": "Warstwa wiatru",
       "markers_and_overlays": "Znaczniki i warstwy"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Ukryj uderzenia starsze niż (minuty)",
       "lightning_max_age_minutes_helper": "Limit po stronie karty. Domyślnie 30. Nie zmienia ustawienia maksymalnego wieku integracji Blitzortung.",
       "lightning_label": "Pioruny"
+    },
+    "wind": {
+      "back": "Powrót do ustawień",
+      "header": "Warstwa wiatru (DWD ICON 10m)",
+      "description": "Wiatr na wysokości 10 m z modelu prognostycznego ICON. Wybierz styl statyczny i/lub animowane linie prądu.",
+      "style_label": "Styl",
+      "style_off": "Wyłączone",
+      "style_barbs": "Barby (meteorologiczne)",
+      "style_arrows": "Strzałki (zgodnie z wiatrem)",
+      "density_label": "Gęstość",
+      "density_helper": "Wyższa = więcej strzałek na ekranie",
+      "size_label": "Rozmiar",
+      "size_helper": "Większy = większe strzałki",
+      "flow_label": "Animowane linie prądu",
+      "summary_off": "Wyłączone",
+      "summary_barbs": "Barby",
+      "summary_arrows": "Strzałki",
+      "summary_flow": "Przepływ"
     }
   }
 }

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -72,6 +72,7 @@
       "animation": "Animação",
       "appearance": "Aparência",
       "overlays": "Camadas de risco",
+      "wind_overlay": "Camada de vento",
       "markers_and_overlays": "Marcadores e camadas"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Ocultar raios mais antigos que (minutos)",
       "lightning_max_age_minutes_helper": "Limite no lado do cartão. Padrão 30. Não altera a configuração de idade máxima da integração Blitzortung.",
       "lightning_label": "Raios"
+    },
+    "wind": {
+      "back": "Voltar às configurações",
+      "header": "Camada de vento (DWD ICON 10m)",
+      "description": "Vento a 10 m do modelo de previsão ICON. Escolha um estilo estático e/ou linhas de fluxo animadas.",
+      "style_label": "Estilo",
+      "style_off": "Desativado",
+      "style_barbs": "Barbas (meteorológicas)",
+      "style_arrows": "Setas (na direção do vento)",
+      "density_label": "Densidade",
+      "density_helper": "Maior = mais setas na tela",
+      "size_label": "Tamanho",
+      "size_helper": "Maior = setas maiores",
+      "flow_label": "Linhas de fluxo animadas",
+      "summary_off": "Desativado",
+      "summary_barbs": "Barbas",
+      "summary_arrows": "Setas",
+      "summary_flow": "Fluxo"
     }
   }
 }

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -72,6 +72,7 @@
       "animation": "Animácia",
       "appearance": "Vzhľad",
       "overlays": "Vrstvy nebezpečenstiev",
+      "wind_overlay": "Vrstva vetra",
       "markers_and_overlays": "Značky a vrstvy"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Skryť údery staršie ako (minúty)",
       "lightning_max_age_minutes_helper": "Obmedzenie na strane karty. Predvolené 30. Nemení nastavenie maximálneho veku integrácie Blitzortung.",
       "lightning_label": "Blesky"
+    },
+    "wind": {
+      "back": "Späť na nastavenia",
+      "header": "Vrstva vetra (DWD ICON 10m)",
+      "description": "Vietor v 10 m z predpovedného modelu ICON. Vyberte statický štýl a/alebo animované prúdnice.",
+      "style_label": "Štýl",
+      "style_off": "Vypnuté",
+      "style_barbs": "Praporčeky (meteorologické)",
+      "style_arrows": "Šípky (po vetre)",
+      "density_label": "Hustota",
+      "density_helper": "Vyššia = viac šípok na obrazovke",
+      "size_label": "Veľkosť",
+      "size_helper": "Vyššia = väčšie šípky",
+      "flow_label": "Animované prúdnice",
+      "summary_off": "Vypnuté",
+      "summary_barbs": "Praporčeky",
+      "summary_arrows": "Šípky",
+      "summary_flow": "Prúdenie"
     }
   }
 }

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -72,6 +72,7 @@
       "animation": "Animation",
       "appearance": "Utseende",
       "overlays": "Riskskikt",
+      "wind_overlay": "Vindlager",
       "markers_and_overlays": "Markörer och skikt"
     },
     "map": {
@@ -212,6 +213,24 @@
       "lightning_max_age_minutes": "Dölj nedslag äldre än (minuter)",
       "lightning_max_age_minutes_helper": "Begränsning på kortets sida. Standard 30. Ändrar inte Blitzortung-integrationens egen max-ålderinställning.",
       "lightning_label": "Blixtar"
+    },
+    "wind": {
+      "back": "Tillbaka till inställningar",
+      "header": "Vindlager (DWD ICON 10m)",
+      "description": "10 m vind från ICON-prognosmodellen. Välj en statisk stil och/eller animerade strömlinjer.",
+      "style_label": "Stil",
+      "style_off": "Av",
+      "style_barbs": "Vindfjädrar (meteorologiska)",
+      "style_arrows": "Vindpilar (medvinds)",
+      "density_label": "Täthet",
+      "density_helper": "Högre = fler pilar på skärmen",
+      "size_label": "Storlek",
+      "size_helper": "Högre = större pilar",
+      "flow_label": "Animerade strömlinjer",
+      "summary_off": "Av",
+      "summary_barbs": "Fjädrar",
+      "summary_arrows": "Pilar",
+      "summary_flow": "Flöde"
     }
   }
 }

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as L from 'leaflet';
 import { WeatherRadarCardConfig } from './types';
+import { Z_RADAR_BASE } from './const';
 import { RateLimiter } from './rate-limiter';
 import { FetchTileLayer, FetchWmsTileLayer, layerSettled } from './fetch-tile-layer';
 import { RadarToolbar } from './radar-toolbar';
@@ -552,7 +553,7 @@ export class RadarPlayer {
     // to delay, so the chain logic collapses: snap new to active, snap
     // all others to 0. Single layer always visible.
     this._zCounter++;
-    const newZ = 100 + this._zCounter;
+    const newZ = Z_RADAR_BASE + this._zCounter;
     const prev1 = this._prev1Slot;
     const useChain = fade > 0;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,14 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
   dwd_layer?: string;
   /** @deprecated since 3.5: use forecast_minutes (source-agnostic). Auto-migrated by migrateConfig. */
   dwd_forecast_hours?: number;
+  /** DWD-only: 10m wind overlay from ICON. Both styles are client-rendered from the same U/V grid. */
+  dwd_wind?: 'off' | 'barbs' | 'arrows';
+  /** DWD-only: grid-density multiplier for the wind overlay (0.25–4). 1 = default. Higher = more arrows on screen. */
+  dwd_wind_density?: number;
+  /** DWD-only: icon-size multiplier for the wind overlay (0.5–2). 1 = default 22px. */
+  dwd_wind_size?: number;
+  /** DWD-only: animated wind streamline overlay (à la DWD WarnWetter app). Stacks with dwd_wind. */
+  dwd_wind_flow?: boolean;
   show_snow?: boolean;
   show_progress_bar?: boolean;
   show_color_bar?: boolean;

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -11,11 +11,13 @@ import markerClusterCss from 'leaflet.markercluster/dist/MarkerCluster.css';
 
 import './editor';
 import { WeatherRadarCardConfig, Marker } from './types';
-import { CARD_VERSION, BUILD_TIMESTAMP } from './const';
+import { CARD_VERSION, BUILD_TIMESTAMP, Z_BASEMAP, Z_LABELS } from './const';
 import { getEffectiveTimeRange } from './source-caps';
 import { localize } from './localize/localize';
 import { rainviewerLimiter, noaaLimiter, dwdLimiter } from './rate-limiters';
 import { FetchTileLayer } from './fetch-tile-layer';
+import { WindOverlay } from './wind-overlay';
+import { WindFlowOverlay } from './wind-flow-overlay';
 import { RadarToolbar } from './radar-toolbar';
 import { RadarPlayer } from './radar-player';
 import {
@@ -81,6 +83,8 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
   private _map: L.Map | null = null;
   private _currentMapStyle: string | null = null;
   private _townLayer: FetchTileLayer | null = null;
+  private _windOverlay: WindOverlay | null = null;
+  private _windFlow: WindFlowOverlay | null = null;
   private _toolbar: RadarToolbar | null = null;
   private _markers: Map<number, L.Marker> = new Map();
   private _clusterGroup: L.MarkerClusterGroup | null = null;
@@ -460,6 +464,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       L.control.scale({ imperial: !metric, metric }).addTo(this._map);
     }
     this._setupBasemap(mapStyle);
+    this._setupWindOverlay();
     this._setupAttribution(mapStyle);
     this._setupMarkers(mapStyle);
     this._setupToolbar();
@@ -552,6 +557,10 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     if (this._map) { this._map.remove(); this._map = null; }
     this._currentMapStyle = null;
     this._townLayer = null;
+    this._windOverlay?.destroy();
+    this._windOverlay = null;
+    this._windFlow?.destroy();
+    this._windFlow = null;
     this._toolbar = null;
     this._markers.clear();
     this._trackedMarkerIdx = -1;
@@ -591,13 +600,44 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     }
 
     new FetchTileLayer(url, { style, subdomains, detectRetina: false, tileSize, zoomOffset } as any)
-      .addTo(this._map).setZIndex(0);
+      .addTo(this._map).setZIndex(Z_BASEMAP);
 
     if (!osmLabels && labelUrl) {
       this._townLayer = new FetchTileLayer(labelUrl, {
         subdomains: 'abcd', detectRetina: false, tileSize, zoomOffset,
       } as any).addTo(this._map);
-      this._townLayer.setZIndex(2);
+      this._townLayer.setZIndex(Z_LABELS);
+    }
+  }
+
+  private _setupWindOverlay(): void {
+    if (!this._map) return;
+    const cfg = this._config;
+    if (cfg.data_source !== 'DWD') return;
+
+    // Anchor matches the radar's latest playback frame: override (or now) plus forecast.
+    const forecastMs = (cfg.forecast_minutes ?? 0) * 60_000;
+    const baseMs = cfg.dwd_time_override ? new Date(cfg.dwd_time_override).getTime() : Date.now();
+    const anchorMs = baseMs + forecastMs;
+    const useAnchor = cfg.dwd_time_override != null || forecastMs > 0;
+    const timeMs = useAnchor ? anchorMs : undefined;
+
+    const mode = cfg.dwd_wind ?? 'off';
+    if (mode === 'barbs' || mode === 'arrows') {
+      this._windOverlay = new WindOverlay(this._map, {
+        style: mode,
+        density: cfg.dwd_wind_density,
+        size: cfg.dwd_wind_size,
+        timeMs,
+      });
+    }
+    if (cfg.dwd_wind_flow === true) {
+      // Use a darker stroke on light basemaps and a lighter one on dark.
+      const dark = this._currentMapStyle === 'dark' || this._currentMapStyle === 'satellite';
+      this._windFlow = new WindFlowOverlay(this._map, {
+        timeMs,
+        particleColor: dark ? 'rgba(220,225,235,0.55)' : 'rgba(50,55,75,0.5)',
+      });
     }
   }
 

--- a/src/wind-flow-overlay.ts
+++ b/src/wind-flow-overlay.ts
@@ -57,6 +57,12 @@ export class WindFlowOverlay {
   private _onMoveStart: () => void;
   private _onMoveEnd: () => void;
   private _onResize: () => void;
+  // prefers-reduced-motion: spinning particles 30×/s on lower-end devices is
+  // exactly the kind of work the OS-level setting asks us to skip. We watch
+  // the media query so toggling it in System Settings takes effect without
+  // a card reload.
+  private _reducedMotionMql: MediaQueryList | null = null;
+  private _onReducedMotionChange: ((e: MediaQueryListEvent) => void) | null = null;
 
   constructor(map: L.Map, opts: WindFlowOverlayOptions = {}) {
     this._map = map;
@@ -84,6 +90,12 @@ export class WindFlowOverlay {
     map.on('moveend zoomend', this._onMoveEnd);
     map.on('resize', this._onResize);
 
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      this._reducedMotionMql = window.matchMedia('(prefers-reduced-motion: reduce)');
+      this._onReducedMotionChange = (): void => { void this._restart(); };
+      this._reducedMotionMql.addEventListener('change', this._onReducedMotionChange);
+    }
+
     void this._restart();
   }
 
@@ -93,6 +105,9 @@ export class WindFlowOverlay {
     this._map.off('movestart zoomstart', this._onMoveStart);
     this._map.off('moveend zoomend', this._onMoveEnd);
     this._map.off('resize', this._onResize);
+    if (this._reducedMotionMql && this._onReducedMotionChange) {
+      this._reducedMotionMql.removeEventListener('change', this._onReducedMotionChange);
+    }
     if (this._canvas.parentNode) this._canvas.parentNode.removeChild(this._canvas);
   }
 
@@ -110,6 +125,11 @@ export class WindFlowOverlay {
     this._canvas.width = size.x;
     this._canvas.height = size.y;
     this._ctx.clearRect(0, 0, size.x, size.y);
+
+    // Honour OS-level reduced-motion. The streamlines layer is purely
+    // decorative — barbs/arrows still convey direction & speed — so we
+    // disable the animation entirely rather than rendering a static frame.
+    if (this._reducedMotionMql?.matches) return;
 
     await this._fetchGrid();
     if (myGen !== this._gen) return;
@@ -207,24 +227,10 @@ export class WindFlowOverlay {
   }
 
   private _interpolate(lat: number, lon: number): { u: number; v: number } {
-    if (this._gridRows === 0) return { u: 0, v: 0 };
-    const step = this._gridStep;
-    const r = (lat - this._gridLatMin) / step;
-    const c = (lon - this._gridLonMin) / step;
-    const r0 = Math.floor(r);
-    const c0 = Math.floor(c);
-    if (r0 < 0 || r0 + 1 >= this._gridRows || c0 < 0 || c0 + 1 >= this._gridCols) {
-      return { u: 0, v: 0 };
-    }
-    const fr = r - r0;
-    const fc = c - c0;
-    const a = this._grid[r0][c0];
-    const b = this._grid[r0][c0 + 1];
-    const cc = this._grid[r0 + 1][c0];
-    const d = this._grid[r0 + 1][c0 + 1];
-    const u = (1 - fr) * ((1 - fc) * a.u + fc * b.u) + fr * ((1 - fc) * cc.u + fc * d.u);
-    const v = (1 - fr) * ((1 - fc) * a.v + fc * b.v) + fr * ((1 - fc) * cc.v + fc * d.v);
-    return { u, v };
+    return bilinearUV(
+      this._grid, this._gridLatMin, this._gridLonMin, this._gridStep,
+      this._gridRows, this._gridCols, lat, lon,
+    );
   }
 
   private _tick = (): void => {
@@ -276,4 +282,33 @@ export class WindFlowOverlay {
     ctx.stroke();
     this._animFrame = requestAnimationFrame(this._tick);
   };
+}
+
+// Bilinear interpolation of a regular lat/lon U/V grid. Pure: no DOM, no
+// Leaflet, no class state — caller passes the grid + axis params + sample
+// point. Out-of-grid samples and empty grids return (0,0) so the streamline
+// loop draws nothing rather than crashing.
+export function bilinearUV(
+  grid: ReadonlyArray<ReadonlyArray<{ u: number; v: number }>>,
+  latMin: number, lonMin: number, step: number,
+  rows: number, cols: number,
+  lat: number, lon: number,
+): { u: number; v: number } {
+  if (rows === 0 || cols === 0) return { u: 0, v: 0 };
+  const r = (lat - latMin) / step;
+  const c = (lon - lonMin) / step;
+  const r0 = Math.floor(r);
+  const c0 = Math.floor(c);
+  if (r0 < 0 || r0 + 1 >= rows || c0 < 0 || c0 + 1 >= cols) {
+    return { u: 0, v: 0 };
+  }
+  const fr = r - r0;
+  const fc = c - c0;
+  const a = grid[r0][c0];
+  const b = grid[r0][c0 + 1];
+  const cc = grid[r0 + 1][c0];
+  const d = grid[r0 + 1][c0 + 1];
+  const u = (1 - fr) * ((1 - fc) * a.u + fc * b.u) + fr * ((1 - fc) * cc.u + fc * d.u);
+  const v = (1 - fr) * ((1 - fc) * a.v + fc * b.v) + fr * ((1 - fc) * cc.v + fc * d.v);
+  return { u, v };
 }

--- a/src/wind-flow-overlay.ts
+++ b/src/wind-flow-overlay.ts
@@ -1,0 +1,279 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Animated wind streamlines (à la earth.nullschool.net / DWD WarnWetter app).
+// Spawns N particles, advances each one along the local wind vector each frame,
+// trails them on a Canvas2D layer with alpha-fade. Density of trails ends up
+// reflecting wind speed because faster cells carry particles further per frame.
+//
+// Why Canvas2D and not WebGL? At 1500 particles in a 500×500 card the math is
+// trivial and Canvas2D `stroke()` is plenty fast (~5ms/frame on integrated
+// graphics). WebGL would only matter at 50k+ particles, full-screen.
+import * as L from 'leaflet';
+
+const WMS_URL = 'https://maps.dwd.de/geoserver/dwd/wms';
+const WMS_LAYER = 'Icon_reg025_fd_sl_UV10M';
+const ICON_GRID_DEG = 0.25;
+// Hard cap on the U/V grid we fetch each refresh — bilinear interpolation between
+// these points feeds the per-particle wind sample. Keeps the GetFeatureInfo burst
+// bounded even on tall viewports at low zoom.
+const MAX_GRID_POINTS = 400;
+// Particle population is tuned per-area so dense viewports don't starve and tiny
+// ones don't render too many. ~1 particle per 220 px² ≈ 1500 particles at 500×600.
+const PARTICLE_DENSITY = 1 / 220;
+const PARTICLE_CAP = 3500;
+const PARTICLE_LIFETIME_FRAMES = 60;   // ~2s at 30fps
+const FADE_PER_FRAME = 0.04;           // 4% alpha decay → trails persist ~25 frames
+// Visual speed exaggeration. Real m/s × this → screen pixels per frame.
+// 0.4 puts a 10 m/s wind at ~4 px/frame across zooms — roughly the DWD app pace.
+const PARTICLE_SPEED_PX_PER_MPS = 0.4;
+
+export interface WindFlowOverlayOptions {
+  /** Anchor time in epoch ms. Snapped to the hourly ICON boundary. Omit for "current". */
+  timeMs?: number;
+  /** Stroke for new line segments. Defaults to a neutral grey that reads on light or dark maps. */
+  particleColor?: string;
+}
+
+interface GridCell { u: number; v: number; }
+
+export class WindFlowOverlay {
+  private _map: L.Map;
+  private _canvas: HTMLCanvasElement;
+  private _ctx: CanvasRenderingContext2D;
+  private _grid: GridCell[][] = [];
+  private _gridStep = ICON_GRID_DEG;
+  private _gridLatMin = 0;
+  private _gridLonMin = 0;
+  private _gridRows = 0;
+  private _gridCols = 0;
+  // Particles are stored as a flat Float32Array — [x, y, age, x, y, age, …].
+  // Cheaper to update than an Array of objects when we touch it 30×/sec.
+  private _particles = new Float32Array(0);
+  private _particleCount = 0;
+  private _animFrame = 0;
+  private _gen = 0;
+  private _running = false;
+  private _timeIso: string | null = null;
+  private _color: string;
+  private _onMoveStart: () => void;
+  private _onMoveEnd: () => void;
+  private _onResize: () => void;
+
+  constructor(map: L.Map, opts: WindFlowOverlayOptions = {}) {
+    this._map = map;
+    this._color = opts.particleColor ?? 'rgba(60,60,80,0.55)';
+    if (opts.timeMs != null) {
+      const snapped = Math.trunc(opts.timeMs / 3_600_000) * 3_600_000;
+      this._timeIso = new Date(snapped).toISOString().split('.')[0] + 'Z';
+    }
+
+    this._canvas = L.DomUtil.create('canvas', 'wrc-wind-flow') as HTMLCanvasElement;
+    Object.assign(this._canvas.style, {
+      position: 'absolute',
+      pointerEvents: 'none',
+      left: '0',
+      top: '0',
+      zIndex: '500',                    // above tilePane (200), below markerPane (600)
+    } satisfies Partial<CSSStyleDeclaration>);
+    map.getContainer().appendChild(this._canvas);
+    this._ctx = this._canvas.getContext('2d')!;
+
+    this._onMoveStart = (): void => this._stopLoop();
+    this._onMoveEnd = (): void => { void this._restart(); };
+    this._onResize = (): void => { void this._restart(); };
+    map.on('movestart zoomstart', this._onMoveStart);
+    map.on('moveend zoomend', this._onMoveEnd);
+    map.on('resize', this._onResize);
+
+    void this._restart();
+  }
+
+  destroy(): void {
+    this._stopLoop();
+    this._gen++;
+    this._map.off('movestart zoomstart', this._onMoveStart);
+    this._map.off('moveend zoomend', this._onMoveEnd);
+    this._map.off('resize', this._onResize);
+    if (this._canvas.parentNode) this._canvas.parentNode.removeChild(this._canvas);
+  }
+
+  private _stopLoop(): void {
+    this._running = false;
+    if (this._animFrame) cancelAnimationFrame(this._animFrame);
+    this._animFrame = 0;
+  }
+
+  private async _restart(): Promise<void> {
+    this._stopLoop();
+    const myGen = ++this._gen;
+
+    const size = this._map.getSize();
+    this._canvas.width = size.x;
+    this._canvas.height = size.y;
+    this._ctx.clearRect(0, 0, size.x, size.y);
+
+    await this._fetchGrid();
+    if (myGen !== this._gen) return;
+
+    this._spawnParticles(size.x, size.y);
+    this._running = true;
+    this._tick();
+  }
+
+  private _stepCellsForZoom(): number {
+    const z = this._map.getZoom();
+    return z >= 8 ? 1 : z >= 6 ? 2 : z >= 5 ? 4 : 8;
+  }
+
+  private async _fetchGrid(): Promise<void> {
+    const b = this._map.getBounds();
+    const stepCells = this._stepCellsForZoom();
+    const step = ICON_GRID_DEG * stepCells;
+    // Snap outward + 1 cell padding so off-screen particles still find data.
+    const south = Math.floor(b.getSouth() / step) * step - step;
+    const north = Math.ceil(b.getNorth() / step) * step + step;
+    const west = Math.floor(b.getWest() / step) * step - step;
+    const east = Math.ceil(b.getEast() / step) * step + step;
+
+    const lats: number[] = [];
+    const lons: number[] = [];
+    for (let lat = south; lat <= north + 1e-9; lat += step) lats.push(lat);
+    for (let lon = west; lon <= east + 1e-9; lon += step) lons.push(lon);
+
+    if (lats.length * lons.length > MAX_GRID_POINTS) {
+      // Belt-and-braces: shouldn't normally hit this with the zoom rules above.
+      console.warn('WindFlowOverlay: grid exceeds cap, skipping fetch');
+      this._grid = [];
+      this._gridRows = this._gridCols = 0;
+      return;
+    }
+
+    const promises: Promise<GridCell>[] = [];
+    for (const lat of lats) {
+      for (const lon of lons) {
+        promises.push(this._fetchPoint(lat, lon));
+      }
+    }
+    const samples = await Promise.all(promises);
+
+    const grid: GridCell[][] = [];
+    let i = 0;
+    for (let r = 0; r < lats.length; r++) {
+      const row: GridCell[] = [];
+      for (let c = 0; c < lons.length; c++) row.push(samples[i++]);
+      grid.push(row);
+    }
+
+    this._grid = grid;
+    this._gridStep = step;
+    this._gridLatMin = south;
+    this._gridLonMin = west;
+    this._gridRows = lats.length;
+    this._gridCols = lons.length;
+  }
+
+  private async _fetchPoint(lat: number, lon: number): Promise<GridCell> {
+    const half = ICON_GRID_DEG / 4;
+    const params = new URLSearchParams({
+      service: 'WMS', version: '1.3.0', request: 'GetFeatureInfo',
+      layers: WMS_LAYER, query_layers: WMS_LAYER, styles: '',
+      crs: 'EPSG:4326',
+      bbox: `${lat - half},${lon - half},${lat + half},${lon + half}`,
+      width: '2', height: '2', i: '1', j: '1',
+      info_format: 'application/json',
+    });
+    if (this._timeIso) params.set('TIME', this._timeIso);
+    try {
+      const res = await fetch(`${WMS_URL}?${params}`);
+      if (!res.ok) return { u: 0, v: 0 };
+      const data = await res.json();
+      const p = data?.features?.[0]?.properties;
+      if (!p || typeof p.u !== 'number') return { u: 0, v: 0 };
+      return { u: p.u, v: p.v };
+    } catch {
+      return { u: 0, v: 0 };
+    }
+  }
+
+  private _spawnParticles(w: number, h: number): void {
+    const count = Math.min(PARTICLE_CAP, Math.round(w * h * PARTICLE_DENSITY));
+    this._particleCount = count;
+    this._particles = new Float32Array(count * 3);
+    for (let p = 0; p < count; p++) {
+      this._particles[p * 3] = Math.random() * w;
+      this._particles[p * 3 + 1] = Math.random() * h;
+      // Stagger initial ages so particles don't all respawn on the same frame.
+      this._particles[p * 3 + 2] = Math.random() * PARTICLE_LIFETIME_FRAMES;
+    }
+  }
+
+  private _interpolate(lat: number, lon: number): { u: number; v: number } {
+    if (this._gridRows === 0) return { u: 0, v: 0 };
+    const step = this._gridStep;
+    const r = (lat - this._gridLatMin) / step;
+    const c = (lon - this._gridLonMin) / step;
+    const r0 = Math.floor(r);
+    const c0 = Math.floor(c);
+    if (r0 < 0 || r0 + 1 >= this._gridRows || c0 < 0 || c0 + 1 >= this._gridCols) {
+      return { u: 0, v: 0 };
+    }
+    const fr = r - r0;
+    const fc = c - c0;
+    const a = this._grid[r0][c0];
+    const b = this._grid[r0][c0 + 1];
+    const cc = this._grid[r0 + 1][c0];
+    const d = this._grid[r0 + 1][c0 + 1];
+    const u = (1 - fr) * ((1 - fc) * a.u + fc * b.u) + fr * ((1 - fc) * cc.u + fc * d.u);
+    const v = (1 - fr) * ((1 - fc) * a.v + fc * b.v) + fr * ((1 - fc) * cc.v + fc * d.v);
+    return { u, v };
+  }
+
+  private _tick = (): void => {
+    if (!this._running) return;
+    const ctx = this._ctx;
+    const w = this._canvas.width;
+    const h = this._canvas.height;
+
+    // Decay existing trails — destination-out drops alpha regardless of colour,
+    // so this works on any basemap.
+    ctx.globalCompositeOperation = 'destination-out';
+    ctx.fillStyle = `rgba(0,0,0,${FADE_PER_FRAME})`;
+    ctx.fillRect(0, 0, w, h);
+
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.strokeStyle = this._color;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+
+    for (let p = 0; p < this._particleCount; p++) {
+      const idx = p * 3;
+      const x = this._particles[idx];
+      const y = this._particles[idx + 1];
+      let age = this._particles[idx + 2];
+
+      const ll = this._map.containerPointToLatLng(L.point(x, y));
+      const wind = this._interpolate(ll.lat, ll.lng);
+
+      const nx = x + wind.u * PARTICLE_SPEED_PX_PER_MPS;
+      const ny = y - wind.v * PARTICLE_SPEED_PX_PER_MPS; // pixel y goes down; v is northward
+
+      if (Math.abs(wind.u) + Math.abs(wind.v) > 0.05) {
+        ctx.moveTo(x, y);
+        ctx.lineTo(nx, ny);
+      }
+
+      age++;
+      if (age > PARTICLE_LIFETIME_FRAMES || nx < 0 || nx > w || ny < 0 || ny > h) {
+        this._particles[idx] = Math.random() * w;
+        this._particles[idx + 1] = Math.random() * h;
+        this._particles[idx + 2] = 0;
+      } else {
+        this._particles[idx] = nx;
+        this._particles[idx + 1] = ny;
+        this._particles[idx + 2] = age;
+      }
+    }
+
+    ctx.stroke();
+    this._animFrame = requestAnimationFrame(this._tick);
+  };
+}

--- a/src/wind-overlay.ts
+++ b/src/wind-overlay.ts
@@ -196,11 +196,7 @@ function barbIcon(u: number, v: number, speedMps: number, size: number): L.DivIc
   // Wind FROM direction: opposite of "to" direction (atan2(u, v) is "to").
   const angleDeg = (Math.atan2(u, v) * 180) / Math.PI + 180;
 
-  const k5 = Math.round(knots / 5) * 5;
-  let remaining = k5;
-  const pennants = Math.floor(remaining / 50); remaining -= pennants * 50;
-  const fullFeathers = Math.floor(remaining / 10); remaining -= fullFeathers * 10;
-  const halfFeather = remaining >= 5 ? 1 : 0;
+  const { pennants, fullFeathers, halfFeather } = decomposeBarbKnots(knots);
 
   // Staff: from origin (12,12) up to (12,2). Feathers attach starting at the tip
   // and walk down the staff. Northern Hemisphere convention puts feathers on the
@@ -241,7 +237,7 @@ function barbIcon(u: number, v: number, speedMps: number, size: number): L.DivIc
   });
 }
 
-function speedColour(mps: number): string {
+export function speedColour(mps: number): string {
   // Beaufort-ish bands: calm/light/moderate/fresh/strong/gale.
   if (mps < 1.5) return '#88a';
   if (mps < 3.5) return '#3a7';
@@ -249,4 +245,18 @@ function speedColour(mps: number): string {
   if (mps < 8) return '#d80';
   if (mps < 11) return '#c40';
   return '#a00';
+}
+
+// Round speed to the nearest 5 kt and decompose into glyph counts. WMO
+// convention: pennant = 50 kt, full feather = 10 kt, half feather = 5 kt.
+// Pure: speed in → glyph counts out, no DOM, no SVG.
+export function decomposeBarbKnots(knots: number): {
+  k5: number; pennants: number; fullFeathers: number; halfFeather: 0 | 1;
+} {
+  const k5 = Math.round(knots / 5) * 5;
+  let r = k5;
+  const pennants = Math.floor(r / 50); r -= pennants * 50;
+  const fullFeathers = Math.floor(r / 10); r -= fullFeathers * 10;
+  const halfFeather: 0 | 1 = r >= 5 ? 1 : 0;
+  return { k5, pennants, fullFeathers, halfFeather };
 }

--- a/src/wind-overlay.ts
+++ b/src/wind-overlay.ts
@@ -1,0 +1,252 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as L from 'leaflet';
+
+const WMS_URL = 'https://maps.dwd.de/geoserver/dwd/wms';
+const WMS_LAYER = 'Icon_reg025_fd_sl_UV10M';
+const ICON_GRID_DEG = 0.25;
+const MAX_POINTS = 400;
+// Min step sizes (in ICON grid units) per zoom — keeps screen density roughly constant
+// at density=1. Higher density divides this; lower multiplies it. Native floor is 1.
+const MIN_STEP_BY_ZOOM: Record<number, number> = {
+  3: 8, 4: 4, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1,
+};
+const BASE_ICON_PX = 22;
+const MIN_ICON_PX = 10;
+
+export type WindStyle = 'barbs' | 'arrows';
+
+export interface WindOverlayOptions {
+  style: WindStyle;
+  /** 1.0 = default. Higher = denser grid (more arrows on screen). Independent of icon size. */
+  density?: number;
+  /** 1.0 = default 22px. Range 0.5–2. Independent of density. */
+  size?: number;
+  /** Anchor time in epoch ms. Snapped to the hourly ICON boundary. Omit for "current". */
+  timeMs?: number;
+}
+
+interface Sample { lat: number; lon: number; u: number; v: number; }
+
+export class WindOverlay {
+  private _map: L.Map;
+  private _layer: L.LayerGroup;
+  private _style: WindStyle;
+  private _density: number;
+  private _sizeMult: number;
+  private _timeIso: string | null;
+  private _gen = 0;
+  private _moveHandler: () => void;
+  private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(map: L.Map, opts: WindOverlayOptions) {
+    this._map = map;
+    this._style = opts.style;
+    // Sanitise density: NaN, 0, negative, and Infinity all fall back to the
+    // default 1. NaN propagates through Math.max/min and would freeze the
+    // grid step loop in _gridPoints (NaN > 64 is false, NaN *= 2 stays NaN).
+    const d = Number(opts.density);
+    this._density = Number.isFinite(d) && d > 0 ? Math.max(0.25, Math.min(4, d)) : 1;
+    const s = Number(opts.size);
+    this._sizeMult = Number.isFinite(s) && s > 0 ? Math.max(0.5, Math.min(2, s)) : 1;
+    if (opts.timeMs != null) {
+      // Snap to the hourly ICON boundary; DWD rejects off-boundary timestamps.
+      const snapped = Math.trunc(opts.timeMs / 3_600_000) * 3_600_000;
+      this._timeIso = new Date(snapped).toISOString().split('.')[0] + 'Z';
+    } else {
+      this._timeIso = null;
+    }
+    this._layer = L.layerGroup().addTo(map);
+    this._moveHandler = (): void => {
+      if (this._debounceTimer) clearTimeout(this._debounceTimer);
+      this._debounceTimer = setTimeout(() => this._refresh(), 250);
+    };
+    map.on('moveend', this._moveHandler);
+    void this._refresh();
+  }
+
+  destroy(): void {
+    if (this._debounceTimer) clearTimeout(this._debounceTimer);
+    this._map.off('moveend', this._moveHandler);
+    this._layer.remove();
+    this._gen++;
+  }
+
+  private get _iconSize(): number {
+    return Math.max(MIN_ICON_PX, Math.round(BASE_ICON_PX * this._sizeMult));
+  }
+
+  private async _refresh(): Promise<void> {
+    const myGen = ++this._gen;
+    const points = this._gridPoints();
+    if (points.length === 0) {
+      this._layer.clearLayers();
+      return;
+    }
+    const samples = await Promise.all(points.map(p => this._fetchPoint(p.lat, p.lon)));
+    if (myGen !== this._gen) return;
+    this._layer.clearLayers();
+    const size = this._iconSize;
+    for (const s of samples) {
+      if (!s) continue;
+      const speed = Math.hypot(s.u, s.v);
+      const icon = this._style === 'barbs' ? barbIcon(s.u, s.v, speed, size) : arrowIcon(s.u, s.v, speed, size);
+      if (!icon) continue;
+      const marker = L.marker([s.lat, s.lon], { icon, interactive: false, keyboard: false });
+      this._layer.addLayer(marker);
+    }
+  }
+
+  private _gridPoints(): { lat: number; lon: number }[] {
+    const b = this._map.getBounds();
+    const z = this._map.getZoom();
+    const minStepCells = MIN_STEP_BY_ZOOM[z] ?? (z < 3 ? 12 : 1);
+    // Scale step inversely with density (higher density → smaller step), floor at 1 cell (native).
+    const scaledFloor = Math.max(1, Math.round(minStepCells / this._density));
+    const latSpan = b.getNorth() - b.getSouth();
+    const lonSpan = b.getEast() - b.getWest();
+    let stepCells = scaledFloor;
+    for (;;) {
+      const step = ICON_GRID_DEG * stepCells;
+      const rows = Math.floor(latSpan / step) + 1;
+      const cols = Math.floor(lonSpan / step) + 1;
+      if (rows * cols <= MAX_POINTS) break;
+      stepCells *= 2;
+      if (stepCells > 64) break;
+    }
+    const step = ICON_GRID_DEG * stepCells;
+    const south = Math.ceil(b.getSouth() / step) * step;
+    const north = Math.floor(b.getNorth() / step) * step;
+    const west = Math.ceil(b.getWest() / step) * step;
+    const east = Math.floor(b.getEast() / step) * step;
+    const points: { lat: number; lon: number }[] = [];
+    for (let lat = south; lat <= north + 1e-9; lat += step) {
+      for (let lon = west; lon <= east + 1e-9; lon += step) {
+        points.push({ lat, lon });
+      }
+    }
+    return points;
+  }
+
+  private async _fetchPoint(lat: number, lon: number): Promise<Sample | null> {
+    const half = ICON_GRID_DEG / 4;
+    const params = new URLSearchParams({
+      service: 'WMS',
+      version: '1.3.0',
+      request: 'GetFeatureInfo',
+      layers: WMS_LAYER,
+      query_layers: WMS_LAYER,
+      styles: '',
+      crs: 'EPSG:4326',
+      // WMS 1.3.0 with EPSG:4326 expects lat,lon order
+      bbox: `${lat - half},${lon - half},${lat + half},${lon + half}`,
+      width: '2',
+      height: '2',
+      i: '1',
+      j: '1',
+      info_format: 'application/json',
+    });
+    if (this._timeIso) params.set('TIME', this._timeIso);
+    try {
+      const res = await fetch(`${WMS_URL}?${params}`);
+      if (!res.ok) return null;
+      const data = await res.json();
+      const props = data?.features?.[0]?.properties;
+      if (!props || typeof props.u !== 'number' || typeof props.v !== 'number') return null;
+      return { lat, lon, u: props.u, v: props.v };
+    } catch {
+      return null;
+    }
+  }
+}
+
+function arrowIcon(u: number, v: number, speed: number, size: number): L.DivIcon | null {
+  if (speed < 0.3) return null; // suppress calm cells for arrows
+  const angleDeg = (Math.atan2(u, v) * 180) / Math.PI;
+  const colour = speedColour(speed);
+  const stroke = Math.max(1.1, size / 12);
+  const html = `<svg width="${size}" height="${size}" viewBox="0 0 24 24" style="transform:rotate(${angleDeg}deg);overflow:visible">
+    <path d="M12 3 L12 19 M7 8 L12 3 L17 8" fill="none" stroke="${colour}" stroke-width="${stroke}" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`;
+  return L.divIcon({
+    html,
+    className: 'wrc-wind-arrow',
+    iconSize: [size, size] as L.PointExpression,
+    iconAnchor: [size / 2, size / 2] as L.PointExpression,
+  });
+}
+
+function barbIcon(u: number, v: number, speedMps: number, size: number): L.DivIcon {
+  const knots = speedMps * 1.943844;
+  const colour = speedColour(speedMps);
+  const stroke = Math.max(1, size / 16);
+
+  // Calm: open circle.
+  if (knots < 2.5) {
+    const r = Math.max(2.5, size * 0.18);
+    const html = `<svg width="${size}" height="${size}" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="${r}" fill="none" stroke="${colour}" stroke-width="${stroke}"/>
+    </svg>`;
+    return L.divIcon({
+      html, className: 'wrc-wind-barb',
+      iconSize: [size, size] as L.PointExpression,
+      iconAnchor: [size / 2, size / 2] as L.PointExpression,
+    });
+  }
+
+  // Wind FROM direction: opposite of "to" direction (atan2(u, v) is "to").
+  const angleDeg = (Math.atan2(u, v) * 180) / Math.PI + 180;
+
+  const k5 = Math.round(knots / 5) * 5;
+  let remaining = k5;
+  const pennants = Math.floor(remaining / 50); remaining -= pennants * 50;
+  const fullFeathers = Math.floor(remaining / 10); remaining -= fullFeathers * 10;
+  const halfFeather = remaining >= 5 ? 1 : 0;
+
+  // Staff: from origin (12,12) up to (12,2). Feathers attach starting at the tip
+  // and walk down the staff. Northern Hemisphere convention puts feathers on the
+  // CCW side of the staff when viewed downwind — for an upward staff that's the
+  // right side in screen coords (positive x).
+  const tipY = 2;
+  const staffStartY = 12;
+  const featherStep = 2.2; // y-distance between successive glyphs along the staff
+  const featherLenFull = 6;
+  const pennantH = 2.4; // pennant base width along the staff
+  const segments: string[] = [`M12 ${staffStartY} L12 ${tipY}`];
+  let y = tipY;
+  // Pennants first (closest to tip).
+  for (let i = 0; i < pennants; i++) {
+    segments.push(`M12 ${y} L${12 + featherLenFull} ${y + pennantH / 2} L12 ${y + pennantH} Z`);
+    y += pennantH + 0.6;
+  }
+  // Full feathers.
+  for (let i = 0; i < fullFeathers; i++) {
+    segments.push(`M12 ${y} L${12 + featherLenFull} ${y - featherStep * 0.6}`);
+    y += featherStep;
+  }
+  // Half feather.
+  if (halfFeather) {
+    // If the bare staff has no other feathers yet, push the half feather one step in
+    // so it doesn't sit at the very tip (standard convention).
+    if (pennants === 0 && fullFeathers === 0) y += featherStep;
+    segments.push(`M12 ${y} L${12 + featherLenFull / 2} ${y - featherStep * 0.4}`);
+  }
+
+  const html = `<svg width="${size}" height="${size}" viewBox="0 0 24 24" style="transform:rotate(${angleDeg}deg);overflow:visible">
+    <path d="${segments.join(' ')}" fill="${colour}" stroke="${colour}" stroke-width="${stroke}" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`;
+  return L.divIcon({
+    html, className: 'wrc-wind-barb',
+    iconSize: [size, size] as L.PointExpression,
+    iconAnchor: [size / 2, size / 2] as L.PointExpression,
+  });
+}
+
+function speedColour(mps: number): string {
+  // Beaufort-ish bands: calm/light/moderate/fresh/strong/gale.
+  if (mps < 1.5) return '#88a';
+  if (mps < 3.5) return '#3a7';
+  if (mps < 5.5) return '#1a8';
+  if (mps < 8) return '#d80';
+  if (mps < 11) return '#c40';
+  return '#a00';
+}

--- a/tests/wind-helpers.test.ts
+++ b/tests/wind-helpers.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Same Leaflet stub as tests/nearest-frame-index.test.ts: the helpers under
+// test are pure, but their host modules import leaflet eagerly.
+vi.mock('leaflet', () => {
+  class Layer {}
+  class LayerGroup {}
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as any).WMS = WMS;
+  const DomUtil = { create: vi.fn() };
+  const point = vi.fn((x: number, y: number) => ({ x, y }));
+  const divIcon = vi.fn((opts: any) => ({ ...opts }));
+  return {
+    Layer, LayerGroup, TileLayer, DomUtil, point, divIcon,
+    default: { Layer, LayerGroup, TileLayer, DomUtil, point, divIcon },
+  };
+});
+
+import { speedColour, decomposeBarbKnots } from '../src/wind-overlay';
+import { bilinearUV } from '../src/wind-flow-overlay';
+
+// ── speedColour ────────────────────────────────────────────────────────────
+//
+// 6 Beaufort-ish bands. The exact hex strings matter — the visual contract
+// on the editor is "colour-coded by speed". Locking the boundaries here
+// prevents an off-by-one regression where e.g. 8 m/s drifts from "fresh"
+// to "moderate".
+
+describe('speedColour', () => {
+  it('returns calm grey-blue below 1.5 m/s', () => {
+    expect(speedColour(0)).toBe('#88a');
+    expect(speedColour(1.49)).toBe('#88a');
+  });
+
+  it('returns light green at 1.5–3.5 m/s', () => {
+    expect(speedColour(1.5)).toBe('#3a7');
+    expect(speedColour(2)).toBe('#3a7');
+    expect(speedColour(3.49)).toBe('#3a7');
+  });
+
+  it('returns moderate teal at 3.5–5.5 m/s', () => {
+    expect(speedColour(3.5)).toBe('#1a8');
+    expect(speedColour(5.49)).toBe('#1a8');
+  });
+
+  it('returns fresh orange at 5.5–8 m/s', () => {
+    expect(speedColour(5.5)).toBe('#d80');
+    expect(speedColour(7.99)).toBe('#d80');
+  });
+
+  it('returns strong red-orange at 8–11 m/s', () => {
+    expect(speedColour(8)).toBe('#c40');
+    expect(speedColour(10.99)).toBe('#c40');
+  });
+
+  it('returns gale red at and above 11 m/s', () => {
+    expect(speedColour(11)).toBe('#a00');
+    expect(speedColour(40)).toBe('#a00');
+  });
+
+  it('handles zero and tiny values without throwing', () => {
+    expect(speedColour(0)).toBe('#88a');
+    expect(speedColour(0.0001)).toBe('#88a');
+  });
+});
+
+// ── decomposeBarbKnots ─────────────────────────────────────────────────────
+//
+// WMO meteorological wind-barb convention: pennant = 50 kt, full feather =
+// 10 kt, half feather = 5 kt. Speed is rounded to the nearest 5 kt before
+// decomposing, so 7-knot input renders as 5 (one half), 8-knot as 10 (one
+// full feather), and so on. These cases lock the rounding and the
+// decomposition order — the latter is easy to typo into "half before full".
+
+describe('decomposeBarbKnots', () => {
+  it('rounds to the nearest 5 kt before decomposing', () => {
+    expect(decomposeBarbKnots(7).k5).toBe(5);   // 7 → 5
+    expect(decomposeBarbKnots(8).k5).toBe(10);  // 8 → 10
+    expect(decomposeBarbKnots(12).k5).toBe(10); // 12 → 10
+    expect(decomposeBarbKnots(13).k5).toBe(15); // 13 → 15
+    expect(decomposeBarbKnots(0).k5).toBe(0);
+  });
+
+  it('represents 5 kt as one half feather, no full, no pennant', () => {
+    expect(decomposeBarbKnots(5)).toEqual({
+      k5: 5, pennants: 0, fullFeathers: 0, halfFeather: 1,
+    });
+  });
+
+  it('represents 10 kt as one full feather, no half, no pennant', () => {
+    expect(decomposeBarbKnots(10)).toEqual({
+      k5: 10, pennants: 0, fullFeathers: 1, halfFeather: 0,
+    });
+  });
+
+  it('represents 15 kt as one full + one half', () => {
+    expect(decomposeBarbKnots(15)).toEqual({
+      k5: 15, pennants: 0, fullFeathers: 1, halfFeather: 1,
+    });
+  });
+
+  it('represents 50 kt as exactly one pennant, no feathers', () => {
+    expect(decomposeBarbKnots(50)).toEqual({
+      k5: 50, pennants: 1, fullFeathers: 0, halfFeather: 0,
+    });
+  });
+
+  it('represents 55 kt as one pennant + one half feather', () => {
+    expect(decomposeBarbKnots(55)).toEqual({
+      k5: 55, pennants: 1, fullFeathers: 0, halfFeather: 1,
+    });
+  });
+
+  it('represents 65 kt as one pennant + one full + one half', () => {
+    expect(decomposeBarbKnots(65)).toEqual({
+      k5: 65, pennants: 1, fullFeathers: 1, halfFeather: 1,
+    });
+  });
+
+  it('represents 100 kt as two pennants, no feathers', () => {
+    expect(decomposeBarbKnots(100)).toEqual({
+      k5: 100, pennants: 2, fullFeathers: 0, halfFeather: 0,
+    });
+  });
+
+  it('decomposes in pennant → full → half order', () => {
+    // 105 = 50 + 50 + 5. NOT 50 + 10·5 + 5, NOT 10·10 + 5.
+    expect(decomposeBarbKnots(105)).toEqual({
+      k5: 105, pennants: 2, fullFeathers: 0, halfFeather: 1,
+    });
+    // 145 = 50 + 50 + 10·4 + 5.
+    expect(decomposeBarbKnots(145)).toEqual({
+      k5: 145, pennants: 2, fullFeathers: 4, halfFeather: 1,
+    });
+  });
+});
+
+// ── bilinearUV ─────────────────────────────────────────────────────────────
+//
+// Pure bilinear interpolation of a regular lat/lon U/V grid. Out-of-grid
+// samples and empty grids must return (0,0) so the streamline loop draws
+// nothing rather than crashing.
+
+describe('bilinearUV', () => {
+  // Tiny 2×2 grid covering lat ∈ [50, 51], lon ∈ [10, 11], step 1°.
+  // Layout: grid[row][col] where row 0 is latMin, col 0 is lonMin.
+  //
+  //     lon=10   lon=11
+  // lat=50  (10,0)  (20,0)
+  // lat=51  (10,5)  (20,5)
+  const grid2x2: ReadonlyArray<ReadonlyArray<{ u: number; v: number }>> = [
+    [{ u: 10, v: 0 }, { u: 20, v: 0 }],
+    [{ u: 10, v: 5 }, { u: 20, v: 5 }],
+  ];
+
+  it('returns (0, 0) on an empty grid', () => {
+    expect(bilinearUV([], 0, 0, 1, 0, 0, 50.5, 10.5)).toEqual({ u: 0, v: 0 });
+  });
+
+  it('returns (0, 0) for samples outside the grid bbox', () => {
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 49.5, 10.5)).toEqual({ u: 0, v: 0 }); // south
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 52, 10.5)).toEqual({ u: 0, v: 0 });   // north
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 50.5, 9)).toEqual({ u: 0, v: 0 });    // west
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 50.5, 12)).toEqual({ u: 0, v: 0 });   // east
+  });
+
+  it('returns the corner value when sampled exactly on a grid node', () => {
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 50, 10)).toEqual({ u: 10, v: 0 });
+    // Top-right (lat=51, lon=11) is *outside* the [r0+1<rows] guard since
+    // r0 = 1 makes r0+1 = 2 which equals rows. (0,0) is correct.
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 51, 11)).toEqual({ u: 0, v: 0 });
+  });
+
+  it('linearly interpolates along the lon axis at a grid-row latitude', () => {
+    // At lat=50, half-way between lon=10 and lon=11: u should be (10+20)/2 = 15.
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 50, 10.5)).toEqual({ u: 15, v: 0 });
+  });
+
+  it('linearly interpolates along the lat axis at a grid-col longitude', () => {
+    // At lon=10, half-way between lat=50 and lat=51: v should be (0+5)/2 = 2.5.
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 50.5, 10)).toEqual({ u: 10, v: 2.5 });
+  });
+
+  it('bilinear-blends along both axes simultaneously', () => {
+    // Centre of the cell — equal weights on all four corners.
+    // u = (10 + 20 + 10 + 20) / 4 = 15; v = (0 + 0 + 5 + 5) / 4 = 2.5.
+    expect(bilinearUV(grid2x2, 50, 10, 1, 2, 2, 50.5, 10.5)).toEqual({ u: 15, v: 2.5 });
+  });
+
+  it('respects an off-zero grid origin and a non-1 step', () => {
+    // Grid covers lat ∈ [40, 40.5], lon ∈ [-5, -4.5], step 0.5.
+    const grid: ReadonlyArray<ReadonlyArray<{ u: number; v: number }>> = [
+      [{ u: 1, v: 1 }, { u: 3, v: 1 }],
+      [{ u: 1, v: 9 }, { u: 3, v: 9 }],
+    ];
+    // Centre of the cell.
+    const got = bilinearUV(grid, 40, -5, 0.5, 2, 2, 40.25, -4.75);
+    expect(got.u).toBeCloseTo(2, 6);
+    expect(got.v).toBeCloseTo(5, 6);
+  });
+});


### PR DESCRIPTION
Three wind overlay styles for the DWD source: meteorological barbs, downwind arrows, and animated streamlines. All client-rendered from `Icon_reg025_fd_sl_UV10M` (10m wind from ICON-D2), sampled point by point on a zoom-adaptive sparse grid. Stacks with the radar.

<img width="982" height="988" alt="Screen Recording 2026-05-06 at 11 45 44" src="https://github.com/user-attachments/assets/fe7d7c25-045d-4b2f-a5d3-bc7887f29b4f" />

<img width="1007" height="581" alt="Screenshot 2026-05-06 at 11 33 38" src="https://github.com/user-attachments/assets/6ed90c4c-af20-41de-9cf0-1d5657757b1b" />

In the editor it lives as a Wind Overlay subpage under MARKERS AND OVERLAYS, with separate Density (how many arrows) and Size (how big each one is) sliders.

Sorry about the stack — this is based on #130, #131, and #132. Once those merge the diff here drops to the wind code.