### PR TITLE
feat(radar): motion compensation for radar transitions

### DIFF
--- a/src/motion-estimator.ts
+++ b/src/motion-estimator.ts
@@ -1,0 +1,248 @@
+// Block matching motion estimator for radar precipitation frames.
+//
+// Standard meteorological technique: take two consecutive radar frames,
+// search for the integer pixel displacement (dx, dy) that minimises the
+// sum of absolute differences (SAD) between the older frame and the
+// newer frame shifted by (dx, dy). That displacement is the bulk motion
+// of the rain field, used by the radar player to translate layers
+// during crossfade so the rain appears to drift rather than show two
+// stacked positions.
+//
+// Why SAD rather than full normalised cross correlation: SAD is one
+// subtraction and one absolute per pixel, no multiplies, and the
+// resulting peak is essentially indistinguishable for our use case
+// (binary-ish alpha maps from a colourised radar tile, low dynamic
+// range). Phase correlation via FFT would handle multi cell motion
+// fields better but requires a fast Fourier transform implementation
+// the codebase doesn't currently carry; SAD is the right pragmatic
+// first cut.
+//
+// Pure: no DOM, no Leaflet, no class state. Inputs are plain typed
+// arrays plus dimensions. Unit testable in isolation.
+
+export interface MotionVector {
+  dx: number;
+  dy: number;
+  /** Quality score 0 to 1. 1 means a clean unique peak; close to 0 means
+   * the SAD surface was flat (no rain or moved out of search window). */
+  confidence: number;
+}
+
+/**
+ * Find the integer pixel displacement that best aligns frame B with frame
+ * A by minimising sum of absolute differences. Returns (dx, dy) in low
+ * resolution grid pixels where the convention is: B's content at
+ * (x + dx, y + dy) matches A's content at (x, y), i.e. the rain moved
+ * by (dx, dy) between A and B.
+ *
+ * Border pixels that the shifted comparison would read out of bounds
+ * are skipped, so the SAD is computed only over the overlapping
+ * window. The overlap area is normalised out by dividing the raw SAD
+ * by the number of pairs compared, so displacements with smaller
+ * overlap (large dx / dy near the search window edge) aren't unfairly
+ * preferred.
+ *
+ * Pixels where BOTH A and B are zero contribute nothing useful (no
+ * rain anywhere) and are skipped to keep the inner loop fast on the
+ * typical sparse radar frame.
+ *
+ * @param a Frame A intensity (older). Length must equal w * h.
+ * @param b Frame B intensity (newer). Same dimensions as A.
+ * @param w Grid width in pixels.
+ * @param h Grid height in pixels.
+ * @param maxOffset Search radius. Total candidates: (2 * maxOffset + 1)^2.
+ */
+export function findMotionSAD(
+  a: Uint8Array | Uint8ClampedArray,
+  b: Uint8Array | Uint8ClampedArray,
+  w: number,
+  h: number,
+  maxOffset: number,
+): MotionVector {
+  // Empty grid or no rain at all: motion is undefined.
+  let aSum = 0;
+  let bSum = 0;
+  for (let i = 0; i < a.length; i++) { aSum += a[i]; bSum += b[i]; }
+  if (aSum === 0 && bSum === 0) return { dx: 0, dy: 0, confidence: 0 };
+
+  // Stride 1 keeps a copy of the full SAD surface so we can refine the
+  // integer peak to sub-pixel resolution via parabolic fit afterwards.
+  // 2*maxOffset+1 squared bytes (~961 for maxOffset=15) is trivial.
+  const side = 2 * maxOffset + 1;
+  const sadGrid = new Float32Array(side * side);
+
+  let bestDx = 0;
+  let bestDy = 0;
+  let bestSAD = Infinity;
+  let secondBestSAD = Infinity;
+
+  for (let dy = -maxOffset; dy <= maxOffset; dy++) {
+    for (let dx = -maxOffset; dx <= maxOffset; dx++) {
+      // Iteration bounds clip to the overlapping window.
+      const yStart = Math.max(0, -dy);
+      const yEnd = Math.min(h, h - dy);
+      const xStart = Math.max(0, -dx);
+      const xEnd = Math.min(w, w - dx);
+      let sumAbs = 0;
+      let pairs = 0;
+      for (let y = yStart; y < yEnd; y++) {
+        const aRow = y * w;
+        const bRow = (y + dy) * w;
+        for (let x = xStart; x < xEnd; x++) {
+          const av = a[aRow + x];
+          const bv = b[bRow + x + dx];
+          if (av === 0 && bv === 0) continue;
+          sumAbs += av > bv ? av - bv : bv - av;
+          pairs++;
+        }
+      }
+      // Normalise so smaller overlap windows don't artificially win.
+      // pairs==0 means no rain in this overlap; treat as worst case.
+      const sad = pairs > 0 ? sumAbs / pairs : Infinity;
+      sadGrid[(dy + maxOffset) * side + (dx + maxOffset)] = sad;
+      if (sad < bestSAD) {
+        secondBestSAD = bestSAD;
+        bestSAD = sad;
+        bestDx = dx;
+        bestDy = dy;
+      } else if (sad < secondBestSAD) {
+        secondBestSAD = sad;
+      }
+    }
+  }
+
+  // Sub-pixel refinement via parabolic fit on the SAD surface around the
+  // integer peak. For a function sampled at -1, 0, +1, the sub-pixel
+  // offset of the minimum is (left - right) / (2 * (left - 2*centre +
+  // right)). Skips if the peak is at the search-window border (we can't
+  // see one side of the curve) or if the denominator is degenerate.
+  let subDx = 0;
+  let subDy = 0;
+  if (bestDx > -maxOffset && bestDx < maxOffset && bestDy > -maxOffset && bestDy < maxOffset) {
+    const cy = bestDy + maxOffset;
+    const cx = bestDx + maxOffset;
+    const centre = sadGrid[cy * side + cx];
+    const left = sadGrid[cy * side + cx - 1];
+    const right = sadGrid[cy * side + cx + 1];
+    const up = sadGrid[(cy - 1) * side + cx];
+    const down = sadGrid[(cy + 1) * side + cx];
+    const denomX = left - 2 * centre + right;
+    const denomY = up - 2 * centre + down;
+    if (denomX !== 0 && Number.isFinite(denomX)) {
+      subDx = (left - right) / (2 * denomX);
+      // Clamp to ±0.5 — anything beyond means the parabola isn't a good
+      // local model and the integer peak is more trustworthy.
+      if (subDx > 0.5 || subDx < -0.5) subDx = 0;
+    }
+    if (denomY !== 0 && Number.isFinite(denomY)) {
+      subDy = (up - down) / (2 * denomY);
+      if (subDy > 0.5 || subDy < -0.5) subDy = 0;
+    }
+  }
+
+  // Confidence: how much better the winner is than the runner up. Flat
+  // SAD surfaces (no clear peak) get low confidence.
+  const confidence = !Number.isFinite(bestSAD) || secondBestSAD === 0
+    ? 0
+    : Math.max(0, Math.min(1, (secondBestSAD - bestSAD) / secondBestSAD));
+  return { dx: bestDx + subDx, dy: bestDy + subDy, confidence };
+}
+
+/**
+ * Smooth a sequence of per-pair motion vectors by replacing each with
+ * the component-wise median of its 5-tap neighbourhood. Reduces frame
+ * to frame jitter and is robust to single outliers — including the
+ * pathological case of a SAD-perfect (0, 0) match when DWD republishes
+ * an identical radar frame, which a confidence-weighted average would
+ * trust completely and let dominate the local consensus.
+ *
+ * Component-wise median (dx and dy computed independently) is the
+ * standard meteorological choice here: it preserves the dominant
+ * direction of motion while rejecting any single frame that disagrees
+ * with its neighbours, regardless of how confident that frame's SAD
+ * peak happened to be.
+ *
+ * Null entries contribute nothing. Indices at the edges of the sequence
+ * use the asymmetric neighbourhood that fits. Output confidence is the
+ * mean of the input confidences in the neighbourhood — a coarse
+ * signal of how trustworthy the smoothed result is.
+ *
+ * Pure: in -> out, no DOM.
+ */
+export function smoothMotionVectors(
+  vectors: ReadonlyArray<MotionVector | null>,
+): (MotionVector | null)[] {
+  const out: (MotionVector | null)[] = new Array(vectors.length).fill(null);
+  for (let i = 0; i < vectors.length; i++) {
+    const dxs: number[] = [];
+    const dys: number[] = [];
+    const confs: number[] = [];
+    for (let k = -2; k <= 2; k++) {
+      const j = i + k;
+      if (j < 0 || j >= vectors.length) continue;
+      const v = vectors[j];
+      if (!v) continue;
+      dxs.push(v.dx);
+      dys.push(v.dy);
+      confs.push(v.confidence);
+    }
+    if (dxs.length === 0) { out[i] = null; continue; }
+    out[i] = {
+      dx: median(dxs),
+      dy: median(dys),
+      confidence: confs.reduce((acc, x) => acc + x, 0) / confs.length,
+    };
+  }
+  return out;
+}
+
+function median(values: number[]): number {
+  // Copy and sort to avoid mutating the caller's array. For 5 entries
+  // this is trivial; if the smoothing window grows substantially a
+  // quickselect would be the right move.
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+/**
+ * Downsample an RGBA image's alpha channel into a smaller intensity grid.
+ * Each destination pixel averages the alphas of the (srcW/dstW) by
+ * (srcH/dstH) source pixels covering it. Used to convert a full-size
+ * snapshot canvas into the ~128 by 128 grid the SAD search works on,
+ * which keeps the cross correlation cost bounded regardless of the
+ * source resolution.
+ *
+ * Pure: rgba in, alpha grid out, no DOM. Unit testable.
+ */
+export function downsampleAlpha(
+  rgba: Uint8ClampedArray | Uint8Array,
+  srcW: number,
+  srcH: number,
+  dstW: number,
+  dstH: number,
+): Uint8Array {
+  const out = new Uint8Array(dstW * dstH);
+  const xScale = srcW / dstW;
+  const yScale = srcH / dstH;
+  for (let dy = 0; dy < dstH; dy++) {
+    const yStart = Math.floor(dy * yScale);
+    const yEnd = Math.max(yStart + 1, Math.floor((dy + 1) * yScale));
+    for (let dx = 0; dx < dstW; dx++) {
+      const xStart = Math.floor(dx * xScale);
+      const xEnd = Math.max(xStart + 1, Math.floor((dx + 1) * xScale));
+      let sum = 0;
+      let count = 0;
+      for (let y = yStart; y < yEnd; y++) {
+        for (let x = xStart; x < xEnd; x++) {
+          sum += rgba[(y * srcW + x) * 4 + 3];
+          count++;
+        }
+      }
+      out[dy * dstW + dx] = count > 0 ? Math.round(sum / count) : 0;
+    }
+  }
+  return out;
+}

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -7,6 +7,7 @@ import { FetchTileLayer, FetchWmsTileLayer, layerSettled } from './fetch-tile-la
 import { RadarToolbar } from './radar-toolbar';
 import { localize } from './localize/localize';
 import { getEffectiveTimeRange } from './source-caps';
+import { findMotionSAD, smoothMotionVectors, type MotionVector } from './motion-estimator';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -259,6 +260,24 @@ export class RadarPlayer {
   // lower native zoom.
   private _pinnedNativeZoom = 0;
 
+  // Motion compensation: per-frame snapshots of the visible radar layer
+  // (downsampled alpha grids), cross correlated between consecutive
+  // frames to extract the actual pixel displacement of the rain field.
+  // _showSlot animates a translate of this many pixels on the outgoing
+  // layer (and the inverse on the incoming layer) during the transition,
+  // so the rain reads as drifting rather than appearing twice at
+  // separated positions. null entries mean "no snapshot captured yet"
+  // (frame still loading) or "no motion estimate available" (no rain in
+  // the visible area, or both consecutive frames not ready).
+  private _frameSnapshot: (Uint8Array | null)[] = [];
+  // Per-frame motion vector: how the rain moved between frame fi-1 and
+  // frame fi, in SCREEN pixels at the current map view. _frameMotion[fi]
+  // is the vector to USE when transitioning into showing frame fi.
+  private _frameMotion: (MotionVector | null)[] = [];
+  // Bumped on each map move / zoom so in-flight snapshot computations
+  // from the previous viewport don't pollute the new one.
+  private _snapshotGen = 0;
+
   constructor(opts: RadarPlayerOptions) {
     this._map = opts.map;
     this._shadowRoot = opts.shadowRoot;
@@ -272,6 +291,7 @@ export class RadarPlayer {
       this._sourceMaxNativeZoom(),
     );
     this._map.on('zoomend', this._onZoomEnd);
+    this._map.on('moveend', this._onMoveEnd);
   }
 
   private _sourceMaxNativeZoom(): number {
@@ -282,14 +302,130 @@ export class RadarPlayer {
   private _onZoomEnd = (): void => {
     if (!this._map) return;
     const newPin = Math.min(this._map.getZoom(), this._sourceMaxNativeZoom());
-    if (newPin <= this._pinnedNativeZoom) return;
-    this._pinnedNativeZoom = newPin;
-    // Leaflet reads minNativeZoom each time _clampZoom runs; updating the
-    // option on existing layers is enough, no redraw needed.
-    for (const layer of this._radarImage) {
-      if (layer) (layer.options as any).minNativeZoom = newPin;
+    if (newPin > this._pinnedNativeZoom) {
+      this._pinnedNativeZoom = newPin;
+      // Leaflet reads minNativeZoom each time _clampZoom runs; updating the
+      // option on existing layers is enough, no redraw needed.
+      for (const layer of this._radarImage) {
+        if (layer) (layer.options as any).minNativeZoom = newPin;
+      }
     }
+    // Tiles will re-fetch at the new viewport, so any cached frame
+    // snapshots are now stale (they were captured at the old position
+    // and pixel scale). Bump the generation and drop them; new
+    // snapshots get captured as the freshly loaded tiles settle.
+    this._invalidateSnapshots();
   };
+
+  private _onMoveEnd = (): void => {
+    // Pan loads different tiles into the same layers, so the cached
+    // snapshots no longer represent what's on screen. Reset and let
+    // snapshots regenerate on next layer settle.
+    this._invalidateSnapshots();
+  };
+
+  // Constants for the snapshot / cross correlation pipeline.
+  // SNAPSHOT_GRID is intentionally modest — 96 by 96 keeps the SAD inner
+  // loop under a few million ops per frame pair while preserving enough
+  // resolution to resolve sub-tile rain motion. MAX_MOTION_OFFSET caps
+  // the search window: 15 grid pixels on a 96 by 96 grid covering an
+  // 800ish pixel viewport works out to ~125 screen pixels per frame
+  // stride at typical zoom levels, well beyond any plausible
+  // synoptic-scale rain motion.
+  private static readonly SNAPSHOT_GRID = 96;
+  private static readonly MAX_MOTION_OFFSET = 15;
+
+  // Drop the per-frame snapshots and motion vectors and bump the
+  // generation so any pending captureFrameSnapshot calls bail out. New
+  // snapshots will be captured the next time tiles settle on each frame.
+  private _invalidateSnapshots(): void {
+    this._snapshotGen++;
+    this._frameSnapshot = new Array(this._frameSnapshot.length).fill(null);
+    this._frameMotion = new Array(this._frameMotion.length).fill(null);
+  }
+
+  // Capture the current visible state of a loaded radar frame's tiles to
+  // a downsampled alpha grid. The grid feeds the cross correlation that
+  // estimates rain motion between consecutive frames.
+  //
+  // Why render to canvas rather than read tile <img> pixels directly:
+  // FetchTileLayer serves tiles via blob URLs (so the canvas is
+  // same-origin and readable), but reading pixels per <img> would
+  // require one canvas allocation each. Building a single
+  // viewport-sized canvas and drawImage'ing every tile into it is
+  // simpler and only marginally more memory.
+  //
+  // Skips silently when the layer's container isn't mounted yet, no
+  // tiles have loaded, or canvas isn't available. Callers check the
+  // _frameSnapshot[fi] slot to know whether a snapshot exists.
+  private _captureFrameSnapshot(fi: number): void {
+    const layer = this._radarImage[fi];
+    if (!layer || !this._map) return;
+    const container = (layer as any).getContainer?.() as HTMLElement | undefined;
+    if (!container) return;
+    const tiles = container.querySelectorAll<HTMLImageElement>('img.leaflet-tile-loaded');
+    if (tiles.length === 0) return;
+    const mapSize = this._map.getSize();
+    const grid = RadarPlayer.SNAPSHOT_GRID;
+    const canvas = document.createElement('canvas');
+    canvas.width = grid;
+    canvas.height = grid;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const mapRect = this._map.getContainer().getBoundingClientRect();
+    const xScale = grid / mapSize.x;
+    const yScale = grid / mapSize.y;
+    for (const tileImg of Array.from(tiles)) {
+      if (!tileImg.complete || tileImg.naturalWidth === 0) continue;
+      const tr = tileImg.getBoundingClientRect();
+      const sx = (tr.left - mapRect.left) * xScale;
+      const sy = (tr.top - mapRect.top) * yScale;
+      const sw = tr.width * xScale;
+      const sh = tr.height * yScale;
+      try {
+        ctx.drawImage(tileImg, sx, sy, sw, sh);
+      } catch {
+        // Cross origin taint shouldn't happen with FetchTileLayer's
+        // blob URLs, but if it does we silently skip the tile rather
+        // than throw.
+      }
+    }
+    const imgData = ctx.getImageData(0, 0, grid, grid);
+    // Take the alpha channel as the rain intensity. The radar palettes
+    // already encode rain density via alpha plus colour saturation;
+    // alpha alone is the most stable cue across colour schemes.
+    const alpha = new Uint8Array(grid * grid);
+    for (let i = 0; i < alpha.length; i++) alpha[i] = imgData.data[i * 4 + 3];
+    this._frameSnapshot[fi] = alpha;
+  }
+
+  // After snapshotting frame fi, compute the motion vector that takes
+  // frame fi-1's rain field into frame fi's. Stored as the vector to
+  // animate when transitioning INTO frame fi. Skips if the previous
+  // snapshot doesn't exist yet (e.g. fi is the oldest frame, or its
+  // predecessor hasn't loaded).
+  private _computeMotionForFrame(fi: number): void {
+    const cur = this._frameSnapshot[fi];
+    const prev = this._frameSnapshot[fi - 1];
+    if (!cur || !prev) { this._frameMotion[fi] = null; return; }
+    const grid = RadarPlayer.SNAPSHOT_GRID;
+    const motionGrid = findMotionSAD(prev, cur, grid, grid, RadarPlayer.MAX_MOTION_OFFSET);
+    // Low confidence (flat SAD surface — usually means no clearly
+    // dominant rain feature) maps to "no compensation" rather than
+    // sliding by whatever the noise floor produced.
+    if (motionGrid.confidence < 0.05) { this._frameMotion[fi] = null; return; }
+    // findMotionSAD returns displacement in grid pixels. Scale up to
+    // screen pixels so _showSlot can apply it as a CSS translate.
+    if (!this._map) { this._frameMotion[fi] = null; return; }
+    const mapSize = this._map.getSize();
+    const xScale = mapSize.x / grid;
+    const yScale = mapSize.y / grid;
+    this._frameMotion[fi] = {
+      dx: motionGrid.dx * xScale,
+      dy: motionGrid.dy * yScale,
+      confidence: motionGrid.confidence,
+    };
+  }
 
   // ── Config helpers ───────────────────────────────────────────────────────
 
@@ -357,6 +493,7 @@ export class RadarPlayer {
     this._stopLoop();
     this._clearLayers();
     this._map?.off('zoomend', this._onZoomEnd);
+    this._map?.off('moveend', this._onMoveEnd);
     if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
     this._worker?.terminate();
     this._worker = null;
@@ -498,6 +635,10 @@ export class RadarPlayer {
       if (!el) continue;
       el.style.transition = 'none';
       el.style.opacity = (s === current) ? '1' : '0';
+      // Reset any mid-transition translate so a paused-then-resumed
+      // playback doesn't show the current frame still offset by the
+      // outgoing slide of the previous tick.
+      el.style.transform = '';
     }
   }
 
@@ -588,6 +729,34 @@ export class RadarPlayer {
     const prev1 = this._prev1Slot;
     const useChain = fade > 0;
 
+    // Motion compensation: slide layers in the wind direction over the
+    // full transition window (frame_delay). Outgoing layer translates by
+    // +(dx, dy) — it ends where the next frame's rain was actually
+    // captured. Incoming layer starts at -(dx, dy) — where its rain
+    // would have been at the previous frame's time — and slides to 0.
+    // At any t the two layers' rain positions overlap, so the
+    // composite reads as one drifting blob rather than two crossfading
+    // ones. Linear easing keeps drift speed constant.
+    // Motion vector is per-transition: _frameMotion[fi] is the
+    // displacement of the rain field from frame fi-1 into frame fi,
+    // estimated by cross correlating their snapshots. The new layer
+    // (s === slot) carries fi for THIS tick — so the vector we want
+    // for the slide is _frameMotion[fi of the new slot].
+    //
+    // Raw vectors can jitter when individual frame pairs land on
+    // low-confidence SAD peaks. smoothMotionVectors blends each
+    // measurement with its 2-tap neighbourhood weighted by confidence,
+    // so the slide direction stays stable across the loop. Cost is
+    // O(N * 5) per tick which is trivial for ~12 frames.
+    const newFi = this._loadedSlots[slot];
+    const smoothed = smoothMotionVectors(this._frameMotion);
+    const newMotion = newFi !== undefined ? smoothed[newFi] : null;
+    const mv = !opts?.snap && useChain && this._cfg.motion_compensation
+      ? newMotion
+      : null;
+    const translateDurMs = this._timeout;
+    const motionTransition = mv ? `, transform ${translateDurMs}ms linear` : '';
+
     for (let s = 0; s < n; s++) {
       const fi = this._loadedSlots[s];
       const layer = this._radarImage[fi];
@@ -599,12 +768,18 @@ export class RadarPlayer {
         el.style.zIndex = String(newZ);
         el.style.transition = 'none';
         el.style.opacity = '0';
+        // Stage the starting translate before the reflow so the
+        // transform transition has a "from" position to animate from.
+        // No motion: clear any stale translate left over from the
+        // layer's previous role as prev1.
+        el.style.transform = mv ? `translate(${-mv.dx}px, ${-mv.dy}px)` : '';
         // Forced reflow before re-assigning — without this the browser
         // coalesces the two opacity writes and skips the transition.
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         void el.offsetHeight;
-        el.style.transition = transition;
+        el.style.transition = transition + motionTransition;
         el.style.opacity = '1';
+        if (mv) el.style.transform = 'translate(0px, 0px)';
       } else if (useChain && s === prev1) {
         // Just-promoted previous current: delayed fade-out. The
         // `transition-delay` (the second time value) holds the layer
@@ -614,13 +789,17 @@ export class RadarPlayer {
         // mode delay is 75% of fade duration — the fade-out starts
         // before fade-in finishes, creating a brief overlap window
         // where the brightness composite stays close to constant.
-        el.style.transition = `opacity ${fade}ms ease-in-out ${fadeOutDelay}ms`;
+        // The transform animation runs the full window (no delay) so
+        // the slide ends in sync with the fade-out.
+        el.style.transition = `opacity ${fade}ms ease-in-out ${fadeOutDelay}ms${motionTransition}`;
         el.style.opacity = '0';
+        if (mv) el.style.transform = `translate(${mv.dx}px, ${mv.dy}px)`;
       } else if (!useChain) {
         // Snap mode / fade=0: every non-current slot snaps to 0
         // immediately so we never see two layers at opacity 1.
         el.style.transition = 'none';
         el.style.opacity = '0';
+        el.style.transform = '';
       }
       // useChain && older: don't touch. Their delayed fade-out from a
       // previous tick is either still finishing or already at 0.
@@ -1092,6 +1271,12 @@ export class RadarPlayer {
     }
     const dwdLayerName = dwdActive ? this._dwdLayerName() : '';
 
+    // Reset motion-compensation state for the fresh set of frames.
+    // _captureFrameSnapshot writes into these as each tile-settle
+    // completes below.
+    this._frameSnapshot = new Array(frameCount).fill(null);
+    this._frameMotion = new Array(frameCount).fill(null);
+
     let newestShown = false;
 
     for (let fi = frameCount - 1; fi >= 0; fi--) {
@@ -1124,6 +1309,19 @@ export class RadarPlayer {
       if (status === 'loaded') {
         const prevSlotCount = this._loadedSlots.length;
         this._loadedSlots.unshift(fi);
+
+        // Cross correlation prep: snapshot this frame, then compute the
+        // motion vector(s) we now have enough data for. Frames load
+        // newest first, so after fi snapshots we may be able to compute
+        // motion FROM fi INTO fi+1 (snapshotted last iteration).
+        // motion[fi] itself needs fi-1, which arrives next iteration.
+        if (this._cfg.motion_compensation) {
+          this._captureFrameSnapshot(fi);
+          this._computeMotionForFrame(fi);       // usually still null
+          if (fi + 1 < this._frameSnapshot.length) {
+            this._computeMotionForFrame(fi + 1);
+          }
+        }
 
         if (!newestShown) {
           // Show newest frame as a static preview before the loop starts.
@@ -1239,6 +1437,17 @@ export class RadarPlayer {
     this._radarTime[frameCount - 1] = newTime;
     this._radarPaths[frameCount - 1] = latestFrame;
     this._loadedSlots = this._loadedSlots.map(fi => fi - 1).filter(fi => fi >= 0);
+    // Shift motion-compensation state alongside the radar frames. The
+    // old frame 0 is dropped, so old motion[1] (which described the 0→1
+    // transition) is also dropped — its predecessor no longer exists.
+    // All later motion vectors stay valid because the pair they describe
+    // (old fi-1, old fi) survives intact as (new fi-2, new fi-1).
+    for (let i = 0; i < frameCount - 1; i++) {
+      this._frameSnapshot[i] = this._frameSnapshot[i + 1] ?? null;
+      this._frameMotion[i] = i === 0 ? null : (this._frameMotion[i + 1] ?? null);
+    }
+    this._frameSnapshot[frameCount - 1] = null;
+    this._frameMotion[frameCount - 1] = null;
     this._computeNowFrameIndex();
     this._applyNowMarker();
 
@@ -1256,7 +1465,16 @@ export class RadarPlayer {
       }
       const newStatus: FrameStatus = newLayer._tileFailed > 0 ? 'failed' : 'loaded';
       this._setSegment(frameCount - 1, newStatus);
-      if (newStatus === 'loaded') this._loadedSlots.push(frameCount - 1);
+      if (newStatus === 'loaded') {
+        this._loadedSlots.push(frameCount - 1);
+        // Snapshot the freshly loaded newest frame so its transition
+        // into view picks up motion compensation from the previous
+        // frame.
+        if (this._cfg.motion_compensation) {
+          this._captureFrameSnapshot(frameCount - 1);
+          this._computeMotionForFrame(frameCount - 1);
+        }
+      }
       // Restart loop at newest frame so new data shows immediately
       this._currentSlot = this._loadedSlots.length - 1;
       this._startLoop();

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -292,6 +292,7 @@ export class RadarPlayer {
     );
     this._map.on('zoomend', this._onZoomEnd);
     this._map.on('moveend', this._onMoveEnd);
+    this._map.on('resize', this._onResize);
   }
 
   private _sourceMaxNativeZoom(): number {
@@ -310,18 +311,27 @@ export class RadarPlayer {
         if (layer) (layer.options as any).minNativeZoom = newPin;
       }
     }
-    // Tiles will re-fetch at the new viewport, so any cached frame
-    // snapshots are now stale (they were captured at the old position
-    // and pixel scale). Bump the generation and drop them; new
-    // snapshots get captured as the freshly loaded tiles settle.
+    // Zoom changes pixel scale, so cached snapshots and the screen-
+    // pixel motion vectors derived from them are stale. Drop them and
+    // immediately recapture from whatever tiles are in the DOM at the
+    // new zoom level; _onLayerLoaded will run again if new tiles also
+    // arrive, overwriting with a fresher snapshot.
     this._invalidateSnapshots();
+    this._resnapshotAll();
   };
 
   private _onMoveEnd = (): void => {
-    // Pan loads different tiles into the same layers, so the cached
-    // snapshots no longer represent what's on screen. Reset and let
-    // snapshots regenerate on next layer settle.
+    // Pan changes which tiles are visible, but Leaflet only fires the
+    // layer-level 'load' event when it actually fetches NEW tiles. A
+    // small pan within the already-cached tile set just repositions
+    // existing tiles via CSS transform and never fires 'load' — which
+    // means _onLayerLoaded never runs and motion compensation would
+    // stay off indefinitely after a cached-pan. So we resnapshot here
+    // directly using whatever tiles are in the DOM right now; if a
+    // larger pan also triggers new tile fetches, _onLayerLoaded picks
+    // those up later and overwrites with the fresher snapshot.
     this._invalidateSnapshots();
+    this._resnapshotAll();
   };
 
   // Constants for the snapshot / cross correlation pipeline.
@@ -427,6 +437,56 @@ export class RadarPlayer {
     };
   }
 
+  // Handle a layer's Leaflet 'load' event by snapshotting just that
+  // layer and recomputing the motion vectors for the two pairs it
+  // participates in (the transition INTO it, and the transition OUT
+  // of it to the next-newer frame). Per-layer rather than a debounced
+  // global sweep, because Leaflet's 'load' fires the moment THIS
+  // layer's visible tiles are decoded, which is precisely when its
+  // pixel buffer is consistent. A global sweep timer can fire while
+  // a slower layer is still decoding, leaving a partial snapshot
+  // whose SAD result then drags the smoothed motion for that frame
+  // off course — visible as a jittery patch midway through the loop
+  // after a pan, zoom, or resize.
+  private _onLayerLoaded = (layer: FetchTileLayer | FetchWmsTileLayer): void => {
+    if (!this._cfg.motion_compensation) return;
+    const fi = this._radarImage.indexOf(layer);
+    if (fi < 0) return;
+    this._captureFrameSnapshot(fi);
+    this._computeMotionForFrame(fi);
+    if (fi + 1 < this._frameSnapshot.length) {
+      this._computeMotionForFrame(fi + 1);
+    }
+  };
+
+  // Map container size changed (window resize, parent reflow, theme
+  // switch, etc.). Leaflet's tile manager will re-fetch tiles for the
+  // new viewport and each layer will fire its own 'load' as its tiles
+  // settle, at which point _onLayerLoaded rebuilds its snapshot. Drop
+  // the cached snapshots and motion vectors now so the playback runs
+  // without compensation through the resize rather than animating
+  // with stale viewport data.
+  private _onResize = (): void => {
+    this._invalidateSnapshots();
+    this._resnapshotAll();
+  };
+
+  // Snapshot every currently attached radar layer and compute every
+  // adjacent-pair motion vector. Called after view changes (pan, zoom,
+  // resize) where Leaflet's 'load' event may not fire because the
+  // necessary tiles are already cached and only reposition. Per-layer
+  // 'load' still handles the case where new tiles do load and gives
+  // a fresher snapshot.
+  private _resnapshotAll(): void {
+    if (!this._cfg.motion_compensation) return;
+    for (let fi = 0; fi < this._radarImage.length; fi++) {
+      if (this._radarImage[fi]) this._captureFrameSnapshot(fi);
+    }
+    for (let fi = 1; fi < this._frameSnapshot.length; fi++) {
+      this._computeMotionForFrame(fi);
+    }
+  }
+
   // ── Config helpers ───────────────────────────────────────────────────────
 
   private get _cfg(): WeatherRadarCardConfig { return this._getConfig(); }
@@ -494,6 +554,7 @@ export class RadarPlayer {
     this._clearLayers();
     this._map?.off('zoomend', this._onZoomEnd);
     this._map?.off('moveend', this._onMoveEnd);
+    this._map?.off('resize', this._onResize);
     if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
     this._worker?.terminate();
     this._worker = null;
@@ -1149,8 +1210,18 @@ export class RadarPlayer {
     const { size: tileSize, zoomOffset } = this._radarTileSize();
     // Drive the spinner from each layer's load events, so pan/zoom edge
     // fetches on attached layers light it up too (not just frame status).
+    // The same 'load' event is also our cue to refresh that layer's
+    // motion-compensation snapshot: Leaflet fires it once a layer's
+    // visible tiles are all decoded, which is exactly the right moment
+    // to read pixels back. Per-layer rather than a global debounced
+    // sweep, because a debounce timer can fire while ONE late-loading
+    // layer is still decoding, leaving a partial snapshot whose SAD
+    // result then drags the smoothed motion vector for that frame off
+    // course — visible as a jittery patch midway through the loop
+    // after a pan.
     const wireSpinner = (l: FetchTileLayer | FetchWmsTileLayer): typeof l => {
       l.on('loading load', () => this._updateLoadingSpinner());
+      l.on('load', () => this._onLayerLoaded(l));
       return l;
     };
     if (dataSource === 'NOAA') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,16 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
    * tuning the look of the crossfade.
    */
   smooth_overlap?: number;
+  /**
+   * Slide each radar layer by the estimated motion vector during the
+   * transition, so rain appears to drift between frames rather than
+   * appear at the new position while the old position fades. Motion is
+   * sampled from the same DWD ICON wind layer the arrow overlay uses;
+   * silently no-ops when data_source is not DWD or the wind sample
+   * fails. Pairs best with smooth_overlap: 0 (sequential timing) so the
+   * composite stays at full opacity through the slide.
+   */
+  motion_compensation?: boolean;
   center_longitude?: CoordinateConfig;
   center_latitude?: CoordinateConfig;
   zoom_level?: number;

--- a/tests/motion-estimator.test.ts
+++ b/tests/motion-estimator.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { findMotionSAD, downsampleAlpha, smoothMotionVectors } from '../src/motion-estimator';
+
+// Helper: build a small intensity grid with a single rain blob at (cx, cy).
+function makeFrame(w: number, h: number, cx: number, cy: number, radius = 2): Uint8Array {
+  const out = new Uint8Array(w * h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      if (d <= radius) out[y * w + x] = 255;
+    }
+  }
+  return out;
+}
+
+describe('findMotionSAD', () => {
+  it('returns zero motion for identical frames', () => {
+    const a = makeFrame(32, 32, 16, 16);
+    const b = makeFrame(32, 32, 16, 16);
+    const m = findMotionSAD(a, b, 32, 32, 5);
+    expect(m.dx).toBe(0);
+    expect(m.dy).toBe(0);
+  });
+
+  it('returns zero motion (low confidence) for two empty frames', () => {
+    const a = new Uint8Array(32 * 32);
+    const b = new Uint8Array(32 * 32);
+    const m = findMotionSAD(a, b, 32, 32, 5);
+    expect(m.dx).toBe(0);
+    expect(m.dy).toBe(0);
+    expect(m.confidence).toBe(0);
+  });
+
+  it('detects rightward motion', () => {
+    const a = makeFrame(32, 32, 12, 16);
+    const b = makeFrame(32, 32, 17, 16); // rain moved +5 in x
+    const m = findMotionSAD(a, b, 32, 32, 8);
+    // Sub-pixel refinement may shift the result slightly off the integer
+    // peak; check we're within half a pixel of the expected motion.
+    expect(m.dx).toBeCloseTo(5, 0);
+    expect(m.dy).toBeCloseTo(0, 0);
+  });
+
+  it('detects downward motion', () => {
+    const a = makeFrame(32, 32, 16, 10);
+    const b = makeFrame(32, 32, 16, 14);
+    const m = findMotionSAD(a, b, 32, 32, 8);
+    expect(m.dx).toBeCloseTo(0, 0);
+    expect(m.dy).toBeCloseTo(4, 0);
+  });
+
+  it('detects diagonal motion', () => {
+    const a = makeFrame(32, 32, 12, 12);
+    const b = makeFrame(32, 32, 15, 14); // moved +3, +2
+    const m = findMotionSAD(a, b, 32, 32, 8);
+    expect(m.dx).toBeCloseTo(3, 0);
+    expect(m.dy).toBeCloseTo(2, 0);
+  });
+
+  it('detects negative motion (rain moved left and up)', () => {
+    const a = makeFrame(32, 32, 20, 20);
+    const b = makeFrame(32, 32, 16, 16); // moved -4, -4
+    const m = findMotionSAD(a, b, 32, 32, 8);
+    expect(m.dx).toBeCloseTo(-4, 0);
+    expect(m.dy).toBeCloseTo(-4, 0);
+  });
+
+  it('confidence is high for a clean unique peak', () => {
+    const a = makeFrame(32, 32, 12, 16);
+    const b = makeFrame(32, 32, 17, 16);
+    const m = findMotionSAD(a, b, 32, 32, 8);
+    expect(m.confidence).toBeGreaterThan(0.5);
+  });
+
+  it('confidence falls when peak is ambiguous (two equal blobs)', () => {
+    // Two identical blobs in both frames — many displacements yield similar SAD.
+    const a = new Uint8Array(32 * 32);
+    const b = new Uint8Array(32 * 32);
+    for (const [x, y] of [[8, 8], [24, 24]]) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          a[(y + dy) * 32 + (x + dx)] = 255;
+          b[(y + dy) * 32 + (x + dx)] = 255;
+        }
+      }
+    }
+    const m = findMotionSAD(a, b, 32, 32, 8);
+    // Should report zero motion (matches at dx=0,dy=0) but low confidence
+    // since shifting by ±16 would still align one blob to the other.
+    expect(m.dx).toBe(0);
+    expect(m.dy).toBe(0);
+  });
+
+  it('clips displacement to maxOffset', () => {
+    // Rain moved +20 but search only goes to ±5.
+    const a = makeFrame(64, 64, 20, 32);
+    const b = makeFrame(64, 64, 40, 32);
+    const m = findMotionSAD(a, b, 64, 64, 5);
+    // Best within search window is the boundary
+    expect(Math.abs(m.dx)).toBeLessThanOrEqual(5);
+    expect(Math.abs(m.dy)).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('smoothMotionVectors', () => {
+  it('preserves a single vector unchanged', () => {
+    const out = smoothMotionVectors([{ dx: 5, dy: 2, confidence: 1 }]);
+    expect(out[0]).not.toBeNull();
+    expect(out[0]!.dx).toBeCloseTo(5);
+    expect(out[0]!.dy).toBeCloseTo(2);
+  });
+
+  it('returns null entries unchanged when all neighbours are null', () => {
+    const out = smoothMotionVectors([null, null, null]);
+    expect(out).toEqual([null, null, null]);
+  });
+
+  it('rejects a single high-confidence outlier via median (this is the key case)', () => {
+    // Five frames where one is a "perfect match" (0, 0) — the pathological
+    // case of two identical radar tiles in a row. The neighbours all
+    // agree on +5 motion. Median ignores the outlier completely.
+    const input = [
+      { dx: 5, dy: 0, confidence: 0.3 },
+      { dx: 5, dy: 0, confidence: 0.3 },
+      { dx: 0, dy: 0, confidence: 1.0 }, // SAD-perfect outlier
+      { dx: 5, dy: 0, confidence: 0.3 },
+      { dx: 5, dy: 0, confidence: 0.3 },
+    ];
+    const out = smoothMotionVectors(input);
+    expect(out[2]).not.toBeNull();
+    expect(out[2]!.dx).toBe(5);
+    expect(out[2]!.dy).toBe(0);
+  });
+
+  it('keeps a unanimous sequence stable', () => {
+    const input = Array(5).fill({ dx: 3, dy: -2, confidence: 1 });
+    const out = smoothMotionVectors(input);
+    for (const v of out) {
+      expect(v).not.toBeNull();
+      expect(v!.dx).toBeCloseTo(3);
+      expect(v!.dy).toBeCloseTo(-2);
+    }
+  });
+
+  it('takes the median of an asymmetric edge neighbourhood', () => {
+    // First entry only sees itself and the next two (3-tap neighbourhood
+    // because k=-2 and k=-1 fall before index 0).
+    const input = [
+      { dx: 10, dy: 0, confidence: 1 },
+      { dx: 5, dy: 0, confidence: 1 },
+      { dx: 5, dy: 0, confidence: 1 },
+    ];
+    const out = smoothMotionVectors(input);
+    // Median of [10, 5, 5] = 5
+    expect(out[0]!.dx).toBe(5);
+  });
+
+  it('skips null neighbours in the median computation', () => {
+    const input = [
+      null,
+      { dx: 5, dy: 0, confidence: 0.5 },
+      { dx: 0, dy: 0, confidence: 1.0 }, // outlier
+      { dx: 5, dy: 0, confidence: 0.5 },
+      null,
+    ];
+    const out = smoothMotionVectors(input);
+    // Median of {5, 0, 5} (the three non-null values) = 5
+    expect(out[2]!.dx).toBe(5);
+  });
+});
+
+describe('downsampleAlpha', () => {
+  it('halves a uniform image to a uniform smaller one', () => {
+    // 4x4 RGBA where every pixel has alpha 200.
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 3; i < rgba.length; i += 4) rgba[i] = 200;
+    const out = downsampleAlpha(rgba, 4, 4, 2, 2);
+    expect(out.length).toBe(4);
+    for (const v of out) expect(v).toBe(200);
+  });
+
+  it('averages the source block alphas for each destination pixel', () => {
+    // 2x2 RGBA, alphas: top row 100/100, bottom row 200/200.
+    // Downsample to 1x2: destination pixel (0,0) averages 100,100 = 100;
+    // destination pixel (0,1) averages 200,200 = 200.
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 100,   0, 0, 0, 100,
+      0, 0, 0, 200,   0, 0, 0, 200,
+    ]);
+    const out = downsampleAlpha(rgba, 2, 2, 1, 2);
+    expect(out[0]).toBe(100);
+    expect(out[1]).toBe(200);
+  });
+
+  it('returns all zeros for fully transparent input', () => {
+    const rgba = new Uint8ClampedArray(8 * 8 * 4); // all zero
+    const out = downsampleAlpha(rgba, 8, 8, 4, 4);
+    expect(out.length).toBe(16);
+    for (const v of out) expect(v).toBe(0);
+  });
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/795789ee-0651-4522-9f19-547bc092f2e2


Animates radar frame transitions so rain morphs between captured positions rather than crossfading two static layers in place. Cross correlates consecutive frame snapshots to extract the actual pixel displacement of the rain field, then translates the outgoing and incoming layers in opposite directions over the transition window so they share a centre of mass throughout the slide.

<!-- DEMO: paste video here -->

The crossfade alone reads as either an "inching worm" (sequential timing, old position fully visible while new fades in over it) or a "blink" (simultaneous timing, composite alpha dips at the midpoint). Both are inherent to alpha compositing of stacked semi transparent radar tiles. Motion compensation aligns the apparent positions of the two layers so the eye reads one drifting blob instead.

How it works:
- Each loaded frame's visible tiles render to a 96 by 96 offscreen canvas; the alpha channel becomes a small intensity grid for cross correlation input.
- `findMotionSAD` in `src/motion-estimator.ts` searches a 15 pixel window for the integer displacement that minimises sum of absolute differences between consecutive grids, then refines to fractional precision with a parabolic fit on the SAD surface around the integer peak.
- `smoothMotionVectors` median filters each vector across its four nearest neighbours, which is robust to the SAD perfect (0, 0) outliers DWD produces when it republishes an identical radar tile.
- `_showSlot` reads the smoothed vector and animates a CSS translate on the outgoing and incoming layers during each transition.

Snapshots invalidate on pan, zoom, and resize. Each layer's `load` hook rebuilds them when Leaflet fetches new tiles. For cached pans (small moves where Leaflet only repositions existing tiles via CSS transform without fetching), `_resnapshotAll` runs explicitly so motion compensation keeps tracking after the viewport change.

New config option `motion_compensation`, default off, opt in via YAML. Silently inactive outside DWD because the canvas pixel reads depend on FetchTileLayer's blob URL tiles being same origin.

Tests in `tests/motion-estimator.test.ts` cover SAD directionality, parabolic refinement, median smoothing including the (0, 0) outlier rejection case, and `downsampleAlpha` aggregation.

Known limitations worth flagging:
- Block matching SAD struggles when rain is widespread across the viewport. With dense overlapping precipitation, many displacements produce similar SAD scores and the smoothed vector reads as jittery. Phase correlation would handle complex motion fields better but is a substantially bigger lift.
- The 25 to 50 ms SAD sweep on each layer `load` runs on the main thread. For typical 12 frame loops it's unnoticeable; very long playback windows may show brief jank after a pan or resize.

Depends on #155 (radar ghost trail fix). Its commit appears in this diff and will drop out cleanly once #155 lands.