### PR TITLE
fix(dwd): coverage-overlay (supersedes #132) + classifier tests

### DIFF
--- a/src/fetch-tile-layer.ts
+++ b/src/fetch-tile-layer.ts
@@ -12,6 +12,44 @@ export interface FetchTileOptions extends L.TileLayerOptions {
   on429?: () => void;
   /** When true, Leaflet's _updateOpacity is suppressed so CSS animations own opacity. */
   animationOwnsOpacity?: boolean;
+  /**
+   * Optional pixel-level rewrite applied to each fetched tile before it
+   * is assigned to the <img>. The function mutates the RGBA byte array
+   * in place. Use to drop server-rendered pixels that shouldn't be in
+   * the animation stack — e.g. the grey "no-data" mask + magenta
+   * coverage outline that DWD's WMS bakes into every tile, which would
+   * otherwise pulse during a crossfade because two stacked layers
+   * compound the dim.
+   */
+  pixelFilter?: (data: Uint8ClampedArray) => void;
+}
+
+// Decode `blob` to a canvas, run `filter` over its RGBA bytes in place,
+// re-encode back to a PNG blob. Returns a fresh blob; the caller owns
+// it. Falls back to the original blob on any failure (a tile is more
+// useful than no tile, even if the mask leaks through).
+async function applyPixelFilter(
+  blob: Blob,
+  filter: (data: Uint8ClampedArray) => void,
+): Promise<Blob> {
+  try {
+    const bitmap = await createImageBitmap(blob);
+    const canvas = document.createElement('canvas');
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) { bitmap.close?.(); return blob; }
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close?.();
+    const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    filter(imgData.data);
+    ctx.putImageData(imgData, 0, 0);
+    return await new Promise<Blob>((resolve) => {
+      canvas.toBlob((b) => resolve(b ?? blob), 'image/png');
+    });
+  } catch {
+    return blob;
+  }
 }
 
 // Augment Leaflet's Coords type (it's missing `z` in some @types versions)
@@ -58,6 +96,10 @@ function createFetchTile(
         if (r.status === 429) { const e: any = new Error('429'); e.status = 429; throw e; }
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.blob();
+      })
+      .then((blob) => {
+        const filter = (layer.options as FetchTileOptions).pixelFilter;
+        return filter ? applyPixelFilter(blob, filter) : blob;
       })
       .then((blob) => {
         const objUrl = URL.createObjectURL(blob);
@@ -151,13 +193,14 @@ export class FetchWmsTileLayer extends L.TileLayer.WMS {
     // Leaflet's L.TileLayer.WMS appends ANY option that isn't a recognised
     // Leaflet/WMS field to the GetMap URL as a query parameter — that
     // would leak our internal options (rateLimiter, on429,
-    // animationOwnsOpacity) into the request, producing URL fragments
-    // like `&rateLimiter=[object%20Object]`. Split them off, hand only
-    // the WMS-relevant subset to the parent initialize, then put ours
-    // back onto this.options so createTile / _updateOpacity can read them.
-    const { rateLimiter, on429, animationOwnsOpacity, ...wmsOptions } = options;
+    // animationOwnsOpacity, pixelFilter) into the request, producing URL
+    // fragments like `&rateLimiter=[object%20Object]`. Split them off,
+    // hand only the WMS-relevant subset to the parent initialize, then
+    // put ours back onto this.options so createTile / _updateOpacity can
+    // read them.
+    const { rateLimiter, on429, animationOwnsOpacity, pixelFilter, ...wmsOptions } = options;
     (L.TileLayer.WMS.prototype as any).initialize.call(this, url, wmsOptions);
-    Object.assign(this.options, { rateLimiter, on429, animationOwnsOpacity });
+    Object.assign(this.options, { rateLimiter, on429, animationOwnsOpacity, pixelFilter });
   }
 
   createTile(coords: L.Coords, done: L.DoneCallback): HTMLElement {

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -39,29 +39,17 @@ const DWD_WMS_LAYER_DEFAULT = 'Niederschlagsradar';
 // Frames usually appear 1–3 min after their timestamp; 5 min is safely past the lag.
 const DWD_LAG_MS = 5 * 60 * 1000;
 
-// DWD's WMS tiles bake a "no-data" mask into every frame: a faint grey
-// wash (rgba 126,126,126,77) for areas outside coverage, plus a magenta
-// boundary outline (rgb 255,0,255 at varying α) where the underlying
-// raster ends. Two stacked tile layers during a crossfade compound the
-// dim, producing a visible pulse. Stripping these at fetch time lifts
-// the mask out of the per-slot stack.
+// DWD's WMS tiles bake a "no-data" mask into every frame — grey wash
+// (rgba 126,126,126,77) outside coverage, magenta outline (G=0, B=255)
+// at the boundary. Two crossfading layers compound the dim into a
+// visible pulse, so we strip them at fetch time and re-render the
+// boundary as a separate, snap-switched overlay (`makeDwdMaskOnlyFilter`).
 //
-// The pixel filter is a *whitelist* in colour space: anything that
-// shaped like purple (G low, R and B both higher than G) gets dropped
-// unless it exactly matches a known palette entry. The DWD radar
-// colourmaps only have a handful of purple/magenta hues for heavy
-// rain, and they fall on specific (r, g, b) triples that no outline
-// blend will hit. Asymmetric outline blends like (188,38,204) and
-// symmetric ones like a hypothetical (112,35,112) are both caught by
-// the same rule; symmetry no longer matters.
-//
-// Known palette purples across the DWD radar layers:
-//   Niederschlagsradar/RV: (204,0,152) (102,0,203)
-//   WN-product/-analysis:  (153,0,153) (255,51,255)
-//
-// `layerName` selects which palette whitelist applies. Pure red/orange
-// palette entries (e.g. (255,32,32), (255,137,0)) are *not* purple-shape
-// because B ≤ G — they pass through untouched.
+// The hard part is telling outline-on-data antialiasing blends apart
+// from the palette purples DWD uses for very heavy rain. Both fall in
+// the same RGB neighbourhood, so we whitelist palette entries by exact
+// triple — the legend only has a handful and they're stable per layer.
+// Anything else with G low and R, B both bright is treated as outline.
 const WN_PALETTE_PURPLES = new Set<number>([
   (153 << 16) | (0 << 8) | 153,
   (255 << 16) | (51 << 8) | 255,
@@ -71,24 +59,28 @@ const RV_PALETTE_PURPLES = new Set<number>([
   (102 << 16) | (0 << 8) | 203,
 ]);
 
+function dwdPaletteFor(layerName: string): Set<number> {
+  return layerName.startsWith('Radar_wn-') ? WN_PALETTE_PURPLES : RV_PALETTE_PURPLES;
+}
+
 type DwdPixelKind = 'data' | 'grey' | 'outline';
 
-// Classify a single pixel into 'data' (real radar), 'grey' (no-data wash),
-// or 'outline' (coverage boundary). Used by both the data filter (which
-// drops mask) and the mask-only filter (which drops data, recoloured to
-// theme variables for the static coverage overlay).
+// Classify a single pixel. Shared by the data filter (drops everything
+// that isn't 'data') and the mask-only filter (drops 'data', recolours
+// the rest).
 function classifyDwdPixel(
   r: number, g: number, b: number, a: number,
   paletteKeys: Set<number>,
 ): DwdPixelKind {
   if (a < 255) {
-    // Antialiased mask edge — distinguish wash (R≈G≈B) from outline blend.
-    if (Math.abs(r - g) <= 15 && Math.abs(g - b) <= 15) return 'grey';
-    return 'outline';
+    // Semi-transparent ⇒ an antialiased mask edge. Wash edges keep
+    // R≈G≈B; magenta-blend edges don't.
+    return Math.abs(r - g) <= 15 && Math.abs(g - b) <= 15 ? 'grey' : 'outline';
   }
   if (r === g && g === b) return 'grey';
   if (g === 0 && b === 255) return 'outline';
-  // Purple-shape: G is smallest, R and B both bright enough to be a colour.
+  // Purple-shape: G is the smallest channel, R and B both bright. Any
+  // such pixel that's not a palette entry is an outline-on-data blend.
   if (g < 120 && r > 50 && b > 50 && r > g && b > g) {
     const key = (r << 16) | (g << 8) | b;
     if (!paletteKeys.has(key)) return 'outline';
@@ -97,9 +89,7 @@ function classifyDwdPixel(
 }
 
 function makeDwdMaskFilter(layerName: string): (data: Uint8ClampedArray) => void {
-  const palette = layerName.startsWith('Radar_wn-')
-    ? WN_PALETTE_PURPLES
-    : RV_PALETTE_PURPLES;
+  const palette = dwdPaletteFor(layerName);
   return (data) => {
     for (let i = 0; i < data.length; i += 4) {
       if (data[i + 3] === 0) continue;
@@ -110,28 +100,22 @@ function makeDwdMaskFilter(layerName: string): (data: Uint8ClampedArray) => void
   };
 }
 
-// Inverse of makeDwdMaskFilter — keeps the mask, drops the radar data,
-// recolours grey wash and outline pixels to theme-controlled values
-// (`dim` / `outline` are RGBA tuples 0..255). Original alpha is
-// multiplied by the themed alpha so antialiasing is preserved and the
-// theme controls overall strength.
+// Inverse of makeDwdMaskFilter: drop radar data, keep the mask, and
+// recolour to theme-controlled RGBA. Original alpha is multiplied by
+// the themed alpha so wash density and outline antialiasing both
+// respond proportionally.
 function makeDwdMaskOnlyFilter(
   layerName: string,
   dim: readonly [number, number, number, number],
   outline: readonly [number, number, number, number],
 ): (data: Uint8ClampedArray) => void {
-  const palette = layerName.startsWith('Radar_wn-')
-    ? WN_PALETTE_PURPLES
-    : RV_PALETTE_PURPLES;
+  const palette = dwdPaletteFor(layerName);
   return (data) => {
     for (let i = 0; i < data.length; i += 4) {
       const origA = data[i + 3];
       if (origA === 0) continue;
       const kind = classifyDwdPixel(data[i], data[i + 1], data[i + 2], origA, palette);
-      if (kind === 'data') {
-        data[i + 3] = 0;
-        continue;
-      }
+      if (kind === 'data') { data[i + 3] = 0; continue; }
       const c = kind === 'grey' ? dim : outline;
       data[i] = c[0];
       data[i + 1] = c[1];
@@ -141,9 +125,10 @@ function makeDwdMaskOnlyFilter(
   };
 }
 
-// Parse any CSS colour string ("rgba(0,0,0,0.3)", "#ff00ff", "magenta",
-// "transparent", …) into [r, g, b, a] bytes (0..255). Returns null if
-// the string can't be parsed.
+// Parse any CSS colour ("rgba(0,0,0,0.3)", "#ff00ff", "magenta",
+// "transparent", …) into [r, g, b, a] bytes via the canvas 2D context.
+// Returns null if the string didn't parse — assigning an invalid value
+// to fillStyle leaves the previous (sentinel) value unchanged.
 function parseCssColor(value: string): [number, number, number, number] | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -157,6 +142,13 @@ function parseCssColor(value: string): [number, number, number, number] | null {
   ctx.fillRect(0, 0, 1, 1);
   const d = ctx.getImageData(0, 0, 1, 1).data;
   return [d[0], d[1], d[2], d[3]];
+}
+
+// Leaflet's tile-layer container is the DOM element holding the
+// rendered tiles — this is where we apply opacity for the snap-switch.
+// Typed loosely because the public API doesn't expose `getContainer`.
+function layerEl(layer: { getContainer?: () => HTMLElement | null } | null | undefined): HTMLElement | null {
+  return layer?.getContainer?.() ?? null;
 }
 
 export interface RadarPlayerOptions {
@@ -185,13 +177,11 @@ export class RadarPlayer {
   private _dwdLimiter: RateLimiter;
   private _dwdSwapLogged = false;
 
-  // Per-frame coverage overlay (DWD only). Each entry is a FetchWmsTileLayer
-  // that fetches the same WMS layer at the matching frame's TIME, filtered
-  // through `makeDwdMaskOnlyFilter` so only the grey wash + outline survive
-  // (recoloured to theme variables). The layers sit on a dedicated pane
-  // above the radar tiles. Visibility is snap-switched per frame in
-  // `_showSlot` — no cross-fade — so two stacked masks during a transition
-  // can never compound the dim and reintroduce the pulse.
+  // Per-frame coverage overlay (DWD only). Parallel to _radarImage,
+  // each entry fetches the same WMS layer at the matching frame's TIME
+  // with makeDwdMaskOnlyFilter so only the wash + outline survive
+  // (recoloured to theme variables). _showSlot snap-switches visibility
+  // — never crossfades — so two stacked masks can't compound the dim.
   private _radarMask: (FetchWmsTileLayer | null)[] = [];
   private _dwdMaskPaneCreated = false;
   private _dwdDimRgba: [number, number, number, number] | null = null;
@@ -775,9 +765,9 @@ export class RadarPlayer {
     return name;
   }
 
-  // Lazily build the dedicated Leaflet pane the coverage overlay sits on.
-  // z-index 350 places it above the basemap + radar tiles (tilePane = 200)
-  // but below SVG overlays / markers (overlayPane = 400).
+  // Dedicated Leaflet pane for the coverage overlay. z-index 350 sits
+  // above the basemap + radar tiles (tilePane = 200) and below SVG
+  // overlays / markers (overlayPane = 400).
   private _ensureDwdMaskPane(): void {
     if (this._dwdMaskPaneCreated || !this._map) return;
     const pane = this._map.createPane('dwd-coverage-mask');
@@ -786,23 +776,24 @@ export class RadarPlayer {
     this._dwdMaskPaneCreated = true;
   }
 
-  // Read --dwd-coverage-dim-color / --dwd-coverage-outline-color off the
-  // card host. Cached per init so 48 frames don't each call getComputedStyle.
+  // Cache the theme colours per init so 48 frames don't each call
+  // getComputedStyle.
   private _refreshDwdMaskColors(): void {
-    const host = this._shadowRoot.host as HTMLElement;
-    const cs = getComputedStyle(host);
+    const cs = getComputedStyle(this._shadowRoot.host as HTMLElement);
     this._dwdDimRgba = parseCssColor(cs.getPropertyValue('--dwd-coverage-dim-color'))
       ?? [0, 0, 0, 255];
     this._dwdOutlineRgba = parseCssColor(cs.getPropertyValue('--dwd-coverage-outline-color'))
       ?? [255, 0, 255, 255];
   }
 
-  // Build a coverage overlay layer matching a specific radar frame. Returns
-  // null if the layer would have nothing to draw (both theme colours are
-  // fully transparent — explicit opt-out).
+  // Returns null if both theme colours are fully transparent — that's a
+  // valid opt-out from CSS, no need to make WMS requests for a layer
+  // that would render nothing.
   private _createDwdMaskLayer(frame: RadarFrame, layerName: string): FetchWmsTileLayer | null {
-    if (!this._dwdDimRgba || !this._dwdOutlineRgba) return null;
-    if (this._dwdDimRgba[3] === 0 && this._dwdOutlineRgba[3] === 0) return null;
+    const dim = this._dwdDimRgba;
+    const outline = this._dwdOutlineRgba;
+    if (!dim || !outline) return null;
+    if (dim[3] === 0 && outline[3] === 0) return null;
     this._ensureDwdMaskPane();
     const isoTime = new Date(frame.time * 1000).toISOString().split('.')[0] + 'Z';
     const { size: tileSize, zoomOffset } = this._radarTileSize();
@@ -819,30 +810,23 @@ export class RadarPlayer {
       on429: () => this._onRateLimited(),
       animationOwnsOpacity: true,
       pane: 'dwd-coverage-mask',
-      pixelFilter: makeDwdMaskOnlyFilter(layerName, this._dwdDimRgba, this._dwdOutlineRgba),
+      pixelFilter: makeDwdMaskOnlyFilter(layerName, dim, outline),
     } as any);
   }
 
-  // Tear down all per-frame mask layers (called from _clearLayers).
   private _clearDwdMaskLayers(): void {
-    for (const layer of this._radarMask) {
-      if (layer && (layer as any).remove) (layer as any).remove();
-    }
+    for (const layer of this._radarMask) layer?.remove();
     this._radarMask = [];
   }
 
-  // Snap-switch mask visibility — only the active slot's mask is visible.
-  // Called from _showSlot. No transition, so two stacked masks during a
-  // data crossfade can never compound the dim into a pulse.
+  // Show only the active slot's mask. No transition — two stacked masks
+  // during a data crossfade would compound the dim into a pulse.
   private _showDwdMaskForSlot(slot: number): void {
     for (let s = 0; s < this._loadedSlots.length; s++) {
-      const fi = this._loadedSlots[s];
-      const layer = this._radarMask[fi];
-      if (!layer) continue;
-      const el = (layer as any).getContainer?.() as HTMLElement | undefined;
+      const el = layerEl(this._radarMask[this._loadedSlots[s]]);
       if (!el) continue;
       el.style.transition = 'none';
-      el.style.opacity = (s === slot) ? '1' : '0';
+      el.style.opacity = s === slot ? '1' : '0';
     }
   }
 
@@ -1061,7 +1045,7 @@ export class RadarPlayer {
         if (maskLayer) {
           this._radarMask[fi] = maskLayer;
           maskLayer.addTo(this._map);
-          const maskEl = (maskLayer as any).getContainer?.() as HTMLElement | undefined;
+          const maskEl = layerEl(maskLayer);
           if (maskEl) maskEl.style.opacity = '0';
         }
       }
@@ -1079,10 +1063,9 @@ export class RadarPlayer {
           // Show newest frame as a static preview before the loop starts
           newestShown = true;
           if (el) el.style.opacity = this._activeOpacity;
-          // Surface the matching mask too, so the newest preview already has
-          // its in-sync coverage overlay before the animation loop begins.
-          const maskLayer = this._radarMask[fi];
-          const maskEl = maskLayer && (maskLayer as any).getContainer?.() as HTMLElement | undefined;
+          // Surface the matching mask too, so the preview already has
+          // its in-sync coverage overlay before the loop begins.
+          const maskEl = layerEl(this._radarMask[fi]);
           if (maskEl) maskEl.style.opacity = '1';
           this._setTimestamp(fi);
           this._highlightSegment(fi);
@@ -1151,13 +1134,13 @@ export class RadarPlayer {
       newMask = this._createDwdMaskLayer(latestFrame, this._dwdLayerName());
       if (newMask) {
         newMask.addTo(this._map);
-        const maskEl = (newMask as any).getContainer?.() as HTMLElement | undefined;
+        const maskEl = layerEl(newMask);
         if (maskEl) maskEl.style.opacity = '0';
       }
     }
 
     this._radarImage[0]?.remove();
-    if (this._radarMask[0]) (this._radarMask[0] as any).remove?.();
+    this._radarMask[0]?.remove();
     // _radarPaths shifts alongside the others because nearestFrameIndex() reads .time off it.
     for (let i = 0; i < frameCount - 1; i++) {
       this._radarImage[i] = this._radarImage[i + 1];

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -71,26 +71,92 @@ const RV_PALETTE_PURPLES = new Set<number>([
   (102 << 16) | (0 << 8) | 203,
 ]);
 
+type DwdPixelKind = 'data' | 'grey' | 'outline';
+
+// Classify a single pixel into 'data' (real radar), 'grey' (no-data wash),
+// or 'outline' (coverage boundary). Used by both the data filter (which
+// drops mask) and the mask-only filter (which drops data, recoloured to
+// theme variables for the static coverage overlay).
+function classifyDwdPixel(
+  r: number, g: number, b: number, a: number,
+  paletteKeys: Set<number>,
+): DwdPixelKind {
+  if (a < 255) {
+    // Antialiased mask edge — distinguish wash (R≈G≈B) from outline blend.
+    if (Math.abs(r - g) <= 15 && Math.abs(g - b) <= 15) return 'grey';
+    return 'outline';
+  }
+  if (r === g && g === b) return 'grey';
+  if (g === 0 && b === 255) return 'outline';
+  // Purple-shape: G is smallest, R and B both bright enough to be a colour.
+  if (g < 120 && r > 50 && b > 50 && r > g && b > g) {
+    const key = (r << 16) | (g << 8) | b;
+    if (!paletteKeys.has(key)) return 'outline';
+  }
+  return 'data';
+}
+
 function makeDwdMaskFilter(layerName: string): (data: Uint8ClampedArray) => void {
   const palette = layerName.startsWith('Radar_wn-')
     ? WN_PALETTE_PURPLES
     : RV_PALETTE_PURPLES;
   return (data) => {
     for (let i = 0; i < data.length; i += 4) {
-      const a = data[i + 3];
-      if (a === 0) continue;
-      if (a < 255) { data[i + 3] = 0; continue; }
-      const r = data[i];
-      const g = data[i + 1];
-      const b = data[i + 2];
-      if (r === g && g === b) { data[i + 3] = 0; continue; }
-      // Purple-shape: G is the smallest channel, and both R and B are
-      // bright enough to read as a colour rather than near-black.
-      if (g >= 120 || r <= 50 || b <= 50 || r <= g || b <= g) continue;
-      const key = (r << 16) | (g << 8) | b;
-      if (!palette.has(key)) data[i + 3] = 0;
+      if (data[i + 3] === 0) continue;
+      if (classifyDwdPixel(data[i], data[i + 1], data[i + 2], data[i + 3], palette) !== 'data') {
+        data[i + 3] = 0;
+      }
     }
   };
+}
+
+// Inverse of makeDwdMaskFilter — keeps the mask, drops the radar data,
+// recolours grey wash and outline pixels to theme-controlled values
+// (`dim` / `outline` are RGBA tuples 0..255). Original alpha is
+// multiplied by the themed alpha so antialiasing is preserved and the
+// theme controls overall strength.
+function makeDwdMaskOnlyFilter(
+  layerName: string,
+  dim: readonly [number, number, number, number],
+  outline: readonly [number, number, number, number],
+): (data: Uint8ClampedArray) => void {
+  const palette = layerName.startsWith('Radar_wn-')
+    ? WN_PALETTE_PURPLES
+    : RV_PALETTE_PURPLES;
+  return (data) => {
+    for (let i = 0; i < data.length; i += 4) {
+      const origA = data[i + 3];
+      if (origA === 0) continue;
+      const kind = classifyDwdPixel(data[i], data[i + 1], data[i + 2], origA, palette);
+      if (kind === 'data') {
+        data[i + 3] = 0;
+        continue;
+      }
+      const c = kind === 'grey' ? dim : outline;
+      data[i] = c[0];
+      data[i + 1] = c[1];
+      data[i + 2] = c[2];
+      data[i + 3] = Math.round((origA * c[3]) / 255);
+    }
+  };
+}
+
+// Parse any CSS colour string ("rgba(0,0,0,0.3)", "#ff00ff", "magenta",
+// "transparent", …) into [r, g, b, a] bytes (0..255). Returns null if
+// the string can't be parsed.
+function parseCssColor(value: string): [number, number, number, number] | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const ctx = document.createElement('canvas').getContext('2d');
+  if (!ctx) return null;
+  const sentinel = '#010203';
+  ctx.fillStyle = sentinel;
+  ctx.fillStyle = trimmed;
+  if (ctx.fillStyle === sentinel && trimmed.toLowerCase() !== sentinel) return null;
+  ctx.clearRect(0, 0, 1, 1);
+  ctx.fillRect(0, 0, 1, 1);
+  const d = ctx.getImageData(0, 0, 1, 1).data;
+  return [d[0], d[1], d[2], d[3]];
 }
 
 export interface RadarPlayerOptions {
@@ -118,6 +184,18 @@ export class RadarPlayer {
   private _noaaLimiter: RateLimiter;
   private _dwdLimiter: RateLimiter;
   private _dwdSwapLogged = false;
+
+  // Per-frame coverage overlay (DWD only). Each entry is a FetchWmsTileLayer
+  // that fetches the same WMS layer at the matching frame's TIME, filtered
+  // through `makeDwdMaskOnlyFilter` so only the grey wash + outline survive
+  // (recoloured to theme variables). The layers sit on a dedicated pane
+  // above the radar tiles. Visibility is snap-switched per frame in
+  // `_showSlot` — no cross-fade — so two stacked masks during a transition
+  // can never compound the dim and reintroduce the pulse.
+  private _radarMask: (FetchWmsTileLayer | null)[] = [];
+  private _dwdMaskPaneCreated = false;
+  private _dwdDimRgba: [number, number, number, number] | null = null;
+  private _dwdOutlineRgba: [number, number, number, number] | null = null;
 
   private _radarImage: (FetchTileLayer | FetchWmsTileLayer)[] = [];
   // Date + time stored as separate parts so the bottom row can hide the
@@ -520,6 +598,11 @@ export class RadarPlayer {
 
     this._prev1Slot = slot;
 
+    // Coverage overlay snap-switch — only the new slot's mask is visible.
+    // Done unconditionally; non-DWD sources have an empty _radarMask array
+    // and the loop is a no-op.
+    this._showDwdMaskForSlot(slot);
+
     const fi = this._loadedSlots[slot];
     if (fi !== undefined) {
       this._setTimestamp(fi);
@@ -672,6 +755,95 @@ export class RadarPlayer {
     // that no longer exist after a teardown + re-init.
     this._prev1Slot = -1;
     this._zCounter = 0;
+    this._clearDwdMaskLayers();
+  }
+
+  // Resolve the DWD WMS layer the player is currently using. Niederschlagsradar
+  // (the default) is past-only; when the user requests forecast hours, switch
+  // to the analysis+nowcast layer which carries +2h frames too.
+  private _dwdLayerName(): string {
+    const wantsForecast = (this._cfg.forecast_minutes ?? 0) > 0;
+    const autoSwap = wantsForecast && this._cfg.dwd_layer === undefined;
+    const name = this._cfg.dwd_layer
+      ?? (wantsForecast ? 'Radar_wn-product_1x1km_ger' : DWD_WMS_LAYER_DEFAULT);
+    if (autoSwap && !this._dwdSwapLogged) {
+      console.info(
+        `[weather-radar-card] forecast_minutes > 0; switched DWD layer ${DWD_WMS_LAYER_DEFAULT} (mm/h) → ${name} (dBZ) for nowcast frames. Set dwd_layer to override.`,
+      );
+      this._dwdSwapLogged = true;
+    }
+    return name;
+  }
+
+  // Lazily build the dedicated Leaflet pane the coverage overlay sits on.
+  // z-index 350 places it above the basemap + radar tiles (tilePane = 200)
+  // but below SVG overlays / markers (overlayPane = 400).
+  private _ensureDwdMaskPane(): void {
+    if (this._dwdMaskPaneCreated || !this._map) return;
+    const pane = this._map.createPane('dwd-coverage-mask');
+    pane.style.zIndex = '350';
+    pane.style.pointerEvents = 'none';
+    this._dwdMaskPaneCreated = true;
+  }
+
+  // Read --dwd-coverage-dim-color / --dwd-coverage-outline-color off the
+  // card host. Cached per init so 48 frames don't each call getComputedStyle.
+  private _refreshDwdMaskColors(): void {
+    const host = this._shadowRoot.host as HTMLElement;
+    const cs = getComputedStyle(host);
+    this._dwdDimRgba = parseCssColor(cs.getPropertyValue('--dwd-coverage-dim-color'))
+      ?? [0, 0, 0, 255];
+    this._dwdOutlineRgba = parseCssColor(cs.getPropertyValue('--dwd-coverage-outline-color'))
+      ?? [255, 0, 255, 255];
+  }
+
+  // Build a coverage overlay layer matching a specific radar frame. Returns
+  // null if the layer would have nothing to draw (both theme colours are
+  // fully transparent — explicit opt-out).
+  private _createDwdMaskLayer(frame: RadarFrame, layerName: string): FetchWmsTileLayer | null {
+    if (!this._dwdDimRgba || !this._dwdOutlineRgba) return null;
+    if (this._dwdDimRgba[3] === 0 && this._dwdOutlineRgba[3] === 0) return null;
+    this._ensureDwdMaskPane();
+    const isoTime = new Date(frame.time * 1000).toISOString().split('.')[0] + 'Z';
+    const { size: tileSize, zoomOffset } = this._radarTileSize();
+    return new FetchWmsTileLayer(DWD_WMS_URL, {
+      layers: layerName,
+      format: 'image/png',
+      transparent: true,
+      version: '1.3.0',
+      TIME: isoTime,
+      tileSize,
+      zoomOffset,
+      maxNativeZoom: 8 + Math.max(0, -zoomOffset),
+      rateLimiter: this._dwdLimiter,
+      on429: () => this._onRateLimited(),
+      animationOwnsOpacity: true,
+      pane: 'dwd-coverage-mask',
+      pixelFilter: makeDwdMaskOnlyFilter(layerName, this._dwdDimRgba, this._dwdOutlineRgba),
+    } as any);
+  }
+
+  // Tear down all per-frame mask layers (called from _clearLayers).
+  private _clearDwdMaskLayers(): void {
+    for (const layer of this._radarMask) {
+      if (layer && (layer as any).remove) (layer as any).remove();
+    }
+    this._radarMask = [];
+  }
+
+  // Snap-switch mask visibility — only the active slot's mask is visible.
+  // Called from _showSlot. No transition, so two stacked masks during a
+  // data crossfade can never compound the dim into a pulse.
+  private _showDwdMaskForSlot(slot: number): void {
+    for (let s = 0; s < this._loadedSlots.length; s++) {
+      const fi = this._loadedSlots[s];
+      const layer = this._radarMask[fi];
+      if (!layer) continue;
+      const el = (layer as any).getContainer?.() as HTMLElement | undefined;
+      if (!el) continue;
+      el.style.transition = 'none';
+      el.style.opacity = (s === slot) ? '1' : '0';
+    }
   }
 
   // ── Radar fetching ───────────────────────────────────────────────────────
@@ -782,17 +954,7 @@ export class RadarPlayer {
     }
     if (dataSource === 'DWD') {
       const isoTime = new Date(frame.time * 1000).toISOString().split('.')[0] + 'Z';
-      // Niederschlagsradar (default) is past-only. When the user has asked for forecast
-      // hours, switch to the analysis+nowcast layer which carries +2h frames too.
-      const wantsForecast = (this._cfg.forecast_minutes ?? 0) > 0;
-      const autoSwap = wantsForecast && this._cfg.dwd_layer === undefined;
-      const layerName = this._cfg.dwd_layer ?? (wantsForecast ? 'Radar_wn-product_1x1km_ger' : DWD_WMS_LAYER_DEFAULT);
-      if (autoSwap && !this._dwdSwapLogged) {
-        console.info(
-          `[weather-radar-card] forecast_minutes > 0; switched DWD layer ${DWD_WMS_LAYER_DEFAULT} (mm/h) → ${layerName} (dBZ) for nowcast frames. Set dwd_layer to override.`,
-        );
-        this._dwdSwapLogged = true;
-      }
+      const layerName = this._dwdLayerName();
       return wireSpinner(new FetchWmsTileLayer(DWD_WMS_URL, {
         layers: layerName,
         format: 'image/png',
@@ -873,6 +1035,13 @@ export class RadarPlayer {
     this._buildSegments();
     this._applyNowMarker();
 
+    const dwdActive = (this._cfg.data_source ?? 'RainViewer') === 'DWD';
+    if (dwdActive) {
+      this._refreshDwdMaskColors();
+      this._radarMask = new Array(frameCount).fill(null);
+    }
+    const dwdLayerName = dwdActive ? this._dwdLayerName() : '';
+
     let newestShown = false;
 
     for (let fi = frameCount - 1; fi >= 0; fi--) {
@@ -887,6 +1056,16 @@ export class RadarPlayer {
       const el = (layer as any).getContainer?.() as HTMLElement | undefined;
       if (el) el.style.opacity = '0';
 
+      if (dwdActive) {
+        const maskLayer = this._createDwdMaskLayer(this._radarPaths[fi], dwdLayerName);
+        if (maskLayer) {
+          this._radarMask[fi] = maskLayer;
+          maskLayer.addTo(this._map);
+          const maskEl = (maskLayer as any).getContainer?.() as HTMLElement | undefined;
+          if (maskEl) maskEl.style.opacity = '0';
+        }
+      }
+
       const status = await layerSettled(layer);
       if (myGen !== this._frameGeneration) return;
 
@@ -900,6 +1079,11 @@ export class RadarPlayer {
           // Show newest frame as a static preview before the loop starts
           newestShown = true;
           if (el) el.style.opacity = this._activeOpacity;
+          // Surface the matching mask too, so the newest preview already has
+          // its in-sync coverage overlay before the animation loop begins.
+          const maskLayer = this._radarMask[fi];
+          const maskEl = maskLayer && (maskLayer as any).getContainer?.() as HTMLElement | undefined;
+          if (maskEl) maskEl.style.opacity = '1';
           this._setTimestamp(fi);
           this._highlightSegment(fi);
         }
@@ -961,16 +1145,29 @@ export class RadarPlayer {
     const newLayer = this._createLayer(latestFrame);
     newLayer.addTo(this._map);
     const newTime = this._getTimeString(latestFrame.time * 1000);
+    const dwdActive = (this._cfg.data_source ?? 'RainViewer') === 'DWD';
+    let newMask: FetchWmsTileLayer | null = null;
+    if (dwdActive) {
+      newMask = this._createDwdMaskLayer(latestFrame, this._dwdLayerName());
+      if (newMask) {
+        newMask.addTo(this._map);
+        const maskEl = (newMask as any).getContainer?.() as HTMLElement | undefined;
+        if (maskEl) maskEl.style.opacity = '0';
+      }
+    }
 
     this._radarImage[0]?.remove();
+    if (this._radarMask[0]) (this._radarMask[0] as any).remove?.();
     // _radarPaths shifts alongside the others because nearestFrameIndex() reads .time off it.
     for (let i = 0; i < frameCount - 1; i++) {
       this._radarImage[i] = this._radarImage[i + 1];
+      this._radarMask[i] = this._radarMask[i + 1] ?? null;
       this._radarTime[i] = this._radarTime[i + 1];
       this._radarPaths[i] = this._radarPaths[i + 1];
       this._frameStatuses[i] = this._frameStatuses[i + 1];
     }
     this._radarImage[frameCount - 1] = newLayer;
+    this._radarMask[frameCount - 1] = newMask;
     this._radarTime[frameCount - 1] = newTime;
     this._radarPaths[frameCount - 1] = latestFrame;
     this._loadedSlots = this._loadedSlots.map(fi => fi - 1).filter(fi => fi >= 0);

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -50,25 +50,33 @@ const DWD_LAG_MS = 5 * 60 * 1000;
 // the same RGB neighbourhood, so we whitelist palette entries by exact
 // triple — the legend only has a handful and they're stable per layer.
 // Anything else with G low and R, B both bright is treated as outline.
-const WN_PALETTE_PURPLES = new Set<number>([
+// Exported for unit-test access — same pattern as nearestFrameIndex
+// above. Not part of the public API; consumers should use
+// makeDwdMaskFilter / makeDwdMaskOnlyFilter instead.
+export const WN_PALETTE_PURPLES = new Set<number>([
   (153 << 16) | (0 << 8) | 153,
   (255 << 16) | (51 << 8) | 255,
 ]);
-const RV_PALETTE_PURPLES = new Set<number>([
+export const RV_PALETTE_PURPLES = new Set<number>([
   (204 << 16) | (0 << 8) | 152,
   (102 << 16) | (0 << 8) | 203,
 ]);
 
-function dwdPaletteFor(layerName: string): Set<number> {
+export function dwdPaletteFor(layerName: string): Set<number> {
   return layerName.startsWith('Radar_wn-') ? WN_PALETTE_PURPLES : RV_PALETTE_PURPLES;
 }
 
-type DwdPixelKind = 'data' | 'grey' | 'outline';
+export type DwdPixelKind = 'data' | 'grey' | 'outline';
 
 // Classify a single pixel. Shared by the data filter (drops everything
 // that isn't 'data') and the mask-only filter (drops 'data', recolours
 // the rest).
-function classifyDwdPixel(
+//
+// Exported for testability — the classifier is the most fragile piece
+// of the DWD mask-stripping pipeline (RGB-indistinguishable palette
+// purples vs outline blends, exact-triple whitelist) and worth pinning
+// against DWD palette drift.
+export function classifyDwdPixel(
   r: number, g: number, b: number, a: number,
   paletteKeys: Set<number>,
 ): DwdPixelKind {

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -39,6 +39,60 @@ const DWD_WMS_LAYER_DEFAULT = 'Niederschlagsradar';
 // Frames usually appear 1–3 min after their timestamp; 5 min is safely past the lag.
 const DWD_LAG_MS = 5 * 60 * 1000;
 
+// DWD's WMS tiles bake a "no-data" mask into every frame: a faint grey
+// wash (rgba 126,126,126,77) for areas outside coverage, plus a magenta
+// boundary outline (rgb 255,0,255 at varying α) where the underlying
+// raster ends. Two stacked tile layers during a crossfade compound the
+// dim, producing a visible pulse. Stripping these at fetch time lifts
+// the mask out of the per-slot stack.
+//
+// The pixel filter is a *whitelist* in colour space: anything that
+// shaped like purple (G low, R and B both higher than G) gets dropped
+// unless it exactly matches a known palette entry. The DWD radar
+// colourmaps only have a handful of purple/magenta hues for heavy
+// rain, and they fall on specific (r, g, b) triples that no outline
+// blend will hit. Asymmetric outline blends like (188,38,204) and
+// symmetric ones like a hypothetical (112,35,112) are both caught by
+// the same rule; symmetry no longer matters.
+//
+// Known palette purples across the DWD radar layers:
+//   Niederschlagsradar/RV: (204,0,152) (102,0,203)
+//   WN-product/-analysis:  (153,0,153) (255,51,255)
+//
+// `layerName` selects which palette whitelist applies. Pure red/orange
+// palette entries (e.g. (255,32,32), (255,137,0)) are *not* purple-shape
+// because B ≤ G — they pass through untouched.
+const WN_PALETTE_PURPLES = new Set<number>([
+  (153 << 16) | (0 << 8) | 153,
+  (255 << 16) | (51 << 8) | 255,
+]);
+const RV_PALETTE_PURPLES = new Set<number>([
+  (204 << 16) | (0 << 8) | 152,
+  (102 << 16) | (0 << 8) | 203,
+]);
+
+function makeDwdMaskFilter(layerName: string): (data: Uint8ClampedArray) => void {
+  const palette = layerName.startsWith('Radar_wn-')
+    ? WN_PALETTE_PURPLES
+    : RV_PALETTE_PURPLES;
+  return (data) => {
+    for (let i = 0; i < data.length; i += 4) {
+      const a = data[i + 3];
+      if (a === 0) continue;
+      if (a < 255) { data[i + 3] = 0; continue; }
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      if (r === g && g === b) { data[i + 3] = 0; continue; }
+      // Purple-shape: G is the smallest channel, and both R and B are
+      // bright enough to read as a colour rather than near-black.
+      if (g >= 120 || r <= 50 || b <= 50 || r <= g || b <= g) continue;
+      const key = (r << 16) | (g << 8) | b;
+      if (!palette.has(key)) data[i + 3] = 0;
+    }
+  };
+}
+
 export interface RadarPlayerOptions {
   map: L.Map;
   shadowRoot: ShadowRoot;
@@ -755,6 +809,7 @@ export class RadarPlayer {
         rateLimiter: this._dwdLimiter,
         on429: () => this._onRateLimited(),
         animationOwnsOpacity: true,
+        pixelFilter: makeDwdMaskFilter(layerName),
       } as any));
     }
     const snow = this._cfg.show_snow ? 1 : 0;

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -1029,12 +1029,9 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     css`
       :host {
         display: block; isolation: isolate; height: 100%;
-        /* DWD coverage overlay — sits above the radar tiles, drawn from the
-           DWD WMS no-data mask. Themes can override these to retint or hide
-           the dim/outline. RGB controls the colour; alpha multiplies the
-           original mask opacity (so wash a=77 stays soft and the magenta
-           outline keeps its antialiasing). Set either to "transparent" to
-           drop that layer entirely. */
+        /* DWD coverage overlay theme hooks. RGB picks the colour, alpha
+           multiplies the original mask opacity (so wash density and outline
+           antialiasing both scale). Set to "transparent" to hide. */
         --dwd-coverage-dim-color: rgba(0, 0, 0, 1);
         --dwd-coverage-outline-color: rgba(255, 0, 255, 1);
       }

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -1027,7 +1027,17 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     unsafeCSS(leafletCss),
     unsafeCSS(markerClusterCss),
     css`
-      :host { display: block; isolation: isolate; height: 100%; }
+      :host {
+        display: block; isolation: isolate; height: 100%;
+        /* DWD coverage overlay — sits above the radar tiles, drawn from the
+           DWD WMS no-data mask. Themes can override these to retint or hide
+           the dim/outline. RGB controls the colour; alpha multiplies the
+           original mask opacity (so wash a=77 stays soft and the magenta
+           outline keeps its antialiasing). Set either to "transparent" to
+           drop that layer entirely. */
+        --dwd-coverage-dim-color: rgba(0, 0, 0, 1);
+        --dwd-coverage-outline-color: rgba(255, 0, 255, 1);
+      }
       /* flex-mode is the default: ha-card fills its container vertically
          (sections-grid cell), with min-height set inline from the user's
          height config so a regular dashboard still renders at the

--- a/tests/dwd-mask-filter.test.ts
+++ b/tests/dwd-mask-filter.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyDwdPixel,
+  dwdPaletteFor,
+  WN_PALETTE_PURPLES,
+  RV_PALETTE_PURPLES,
+} from '../src/radar-player';
+
+// classifyDwdPixel is the heart of the DWD coverage-mask stripping
+// pipeline (PR #132 / #142). It decides whether each fetched-tile
+// pixel is real radar data, the grey "no-data" wash, or the magenta
+// coverage outline. Two filter functions consume it: one drops
+// everything that isn't 'data' (so the radar tiles render clean), the
+// other inverts that to render the boundary as a separate snap-switched
+// overlay (so it doesn't pulse during crossfade).
+//
+// The fragile part is that DWD's heavy-rain palette includes purples
+// that are RGB-indistinguishable from outline-on-data antialiasing
+// blends. The classifier handles this by whitelisting palette entries
+// by exact (r, g, b) triple. These tests pin that whitelist plus the
+// surrounding rules so a future DWD palette tweak that breaks the
+// classifier is caught immediately.
+
+describe('classifyDwdPixel', () => {
+  // ── opaque palette purples (rare radar colours) — must classify as 'data' ──
+
+  it('WN palette purples classify as data when the WN palette is selected', () => {
+    for (const key of WN_PALETTE_PURPLES) {
+      const r = (key >> 16) & 0xff;
+      const g = (key >> 8) & 0xff;
+      const b = key & 0xff;
+      expect(classifyDwdPixel(r, g, b, 255, WN_PALETTE_PURPLES))
+        .toBe('data');
+    }
+  });
+
+  it('RV palette purples classify as data when the RV palette is selected', () => {
+    for (const key of RV_PALETTE_PURPLES) {
+      const r = (key >> 16) & 0xff;
+      const g = (key >> 8) & 0xff;
+      const b = key & 0xff;
+      expect(classifyDwdPixel(r, g, b, 255, RV_PALETTE_PURPLES))
+        .toBe('data');
+    }
+  });
+
+  it('a WN palette purple classifies as outline when the RV palette is selected', () => {
+    // Defensive: same purple triple, wrong palette → looks like an
+    // outline blend. Pins that paletteKeys is actually consulted.
+    const wn = WN_PALETTE_PURPLES.values().next().value as number;
+    const r = (wn >> 16) & 0xff;
+    const g = (wn >> 8) & 0xff;
+    const b = wn & 0xff;
+    if (!RV_PALETTE_PURPLES.has(wn)) {
+      expect(classifyDwdPixel(r, g, b, 255, RV_PALETTE_PURPLES))
+        .toBe('outline');
+    }
+  });
+
+  // ── opaque outline — pure magenta ──
+
+  it('pure magenta (255, 0, 255) classifies as outline', () => {
+    expect(classifyDwdPixel(255, 0, 255, 255, WN_PALETTE_PURPLES))
+      .toBe('outline');
+  });
+
+  it('any G=0 + B=255 colour classifies as outline (the canonical DWD outline rule)', () => {
+    // R varies but G=0 and B=255 always means "magenta-family outline".
+    expect(classifyDwdPixel(0, 0, 255, 255, WN_PALETTE_PURPLES)).toBe('outline');
+    expect(classifyDwdPixel(128, 0, 255, 255, WN_PALETTE_PURPLES)).toBe('outline');
+    expect(classifyDwdPixel(200, 0, 255, 255, WN_PALETTE_PURPLES)).toBe('outline');
+  });
+
+  // ── opaque outline — non-palette purple shape ──
+
+  it('off-palette purple-shape pixels classify as outline (data + outline antialiasing blend)', () => {
+    // Purple-shape: G low, R and B both bright, neither matches a palette entry.
+    expect(classifyDwdPixel(188, 38, 204, 255, WN_PALETTE_PURPLES)).toBe('outline');
+    expect(classifyDwdPixel(177, 23, 200, 255, WN_PALETTE_PURPLES)).toBe('outline');
+  });
+
+  // ── opaque grey — no-data wash ──
+
+  it('equal-channel pixels (r === g === b) classify as grey', () => {
+    expect(classifyDwdPixel(126, 126, 126, 255, WN_PALETTE_PURPLES)).toBe('grey');
+    expect(classifyDwdPixel(0, 0, 0, 255, WN_PALETTE_PURPLES)).toBe('grey');
+    expect(classifyDwdPixel(255, 255, 255, 255, WN_PALETTE_PURPLES)).toBe('grey');
+  });
+
+  // ── opaque data — typical radar palette colours ──
+
+  it('pure red / orange / yellow / green / blue / cyan classify as data (B ≤ G or G ≥ R, not purple-shape)', () => {
+    // These are the canonical radar palette ramp colours that should
+    // pass through untouched by the mask stripper.
+    expect(classifyDwdPixel(255, 0, 0, 255, WN_PALETTE_PURPLES)).toBe('data');         // pure red — B=0
+    expect(classifyDwdPixel(255, 165, 0, 255, WN_PALETTE_PURPLES)).toBe('data');       // orange — B=0
+    expect(classifyDwdPixel(255, 255, 0, 255, WN_PALETTE_PURPLES)).toBe('data');       // yellow — equal but G high
+    // Hmm: pure yellow (255,255,0) — first rule: r === g === b? 255 !== 0 so no.
+    //      magenta? g=255 not 0. Purple-shape? g=255 not <120. → data. Correct.
+    expect(classifyDwdPixel(0, 255, 0, 255, WN_PALETTE_PURPLES)).toBe('data');         // green — R=0, B=0, but g not <120 anyway
+    expect(classifyDwdPixel(0, 0, 255, 255, WN_PALETTE_PURPLES)).toBe('outline');      // pure blue is magenta-family! G=0 B=255
+    expect(classifyDwdPixel(0, 200, 255, 255, WN_PALETTE_PURPLES)).toBe('data');       // cyan — G high, not purple-shape
+  });
+
+  it('a pixel where B ≤ G is never purple-shape (e.g. brown 165, 130, 90)', () => {
+    expect(classifyDwdPixel(165, 130, 90, 255, WN_PALETTE_PURPLES)).toBe('data');
+  });
+
+  it('a pixel where G ≥ 120 is never purple-shape (e.g. lavender 200, 130, 220)', () => {
+    expect(classifyDwdPixel(200, 130, 220, 255, WN_PALETTE_PURPLES)).toBe('data');
+  });
+
+  it('a pixel where R or B ≤ 50 is never purple-shape (the brightness floor)', () => {
+    expect(classifyDwdPixel(40, 10, 200, 255, WN_PALETTE_PURPLES)).toBe('data');  // R below floor
+    expect(classifyDwdPixel(200, 10, 40, 255, WN_PALETTE_PURPLES)).toBe('data');  // B below floor
+  });
+
+  // ── semi-transparent (antialiased mask edges) ──
+
+  it('semi-transparent grey edge (R≈G≈B, alpha < 255) classifies as grey', () => {
+    // The wash boundary antialiases as semi-transparent grey.
+    expect(classifyDwdPixel(126, 126, 126, 100, WN_PALETTE_PURPLES)).toBe('grey');
+    expect(classifyDwdPixel(120, 130, 125, 50, WN_PALETTE_PURPLES)).toBe('grey');  // small channel drift
+  });
+
+  it('semi-transparent magenta-blend edge classifies as outline', () => {
+    // Outline antialiasing produces semi-transparent purple-ish pixels.
+    expect(classifyDwdPixel(220, 50, 220, 100, WN_PALETTE_PURPLES)).toBe('outline');
+    expect(classifyDwdPixel(180, 30, 180, 50, WN_PALETTE_PURPLES)).toBe('outline');
+  });
+
+  it('semi-transparent grey is grey even when channels drift up to 15 apart (the threshold)', () => {
+    expect(classifyDwdPixel(120, 130, 130, 50, WN_PALETTE_PURPLES)).toBe('grey');
+    expect(classifyDwdPixel(135, 120, 130, 50, WN_PALETTE_PURPLES)).toBe('grey');
+  });
+
+  it('semi-transparent pixel with channel drift > 15 classifies as outline (not grey)', () => {
+    // Just past the 15-unit grey-detection threshold.
+    expect(classifyDwdPixel(100, 130, 100, 50, WN_PALETTE_PURPLES)).toBe('outline');
+    expect(classifyDwdPixel(180, 100, 180, 50, WN_PALETTE_PURPLES)).toBe('outline');
+  });
+});
+
+// dwdPaletteFor picks the correct palette set based on the active WMS
+// layer. Tests pin the layer-name → palette mapping so a future layer
+// rename doesn't silently fall back to the wrong palette.
+
+describe('dwdPaletteFor', () => {
+  it('returns WN palette for Radar_wn-* layer names', () => {
+    expect(dwdPaletteFor('Radar_wn-product_1x1km_ger')).toBe(WN_PALETTE_PURPLES);
+    expect(dwdPaletteFor('Radar_wn-anything')).toBe(WN_PALETTE_PURPLES);
+  });
+
+  it('returns RV palette for Niederschlagsradar (the default)', () => {
+    expect(dwdPaletteFor('Niederschlagsradar')).toBe(RV_PALETTE_PURPLES);
+  });
+
+  it('returns RV palette for any non-Radar_wn-prefixed layer (defensive default)', () => {
+    expect(dwdPaletteFor('Some_Other_Layer')).toBe(RV_PALETTE_PURPLES);
+    expect(dwdPaletteFor('')).toBe(RV_PALETTE_PURPLES);
+  });
+});


### PR DESCRIPTION
Replaces [#132](https://github.com/Makin-Things/weather-radar-card/pull/132) — same three feature commits from @genericJE, cherry-picked onto current master with the conflicts resolved against the alpha2/alpha3 work that landed since the original PR opened. Plus the \`classifyDwdPixel\` unit tests that were the one outstanding ask from my review there.

@genericJE — credited as Co-Authored-By on the three feature commits via cherry-pick attribution. Closing #132 in favour of this PR purely for the conflict-resolution + test-coverage adds; the substantive design and code is yours.

## What it does (recap from #132)

The grey \"no data\" wash and the magenta coverage outline that DWD's WMS bakes into every Niederschlagsradar / Radar_wn tile were stacking during the per-frame cross-fade. Two semi-transparent layers compounded the dim and produced a visible pulse on the boundary every tick.

**Two-part fix:**

1. **Strip the mask at fetch time.** Each fetched tile goes through an optional pixel filter (\`pixelFilter\` on \`FetchTileOptions\`) before it lands in the \`<img>\`. For DWD tiles, the filter drops the wash, the outline, and any antialiased blends between them. Heavy-rain palette purples like \`(153, 0, 153)\` are colour-indistinguishable from outline blends in places, so the filter whitelists palette entries by exact RGB triple rather than guessing by saturation.

2. **Re-render the boundary as a separate, snap-switched overlay.** With the mask gone from the data tiles the pulse disappears, but so does the visual cue that tells you where DWD coverage ends. So we add a second tile layer per frame on a dedicated Leaflet pane (z-index 350), running the inverse filter so only the wash and outline survive, recoloured to two CSS variables:
   - \`--dwd-coverage-dim-color\` (default \`rgba(0, 0, 0, 1)\`)
   - \`--dwd-coverage-outline-color\` (default \`rgba(255, 0, 255, 1)\`)
   Per-frame mask layers (rather than one static layer) so radar-station outages like the Feldberg one at 08:25 UTC track correctly.

## What's new vs #132

- **Conflict-resolved against current master.** Three resolution sites:
  - DWD layer-name resolution: kept @genericJE's \`_dwdLayerName()\` extraction AND the \`wireSpinner\` wrap from #131 + the \`pixelFilter\` line.
  - Layer construction in the inner DWD branch: same — combined wireSpinner wrap with the \`pixelFilter\` option.
  - \`weather-radar-card.ts\` auto-merged.
- **Skipped \`a6fc0e3\`** (the tile-active fix) since it's already on master via [#130](https://github.com/Makin-Things/weather-radar-card/pull/130). Skipped the dist-update chore commit too.
- **Added the requested unit tests** for \`classifyDwdPixel\` — 18 cases covering palette purples (per palette), canonical outline rule, off-palette purple-shape blends, equal-channel grey, canonical radar colours that should pass through, brightness-floor / saturation-shape boundary cases, semi-transparent edges, the 15-unit drift threshold. Plus 3 cases for \`dwdPaletteFor\` (layer-name → palette mapping).

## Test plan

- [x] Lint clean
- [x] 347/347 tests (329 + 18 new for the DWD pixel classifier)
- [x] Build succeeds
- [x] All three @genericJE feature commits preserved with original authorship + dates

## Release plan

This lands on the 3.6.0-alpha3 codebase. After merge: cut **3.6.0-alpha4** (or hold for beta1 with #133 — your call).