### PR TITLE
release: 3.6.0-rc4 (static-mode pan fix + tab-hidden particle jump fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0-rc4] - 2026-05-11
+
+> Two bug fixes caught during the rc3 bake — both visible regressions from earlier rc work.
+
+### Fixed
+
+- **Radar layer disappears after first pan in static-frame mode.** When `past_minutes: 0` (one frame, no animation), `_initRadar` showed the static preview but never called `_startLoop` (which requires ≥ 2 loaded slots), so the player's `_prev1Slot` tracker stayed at its initial `-1`. On the first pan/zoom, `onNavPaused` → `_stopLoop` → `_settleVisibility` looped through all loaded radar layers and set `opacity: 0` on every slot whose index didn't match `-1` (i.e., all of them, including the only visible one). The radar precipitation overlay vanished until a full re-init was forced (e.g., a config change). Fixed by initialising `_prev1Slot` to the visible-slot index when the static preview goes up — animated mode unaffected (its `_startLoop` overwrites the value one iteration later).
+- **Wind streamlines jump as long line-segments after tab returns from hidden.** Browsers throttle `requestAnimationFrame` to ~1 Hz on background tabs (or pause it entirely). When the tab became visible again, the wind overlay's motion-compensation math (`motionScale = elapsedMs / 33.33`) saw a multi-second gap and scaled per-frame motion by hundreds, producing massive single-frame jumps that drew very long streak segments across the canvas. Fixed by capping the motion-comp `dt` at 2× the target frame interval (~133 ms / motionScale max 4) so any single frame can move at most 4× the per-frame distance (vs. ~2× normal at 15 fps). Particles "lose" the hidden time but resume at a sensible pace on visibility return.
+
 ## [3.6.0-rc3] - 2026-05-11
 
 > Continuing rc-line tuning: replaces the `destination-out` accumulation rendering of the wind streamline overlay with explicit per-particle trail buffers, drops the animation rate to 15 fps (with motion compensation) for ~4× lower CPU, and adds a smooth fade-out at end-of-life and at the canvas edge. No new features; pure rendering rework. If nothing surfaces during the rc3 bake, this is what 3.6.0 ships as.
@@ -547,7 +556,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc3...HEAD
+[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc4...HEAD
+[3.6.0-rc4]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc3...v3.6.0-rc4
 [3.6.0-rc3]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc2...v3.6.0-rc3
 [3.6.0-rc2]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc1...v3.6.0-rc2
 [3.6.0-rc1]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-beta2...v3.6.0-rc1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-rc3",
+  "version": "3.6.0-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.6.0-rc3",
+      "version": "3.6.0-rc4",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-rc3",
+  "version": "3.6.0-rc4",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.0-rc3';
+export const CARD_VERSION = '3.6.0-rc4';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.

--- a/src/wind-flow-overlay.ts
+++ b/src/wind-flow-overlay.ts
@@ -404,7 +404,12 @@ export class WindFlowOverlay {
     }
     // First frame: prime _lastDrawMs so the next throttle check works,
     // and use the target interval as the assumed dt for motion math.
-    const dtMs = this._lastDrawMs > 0 ? elapsedMs : TARGET_FRAME_INTERVAL_MS;
+    // Cap dtMs at 2× target so a long gap between frames (e.g., the tab
+    // was hidden — browsers throttle raf to ~1 Hz on background tabs)
+    // doesn't translate into a giant per-frame motion jump that would
+    // produce very long line-segments on the next draw.
+    const rawDt = this._lastDrawMs > 0 ? elapsedMs : TARGET_FRAME_INTERVAL_MS;
+    const dtMs = Math.min(rawDt, TARGET_FRAME_INTERVAL_MS * 2);
     this._lastDrawMs = now;
     // Scale per-frame motion so wall-clock head speed stays consistent
     // regardless of the actual throttle rate or display refresh rate.


### PR DESCRIPTION
## Summary

Two bug fixes caught during rc3 bake — both visible regressions from earlier rc work.

## Fixed

- **Radar layer disappears after first pan in static-frame mode** (\`past_minutes: 0\`). \`_prev1Slot\` stayed at its initial \`-1\` because \`_startLoop\` never fires for a 1-frame loop. On pan, \`_settleVisibility\` then set every layer's opacity to 0 (no slot index matched -1). Fixed by initialising \`_prev1Slot\` when the static preview goes up. Animated mode unaffected.
- **Wind streamlines draw giant line segments after a tab returns from hidden.** Browsers throttle raf to ~1 Hz on background tabs; the motion-compensation math saw a multi-second gap and scaled per-frame motion by hundreds. Fixed by capping motion-comp \`dt\` at 2× the target frame interval.

## Test plan

- [x] Lint clean
- [x] All 403 tests pass
- [x] Build OK with 3.6.0-rc4 baked into dist (452.5 KB / 127.7 KB gz)
- [x] Live-browser verification: hard reload + short pan in static mode now keeps radar visible (was: disappeared)
- [x] Code-trace verification of animated-mode safety