### PR TITLE
release: 3.6.0-rc1 (release candidate for 3.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0-rc1] - 2026-05-11
+
+> Release candidate for 3.6.0. Both beta2 known issues are resolved (streak layering, dateline wrap), plus an unrelated edit-mode regression caught via live-browser testing. No new features over beta2 beyond per-basemap streamline colour tuning. If nothing surfaces during the rc1 bake, this is what 3.6.0 ships as.
+
 ### Added
 
 - **Per-basemap streamline colour defaults + YAML overrides.** The streamline stroke colour was previously a single dark-vs-light branch — satellite shared the dark Carto map's near-white, which got lost on bright terrain. Satellite now has its own brighter pure-white default. Light basemaps also get a deeper default (`rgb(25,30,45)` was `rgb(50,55,75)`) for crisper contrast on OSM / Carto-light tiles. New YAML-only override keys `dwd_wind_flow_color_light`, `_dark`, and `_sat` accept any CSS colour string for theming or custom basemap palettes (editor doesn't expose them).
@@ -513,7 +517,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-beta2...HEAD
+[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc1...HEAD
+[3.6.0-rc1]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-beta2...v3.6.0-rc1
 [3.6.0-beta2]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-beta1...v3.6.0-beta2
 [3.6.0-beta1]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-alpha4...v3.6.0-beta1
 [3.6.0-alpha4]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-alpha3...v3.6.0-alpha4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-beta2",
+  "version": "3.6.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.6.0-beta2",
+      "version": "3.6.0-rc1",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-beta2",
+  "version": "3.6.0-rc1",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.0-beta2';
+export const CARD_VERSION = '3.6.0-rc1';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
## Summary

Release candidate for 3.6.0. Both beta2 known issues are resolved + an unrelated edit-mode regression caught via the new live-browser test workflow.

## What's in rc1 (since beta2)

- **Per-basemap streamline colour defaults + YAML overrides** (\`a8de40b\`) — satellite gets brighter pure-white default; light basemaps deeper rgb(25,30,45); three new YAML-only override keys.
- **Dateline wrap fix** (\`771391a\`) — Pacific-centred low-zoom views now show wind everywhere; fetcher detects bbox past ±180° and expands to full world; samplers wrap lon during lookup. *Resolves beta2 known issue #1.*
- **Streak layering fix** (\`607ab9f\`) — streak canvas moved to a dedicated Leaflet pane (z=250) so markers, popups, wildfires, and NWS polys all render above the streaks. The fix uses \`L.DomUtil.setPosition\` to compensate for mapPane's anchor-at-centre transform — diagnosed by attaching to a live Chrome via the DevTools Protocol. *Resolves beta2 known issue #2.*
- **Edit-mode re-init fix** (\`de57ac0\`) — radar tiles no longer disappear when entering HA edit mode. \`requestUpdate()\` in \`connectedCallback\` covers the disconnect→reconnect lifecycle.
- **Layer-control design refresh** (\`734cd41\`) — switched from \`configHash + dashboardPath\` to a card-stored \`{ dash, nonce }\` identity that survives YAML edits and section drags. No code change; design doc only.

## Test plan

- [x] Lint clean
- [x] All 403 tests pass (399 → 403)
- [x] Build OK with 3.6.0-rc1 baked into dist (450.9 KB / 127.2 KB gz)
- [x] Live-browser verification: streak layering, edit-mode re-init, dateline wrap, colour tweaks

If nothing surfaces during the rc1 bake, this is what 3.6.0 ships as.