### PR TITLE
feat(time-range): add "Off (static frame)" option — 3.6.0-alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0-alpha2] - 2026-05-06
+
+> Small follow-up to alpha1: a "no animation" option for users who want a static current-frame view. The animation was always on prior to 3.6 because `getEffectiveTimeRange` floored the frame count at 2 — `past_minutes: 0` silently became a 2-frame loop. Now `0` means 1 frame.
+
+### Added
+
+- **History Duration "Off (static frame, no animation)"** option in the editor's preset dropdown. Selecting it sets `past_minutes: 0`, the player loads exactly one frame and stays on it (no animation loop). The periodic 5-minute refresh still updates the single frame so it doesn't go stale. Helper text under the dropdown switches to "Static frame — no animation, refreshes every 5 min" to confirm the mode.
+
+### Fixed
+
+- **`getEffectiveTimeRange` floor lowered from 2 to 1**, so `past_minutes: 0` actually produces 1 frame instead of being silently rounded up to 2 (which previously made the static-frame mode unreachable from YAML or the editor).
+
+### Tests
+
+314 → **316**. Two new cases pin the new floor behaviour: single-frame for past=0 + no forecast, multi-frame still produced when past=0 + forecast > 0 on DWD.
+
+### Localization
+
+11 languages updated for the two new editor strings (`past_off`, `helper_static`). Coverage parity verified at 100%.
+
 ## [3.6.0-alpha1] - 2026-05-06
 
 > First alpha cut of the 3.6 line. New feature: a lightning overlay sourced from the Blitzortung HA integration. No external HTTP from the card — the integration handles all the data plumbing; we just render.
@@ -362,7 +382,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-alpha1...HEAD
+[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-alpha2...HEAD
+[3.6.0-alpha2]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-alpha1...v3.6.0-alpha2
 [3.6.0-alpha1]: https://github.com/Makin-Things/weather-radar-card/compare/v3.5.0...v3.6.0-alpha1
 [3.5.0]: https://github.com/Makin-Things/weather-radar-card/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/Makin-Things/weather-radar-card/compare/v3.3.0...v3.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-alpha1",
+  "version": "3.6.0-alpha2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.6.0-alpha1",
+      "version": "3.6.0-alpha2",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-alpha1",
+  "version": "3.6.0-alpha2",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.0-alpha1';
+export const CARD_VERSION = '3.6.0-alpha2';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -905,15 +905,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
 
     // Helper text: "≈ N frames at X-min intervals", flagged when a
     // YAML-only stride override is in effect so the user knows the
-    // editor isn't the source of truth for that knob.
+    // editor isn't the source of truth for that knob. Single-frame
+    // case (past_minutes=0 + no forecast) gets a distinct line — the
+    // generic helper would read "≈ 1 frames at 5-min intervals" which
+    // is both grammatically wrong and misleading.
     const isStrideOverride = range.strideMin !== caps.intervalMin;
-    const helper = isStrideOverride
-      ? localize('editor.time_range.helper_stride')
-        .replace('{n}', String(range.frameCount))
-        .replace('{stride}', String(range.strideMin))
-      : localize('editor.time_range.helper')
-        .replace('{n}', String(range.frameCount))
-        .replace('{interval}', String(caps.intervalMin));
+    const helper = range.frameCount === 1
+      ? localize('editor.time_range.helper_static')
+      : isStrideOverride
+        ? localize('editor.time_range.helper_stride')
+          .replace('{n}', String(range.frameCount))
+          .replace('{stride}', String(range.strideMin))
+        : localize('editor.time_range.helper')
+          .replace('{n}', String(range.frameCount))
+          .replace('{interval}', String(caps.intervalMin));
 
     return html`
       <div class="side-by-side">
@@ -941,15 +946,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
   }
 
   // Builds the past-time dropdown options from PAST_PRESETS_MIN,
-  // filtered to ≤ editor cap. If the configured raw value isn't
-  // in the preset list (either > cap or just an off-grid YAML value),
-  // appends it as a "(YAML)" entry at the bottom so the user sees their
-  // actual current value rather than a wrong display.
+  // filtered to ≤ editor cap. Prepends a 0 / Off entry for users who
+  // want a static current frame with no animation loop. If the
+  // configured raw value isn't in the preset list (either > cap or
+  // just an off-grid YAML value), appends it as a "(YAML)" entry at
+  // the bottom so the user sees their actual current value rather
+  // than a wrong display.
   private _buildPastOptions(rawValue: number | undefined, editorCap: number): { value: string; label: string }[] {
-    const opts = PAST_PRESETS_MIN
+    const opts: { value: string; label: string }[] = [
+      { value: '0', label: localize('editor.time_range.past_off') },
+    ];
+    opts.push(...PAST_PRESETS_MIN
       .filter(m => m <= editorCap)
-      .map(m => ({ value: String(m), label: formatDuration(m) }));
-    if (rawValue !== undefined && !PAST_PRESETS_MIN.includes(rawValue)) {
+      .map(m => ({ value: String(m), label: formatDuration(m) })));
+    if (rawValue !== undefined && rawValue !== 0 && !PAST_PRESETS_MIN.includes(rawValue)) {
       opts.push({
         value: String(rawValue),
         label: `${formatDuration(rawValue)} ${localize('editor.time_range.yaml_suffix')}`,

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -95,7 +95,9 @@
       "forecast_off": "Aus",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} Bilder, alle {interval} Min.",
-      "helper_stride": "≈ {n} Bilder, alle {stride} Min. (YAML-Schrittweite)"
+      "helper_stride": "≈ {n} Bilder, alle {stride} Min. (YAML-Schrittweite)",
+      "past_off": "Aus (statisches Bild, keine Animation)",
+      "helper_static": "Statisches Bild — keine Animation, Aktualisierung alle 5 Min"
     },
     "location": {
       "centre_latitude": "Breitengrad des Mittelpunkts",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -95,7 +95,9 @@
       "forecast_off": "Off",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} frames at {interval}-min intervals",
-      "helper_stride": "≈ {n} frames at 1-frame-per-{stride}-min (YAML stride)"
+      "helper_stride": "≈ {n} frames at 1-frame-per-{stride}-min (YAML stride)",
+      "past_off": "Off (static frame, no animation)",
+      "helper_static": "Static frame — no animation, refreshes every 5 min"
     },
     "location": {
       "centre_latitude": "Centre Latitude",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -95,7 +95,9 @@
       "forecast_off": "Desactivado",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} fotogramas en intervalos de {interval} min",
-      "helper_stride": "≈ {n} fotogramas a 1 por {stride} min (paso YAML)"
+      "helper_stride": "≈ {n} fotogramas a 1 por {stride} min (paso YAML)",
+      "past_off": "Apagado (cuadro estático, sin animación)",
+      "helper_static": "Cuadro estático — sin animación, se actualiza cada 5 min"
     },
     "location": {
       "centre_latitude": "Latitud del centro",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -95,7 +95,9 @@
       "forecast_off": "Désactivé",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} images à intervalles de {interval} min",
-      "helper_stride": "≈ {n} images à 1 par {stride} min (pas YAML)"
+      "helper_stride": "≈ {n} images à 1 par {stride} min (pas YAML)",
+      "past_off": "Désactivé (image fixe, sans animation)",
+      "helper_static": "Image fixe — pas d'animation, actualisée toutes les 5 min"
     },
     "location": {
       "centre_latitude": "Latitude du centre",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -95,7 +95,9 @@
       "forecast_off": "Disattivato",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} fotogrammi a intervalli di {interval} min",
-      "helper_stride": "≈ {n} fotogrammi, 1 ogni {stride} min (passo YAML)"
+      "helper_stride": "≈ {n} fotogrammi, 1 ogni {stride} min (passo YAML)",
+      "past_off": "Disattivato (fotogramma statico, nessuna animazione)",
+      "helper_static": "Fotogramma statico — nessuna animazione, aggiornato ogni 5 min"
     },
     "location": {
       "centre_latitude": "Latitudine del centro",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -95,7 +95,9 @@
       "forecast_off": "Av",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} bilder med {interval}-min mellomrom",
-      "helper_stride": "≈ {n} bilder, 1 per {stride} min (YAML-steg)"
+      "helper_stride": "≈ {n} bilder, 1 per {stride} min (YAML-steg)",
+      "past_off": "Av (statisk bilde, ingen animasjon)",
+      "helper_static": "Statisk bilde — ingen animasjon, oppdateres hvert 5. min"
     },
     "location": {
       "centre_latitude": "Sentrumsbreddegrad",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -95,7 +95,9 @@
       "forecast_off": "Uit",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} frames met {interval}-min interval",
-      "helper_stride": "≈ {n} frames, 1 per {stride} min (YAML-stap)"
+      "helper_stride": "≈ {n} frames, 1 per {stride} min (YAML-stap)",
+      "past_off": "Uit (statisch beeld, geen animatie)",
+      "helper_static": "Statisch beeld — geen animatie, vernieuwt elke 5 min"
     },
     "location": {
       "centre_latitude": "Middenbreedtegraad",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -95,7 +95,9 @@
       "forecast_off": "Wyłącz",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} klatek co {interval} min",
-      "helper_stride": "≈ {n} klatek, 1 na {stride} min (krok YAML)"
+      "helper_stride": "≈ {n} klatek, 1 na {stride} min (krok YAML)",
+      "past_off": "Wył. (statyczna klatka, bez animacji)",
+      "helper_static": "Statyczna klatka — bez animacji, odświeżana co 5 min"
     },
     "location": {
       "centre_latitude": "Szerokość geograficzna środka",

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -95,7 +95,9 @@
       "forecast_off": "Desligado",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} quadros em intervalos de {interval} min",
-      "helper_stride": "≈ {n} quadros a 1 por {stride} min (passo YAML)"
+      "helper_stride": "≈ {n} quadros a 1 por {stride} min (passo YAML)",
+      "past_off": "Desligado (quadro estático, sem animação)",
+      "helper_static": "Quadro estático — sem animação, atualiza a cada 5 min"
     },
     "location": {
       "centre_latitude": "Latitude do centro",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -95,7 +95,9 @@
       "forecast_off": "Vypnuté",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} snímok v intervaloch {interval} min",
-      "helper_stride": "≈ {n} snímok, 1 za {stride} min (krok YAML)"
+      "helper_stride": "≈ {n} snímok, 1 za {stride} min (krok YAML)",
+      "past_off": "Vyp. (statický snímok, bez animácie)",
+      "helper_static": "Statický snímok — bez animácie, obnovuje sa každých 5 min"
     },
     "location": {
       "centre_latitude": "Zemepisná šírka stredu",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -95,7 +95,9 @@
       "forecast_off": "Av",
       "yaml_suffix": "(YAML)",
       "helper": "≈ {n} bilder med {interval}-min intervall",
-      "helper_stride": "≈ {n} bilder, 1 per {stride} min (YAML-steg)"
+      "helper_stride": "≈ {n} bilder, 1 per {stride} min (YAML-steg)",
+      "past_off": "Av (statisk bild, ingen animation)",
+      "helper_static": "Statisk bild — ingen animation, uppdateras var 5:e min"
     },
     "location": {
       "centre_latitude": "Centrums latitud",

--- a/src/source-caps.ts
+++ b/src/source-caps.ts
@@ -110,8 +110,14 @@ export function getEffectiveTimeRange(cfg: WeatherRadarCardConfig): EffectiveTim
     strideMin = Math.max(1, k) * caps.intervalMin;
   }
 
+  // frameCount = (history span / stride) + 1, floored at 1 — past_minutes=0
+  // (and forecast_minutes=0) gives a single static frame, which the player
+  // shows without ever entering the animation loop (_scheduleNext returns
+  // early when loaded slots < 2). The periodic 5-min refresh still updates
+  // the single frame so it doesn't go stale. Pre-3.6.0 the floor was 2,
+  // which silently turned a "no animation" config into a 2-frame loop.
   const totalMin = pastMin + forecastMin;
-  const frameCount = Math.max(2, Math.floor(totalMin / strideMin) + 1);
+  const frameCount = Math.max(1, Math.floor(totalMin / strideMin) + 1);
 
   return { pastMin, forecastMin, strideMin, frameCount };
 }

--- a/tests/source-caps.test.ts
+++ b/tests/source-caps.test.ts
@@ -97,9 +97,23 @@ describe('getEffectiveTimeRange', () => {
     expect(r.strideMin).toBe(10);
   });
 
-  it('always returns at least 2 frames so the animation loop has something to switch between', () => {
+  it('past_minutes=0 with no forecast returns a single static frame (3.6+ — was floored at 2 pre-3.6)', () => {
     const r = getEffectiveTimeRange({ ...base, data_source: 'RainViewer', past_minutes: 0 });
-    expect(r.frameCount).toBe(2);
+    expect(r.frameCount).toBe(1);
+  });
+
+  it('past_minutes=0 with forecast on DWD still produces a multi-frame loop (the forecast frames give it something to animate)', () => {
+    const r = getEffectiveTimeRange({
+      ...base, data_source: 'DWD', past_minutes: 0, forecast_minutes: 60,
+    });
+    expect(r.frameCount).toBe(13); // 60/5 + 1
+  });
+
+  it('frameCount floor is 1, not 0 — defensive against zero / negative span configurations', () => {
+    // Hypothetical: stride way bigger than total span. Math.floor(0/strideMin) + 1 = 1 anyway,
+    // but pin it so a future regression that drops the floor too low (e.g. to 0) is caught.
+    const r = getEffectiveTimeRange({ ...base, data_source: 'RainViewer', past_minutes: 0, forecast_minutes: 0 });
+    expect(r.frameCount).toBeGreaterThanOrEqual(1);
   });
 
   it('handles forecast-only ranges (past=0, forecast=120 on DWD)', () => {


### PR DESCRIPTION
Small follow-up to alpha1: a "no animation" option for users who want a static current-frame view.

The pre-3.6 floor of `frameCount = max(2, ...)` in `getEffectiveTimeRange` silently turned `past_minutes: 0` into a 2-frame loop. `static_map` only disables map navigation (no scroll/zoom/drag), not the radar animation — so there was no way to ship a non-animated radar at all.

## Changes

- **`getEffectiveTimeRange` floor lowered from 2 to 1.** With `past_minutes: 0` and no forecast, the player loads a single frame. Player's existing `_scheduleNext` early-returns on `n < 2` so no animation loop starts. The 5-min refresh (`_scheduleUpdate` / `_updateRadar`) still ticks so the static frame doesn't go stale.
- **Editor: "Off (static frame, no animation)" entry** prepended to the History Duration dropdown. Mirrors the pattern `_buildForecastOptions` already uses for forecast.
- **Helper text** below the dropdown switches to "Static frame — no animation, refreshes every 5 min" when `frameCount === 1`.
- **i18n: 11 languages** updated for `past_off` + `helper_static`. 100% parity.
- **Tests: 314 → 316.** Pre-3.6 "always returns at least 2 frames" test replaced with pins for the new behaviour.

## Test plan

- [x] Lint clean
- [x] 316/316 tests pass
- [x] Build succeeds; `3.6.0-alpha2` baked into the bundle
- [x] Manual smoke confirmed by user — `past_minutes: 0` produces a static frame, no loop, refreshes every 5 min