### PR TITLE
fix(radar): clear ghost trails of stacked frames during initial load

### DIFF
--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -1153,6 +1153,15 @@ export class RadarPlayer {
             // A new older frame was prepended; shift _currentSlot to keep the
             // same frame (newest) showing — the running timer continues unaffected.
             this._currentSlot++;
+            // _prev1Slot is also an index into _loadedSlots, and that array
+            // just grew at the front, so the previously shown slot is now
+            // one step up. Without this shift the next _showSlot tries to
+            // fade out the wrong layer (the freshly loaded one, already at
+            // 0) and the previously visible frame stays orphaned at active
+            // opacity until the loop wraps to slot 0, where snap mode
+            // resets every other layer. That's the ghost trail of stacked
+            // frames visible while later frames are still loading.
+            if (this._prev1Slot >= 0) this._prev1Slot++;
           } else {
             // Two frames ready: start the loop at the newest slot.
             this._startLoop(this._loadedSlots.length - 1);


### PR DESCRIPTION
While the card is still fetching frames on initial load, the playback shows a growing trail of overlapping past frames stacked under the current one. Small rain cells look smeared until the loop completes a full cycle and wraps back to slot 0.

The cause is in `_initRadar`'s per frame loop. When a new older frame finishes loading and is unshifted to `_loadedSlots`, `_currentSlot` is bumped so the same physical frame keeps showing as the array grows at the front. The matching bump for `_prev1Slot` was missing, so on the next tick `_showSlot` fades out the wrong layer (the freshly loaded one, already at opacity 0) and the actually visible previous frame stays orphaned at active opacity. The orphan only clears once the loop wraps to slot 0, where snap mode resets every other layer.

Bumping `_prev1Slot` alongside `_currentSlot` keeps both indices pointing at the same physical frames as `_loadedSlots` grows. No behaviour change in steady state.

Verified on a live deployment by sampling layer opacity during initial load and mid playback. Before the fix: multiple radar tile layers at opacity 1 piled up. After: exactly one radar layer at opacity 1 plus at most one cushion mid crossfade, everything else at 0. The full vitest suite (370 tests) still passes.