### PR TITLE
release: 3.6.0 (lightning + DWD wind overlays, bulk WCS fetch, full rc tuning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-05-12
+
+> **DWD wind overlay**: barbs, arrows, and animated streamlines sampled from the same ICON-D2 10 m wind layer DWD's WarnWetter app uses. Available regardless of `data_source` (the model is global). Also: bulk WCS fetch architecture (60–290× fewer HTTP requests per refresh vs. the alpha line), edit-mode regression fix, dateline wrap, and a long tuning pass on the streamline visuals.
+>
+> See the [3.6.0-beta1] entry for the original feature ship and config example, [3.6.0-beta2] for the bulk-fetch rework, and [3.6.0-rc1] / [3.6.0-rc2] / [3.6.0-rc3] / [3.6.0-rc4] for the iterative streamline tuning. This entry is what changed since rc4.
+
+### Fixed
+
+- **Wind streak density and length plateau at z8.** Previously `_zoomDetailMultiplier` ramped from 0.09 at z3 to 1.37 at z12 and `MAX_PX_PER_MPS_PER_FRAME` was 0.30, so city zooms (z9+) ended up ~70% denser AND with ~3× longer streaks than the visually-calibrated z8 reference — the wind field over-painted the basemap at street level. Now the multiplier plateaus at the z8 value (`HIGH_ZOOM_DETAIL_MULT = 0.80`, `REFERENCE_DETAIL_ZOOM = 8` — same z3→z8 slope, just caps above) and `MAX_PX_PER_MPS_PER_FRAME` drops to 0.10 (the z8 reference). z3–z8 look identical; z9+ now match z8 in perceived density and streak length while still resolving finer wind detail (smaller bbox → finer grid samples).
+
+### Cumulative since 3.5.x
+
+A short index of what 3.6.0 actually delivers — full detail in the linked rc / beta entries.
+
+#### New features
+
+- **Lightning overlay** (`show_lightning: true`) — live Blitzortung strikes rendered as bolts that settle into a coloured + sign, ageing white → red over the configured window. Pure renderer; the [Blitzortung integration](https://www.home-assistant.io/integrations/blitzortung/) does the data plumbing ([3.6.0-alpha1]).
+- **DWD wind overlay** — barbs, arrows, animated streamlines (`dwd_wind`, `dwd_wind_flow`); editor subpage; works on RainViewer / NOAA / DWD; per-basemap colour defaults + YAML overrides ([3.6.0-beta1], [3.6.0-beta2], [3.6.0-rc1]).
+- **Bulk WCS GetCoverage architecture** — one request per refresh per overlay (was 60–290 per refresh) ([3.6.0-beta2]).
+- **Hour-aligned wind refresh** that wakes at HH:00:30 instead of polling on a fixed interval ([3.6.0-beta2]).
+- **Static-frame radar mode** (`past_minutes: 0` / "Off (static frame, no animation)" preset) — single-frame view that still refreshes every 5 minutes, no animation loop ([3.6.0-alpha2]).
+- **NWS alert paint order** is now lexicographic over (severity, urgency, certainty), so a Tornado Warning Observed correctly paints over a Tornado Warning Radar-Indicated, etc. ([3.6.0-alpha3]).
+- **CSS theme variables for the DWD coverage overlay** — `--dwd-coverage-dim-color` and `--dwd-coverage-outline-color` (set either to `transparent` to hide) ([3.6.0-alpha4]).
+
+#### Bug fixes
+
+- **DWD coverage-mask cross-fade pulse** — the grey "no-data" wash and magenta outline that DWD bakes into every tile were stacking during cross-fade, producing a visible pulse on the boundary every animation tick. Fixed by stripping the mask at fetch time and re-rendering the boundary as a snap-switched overlay on a dedicated pane. Contributed by [@genericJE](https://github.com/genericJE) ([3.6.0-alpha4]).
+- Edit-mode regression — radar tiles disappearing when entering Lovelace edit mode ([3.6.0-rc1]).
+- Dateline wrap on the wind layer ([3.6.0-rc1]).
+- Wind streaks render below markers / popups instead of above them ([3.6.0-rc1]).
+- Static-frame mode: radar layer no longer disappears on first pan when `past_minutes: 0` ([3.6.0-rc4]).
+- Wind streamlines no longer jump as long line segments after the tab returns from being hidden ([3.6.0-rc4]).
+- Wind streak density and length cap at z8 (this release).
+
+#### Security
+
+- Defensive `escapeHtml` on all three popup `href` interpolations (NWS, wildfire, lightning). Closes a theoretical attribute-breakout via NWS `props.uri`; wildfire / lightning were safe by construction but hardened against future refactors ([3.6.0-alpha3]).
+
+#### Streamline visual tuning (cumulative)
+
+- Explicit per-particle trail buffer instead of `destination-out` accumulation; 15 fps with motion compensation; cubic ease-in fade-out at end-of-life and at the canvas edge ([3.6.0-rc3]).
+- Low-zoom density taper, line-width compensation, sharper trail decay ([3.6.0-rc2]).
+
 ## [3.6.0-rc4] - 2026-05-11
 
 > Two bug fixes caught during the rc3 bake — both visible regressions from earlier rc work.
@@ -556,7 +599,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc4...HEAD
+[Unreleased]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc4...v3.6.0
 [3.6.0-rc4]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc3...v3.6.0-rc4
 [3.6.0-rc3]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc2...v3.6.0-rc3
 [3.6.0-rc2]: https://github.com/Makin-Things/weather-radar-card/compare/v3.6.0-rc1...v3.6.0-rc2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-rc4",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.6.0-rc4",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.0-rc4",
+  "version": "3.6.0",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.0-rc4';
+export const CARD_VERSION = '3.6.0';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.

--- a/src/wind-flow-overlay.ts
+++ b/src/wind-flow-overlay.ts
@@ -65,13 +65,15 @@ const TRAIL_LENGTH = 60;
 // ~20 sec ("ghost ribbons") and the constant per-pixel particle density
 // (which at z3 covers a continental area) painted the whole canvas in
 // uniform streaks. The slope is calibrated so f(z4) ≈ 0.23 (down ~30%
-// from a flat-1.0 baseline at low zoom) and f(z10) ≈ 1.08 (up ~30% at
-// high zoom — denser, more vibrant streaks at city level). Below LOW
-// returns LOW; above REFERENCE returns the high cap.
+// from a flat-1.0 baseline at low zoom) and plateaus at f(z8) = 0.80.
+// Above z8 the multiplier stays at HIGH_ZOOM_DETAIL_MULT — going further
+// (we used to ramp to 1.37 at z12) made high-zoom views over-painted vs
+// what z8 had been visually calibrated to. Below LOW returns LOW; above
+// REFERENCE returns the high cap.
 const LOW_ZOOM_DETAIL_MULT = 0.09;
-const HIGH_ZOOM_DETAIL_MULT = 1.37;
+const HIGH_ZOOM_DETAIL_MULT = 0.80;
 const LOW_DETAIL_ZOOM = 3;
-const REFERENCE_DETAIL_ZOOM = 12;
+const REFERENCE_DETAIL_ZOOM = 8;
 // Visual speed exaggeration, zoom-aware. The naive constant-pixel-speed
 // path made low zoom look much faster than high zoom: at z=4 a 10 m/s wind
 // raced across the continent each second; at z=12 it crawled. We compute
@@ -80,13 +82,16 @@ const REFERENCE_DETAIL_ZOOM = 12;
 //
 // Calibration: at zoom 8 / lat 50, pxPerMeter ≈ 0.00255 → 0.1 px/(m/s)/frame
 // puts a 10 m/s wind at ~3 px/sec there, which reads as gentle drift across
-// city-region zooms. Cap on top zoom keeps particles from flying off-screen
-// at street level. Floor keeps continental views perceptible — combined
-// with the streak-length compensation below, even floored speeds render
-// as visibly drifting ribbons.
+// city-region zooms. MAX is set to the z8 reference value — above z8 we
+// plateau pixel velocity, which means streak length (= TRAIL_LENGTH × velocity)
+// also plateaus, matching the corresponding density cap on _zoomDetailMultiplier.
+// Higher zooms still show finer wind detail (smaller bbox → finer grid samples)
+// but the streaks themselves stay calibrated to z8's "comfortable" length.
+// Floor keeps continental views perceptible — combined with the streak-length
+// compensation below, even floored speeds render as visibly drifting ribbons.
 const REFERENCE_PX_PER_M = 0.00255;
 const REFERENCE_PX_PER_MPS_PER_FRAME = 0.1;
-const MAX_PX_PER_MPS_PER_FRAME = 0.3;
+const MAX_PX_PER_MPS_PER_FRAME = 0.1;
 const MIN_PX_PER_MPS_PER_FRAME = 0.01;
 // Refresh anchored to the top of each clock hour. Our "current" time is
 // already hour-bucketed (Math.trunc(timeMs / 3_600_000)), so the displayed


### PR DESCRIPTION
## Summary

3.6.0 stable. Consolidates the 3.6 alpha + beta + rc line:

- **Lightning overlay** (alpha1) — Blitzortung-driven strike rendering
- **DWD wind overlay** (beta1, refined through rc4) — barbs, arrows, animated streamlines; available regardless of `data_source`
- **Bulk WCS GetCoverage architecture** (beta2) — ~100× fewer HTTP requests per refresh than the alpha line
- **DWD coverage-mask cross-fade pulse fix** (alpha4, by @genericJE)
- Static-frame radar mode, NWS lex paint order, theme variables, edit-mode regression fix, dateline wrap, marker layering, z8+ density/length plateau, full streamline tuning pass.

Full release notes draft at `/tmp/wrc-release/3.6.0-notes.md`.

## Test plan

- [x] Lint clean
- [x] 403/403 tests pass
- [x] Rollup build succeeds
- [x] rc4 baked in user's testbed without surfacing additional issues
- [x] z8 plateau fix verified live in browser at z9-z12

🤖 Generated with [Claude Code](https://claude.com/claude-code)