### PR TITLE
feat(playback): adjustable speed via toolbar button and editor dropdown

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -424,6 +424,26 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
             @value-changed=${this._handleSelectorChanged}
           ></ha-selector>
         ` : ''}
+        <ha-selector
+          .hass=${this.hass}
+          .selector=${{
+            select: {
+              mode: 'dropdown',
+              options: [
+                { value: 0.25, label: localize('editor.animation.playback_speed_quarter') },
+                { value: 0.5,  label: localize('editor.animation.playback_speed_half') },
+                { value: 1,    label: localize('editor.animation.playback_speed_normal') },
+                { value: 2,    label: localize('editor.animation.playback_speed_double') },
+                { value: 4,    label: localize('editor.animation.playback_speed_quad') },
+              ],
+            },
+          }}
+          .value=${config.playback_speed ?? 1}
+          .label=${localize('editor.animation.playback_speed')}
+          .helper=${localize('editor.animation.playback_speed_helper')}
+          .configValue=${'playback_speed'}
+          @value-changed=${this._handleSelectorChanged}
+        ></ha-selector>
 
         <!-- APPEARANCE -->
         <h3 class="section-header">${localize('editor.section.appearance')}</h3>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -444,6 +444,15 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
           .configValue=${'playback_speed'}
           @value-changed=${this._handleSelectorChanged}
         ></ha-selector>
+        <label>
+          <ha-switch
+            .checked=${config.viewer_layer_control === true}
+            .configValue=${'viewer_layer_control'}
+            @change=${this._valueChangedSwitch}
+          ></ha-switch>
+          <span>${localize('editor.animation.viewer_layer_control')}</span>
+        </label>
+        <div class="section-description">${localize('editor.animation.viewer_layer_control_helper')}</div>
 
         <!-- APPEARANCE -->
         <h3 class="section-header">${localize('editor.section.appearance')}</h3>

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Standard: 40 % der Bildverzögerung — max: Bildverzögerung",
       "smooth_animation": "Sanfte Animation (kontinuierliche Überblendung)",
       "smooth_overlap": "Überblendungsüberlappung",
-      "smooth_overlap_helper": "Nur im Sanftmodus. 0 = sequentiell (kein Helligkeitsabfall, Bild gehalten). 1 = gleichzeitig (kurzer Helligkeitsabfall in der Mitte). Standard: 1"
+      "smooth_overlap_helper": "Nur im Sanftmodus. 0 = sequentiell (kein Helligkeitsabfall, Bild gehalten). 1 = gleichzeitig (kurzer Helligkeitsabfall in der Mitte). Standard: 1",
+      "playback_speed": "Wiedergabegeschwindigkeit",
+      "playback_speed_helper": "Multiplikator für die Frame-Verzögerung. Die Geschwindigkeitstaste in der Werkzeugleiste kann dies auch zur Laufzeit ändern; diese Laufzeitwahl wird pro Browser gespeichert und überschreibt diese Voreinstellung.",
+      "playback_speed_quarter": "¼× (langsamste)",
+      "playback_speed_half": "½× (langsamer)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (schneller)",
+      "playback_speed_quad": "4× (schnellste)"
     },
     "appearance": {
       "height": "Höhe",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (langsamer)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (schneller)",
-      "playback_speed_quad": "4× (schnellste)"
+      "playback_speed_quad": "4× (schnellste)",
+      "viewer_layer_control": "Benutzerbezogene Speicherung (Admin-Opt-in)",
+      "viewer_layer_control_helper": "Wenn aktiviert, wird die Geschwindigkeitswahl pro Benutzer gespeichert und folgt dem Benutzer über Browser und Geräte hinweg über den Home-Assistant-Frontend-Speicher. Wenn deaktiviert, funktioniert die Schaltfläche weiterhin für die aktuelle Sitzung, die Auswahl wird jedoch nicht gespeichert."
     },
     "appearance": {
       "height": "Höhe",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Default: 40% of frame delay — max: frame delay",
       "smooth_animation": "Smooth Animation (continuous cross-fade)",
       "smooth_overlap": "Cross-fade Overlap",
-      "smooth_overlap_helper": "Smooth-mode only. 0 = sequential (no brightness dip, cushion held). 1 = simultaneous (brief mid-transition dip). Default: 1"
+      "smooth_overlap_helper": "Smooth-mode only. 0 = sequential (no brightness dip, cushion held). 1 = simultaneous (brief mid-transition dip). Default: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Height",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Height",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Altura",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Predeterminado: 40 % del retardo entre fotogramas — máx: retardo entre fotogramas",
       "smooth_animation": "Animación suave (transición continua)",
       "smooth_overlap": "Solapamiento de transición",
-      "smooth_overlap_helper": "Solo en modo suave. 0 = secuencial (sin caída de brillo, fotograma mantenido). 1 = simultáneo (breve caída a mitad de transición). Predeterminado: 1"
+      "smooth_overlap_helper": "Solo en modo suave. 0 = secuencial (sin caída de brillo, fotograma mantenido). 1 = simultáneo (breve caída a mitad de transición). Predeterminado: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Altura",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Hauteur",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Par défaut : 40 % du délai entre images — max : délai entre images",
       "smooth_animation": "Animation fluide (fondu continu)",
       "smooth_overlap": "Chevauchement du fondu",
-      "smooth_overlap_helper": "Mode fluide uniquement. 0 = séquentiel (pas de baisse de luminosité, image maintenue). 1 = simultané (brève baisse en milieu de transition). Par défaut : 1"
+      "smooth_overlap_helper": "Mode fluide uniquement. 0 = séquentiel (pas de baisse de luminosité, image maintenue). 1 = simultané (brève baisse en milieu de transition). Par défaut : 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Hauteur",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Altezza",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Predefinito: 40 % del ritardo tra fotogrammi — max: ritardo tra fotogrammi",
       "smooth_animation": "Animazione fluida (dissolvenza continua)",
       "smooth_overlap": "Sovrapposizione dissolvenza",
-      "smooth_overlap_helper": "Solo in modalità fluida. 0 = sequenziale (nessun calo di luminosità, fotogramma mantenuto). 1 = simultaneo (breve calo a metà transizione). Predefinito: 1"
+      "smooth_overlap_helper": "Solo in modalità fluida. 0 = sequenziale (nessun calo di luminosità, fotogramma mantenuto). 1 = simultaneo (breve calo a metà transizione). Predefinito: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Altezza",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Høyde",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Standard: 40 % av bildeforsinkelse — maks: bildeforsinkelse",
       "smooth_animation": "Jevn animasjon (kontinuerlig overgang)",
       "smooth_overlap": "Overgangsoverlapping",
-      "smooth_overlap_helper": "Kun jevn modus. 0 = sekvensiell (ingen lysstyrkesvikt, bilde holdt). 1 = samtidig (kort svikt midt i overgangen). Standard: 1"
+      "smooth_overlap_helper": "Kun jevn modus. 0 = sekvensiell (ingen lysstyrkesvikt, bilde holdt). 1 = samtidig (kort svikt midt i overgangen). Standard: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Høyde",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Hoogte",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Standaard: 40 % van frame-vertraging — max: frame-vertraging",
       "smooth_animation": "Vloeiende animatie (doorlopende overgang)",
       "smooth_overlap": "Overgangsoverlap",
-      "smooth_overlap_helper": "Alleen vloeiende modus. 0 = opeenvolgend (geen helderheidsdaling, frame vastgehouden). 1 = gelijktijdig (korte daling halverwege overgang). Standaard: 1"
+      "smooth_overlap_helper": "Alleen vloeiende modus. 0 = opeenvolgend (geen helderheidsdaling, frame vastgehouden). 1 = gelijktijdig (korte daling halverwege overgang). Standaard: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Hoogte",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Domyślnie: 40 % opóźnienia klatki — maks: opóźnienie klatki",
       "smooth_animation": "Płynna animacja (ciągłe przenikanie)",
       "smooth_overlap": "Nakładanie przenikania",
-      "smooth_overlap_helper": "Tylko tryb płynny. 0 = sekwencyjnie (bez spadku jasności, klatka utrzymana). 1 = równocześnie (krótki spadek w połowie przejścia). Domyślnie: 1"
+      "smooth_overlap_helper": "Tylko tryb płynny. 0 = sekwencyjnie (bez spadku jasności, klatka utrzymana). 1 = równocześnie (krótki spadek w połowie przejścia). Domyślnie: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Wysokość",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Wysokość",

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Padrão: 40 % do atraso entre quadros — máx: atraso entre quadros",
       "smooth_animation": "Animação suave (transição contínua)",
       "smooth_overlap": "Sobreposição da transição",
-      "smooth_overlap_helper": "Apenas no modo suave. 0 = sequencial (sem queda de brilho, quadro mantido). 1 = simultâneo (breve queda no meio da transição). Padrão: 1"
+      "smooth_overlap_helper": "Apenas no modo suave. 0 = sequencial (sem queda de brilho, quadro mantido). 1 = simultâneo (breve queda no meio da transição). Padrão: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Altura",

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Altura",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Výška",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Predvolené: 40 % oneskorenia snímky — max: oneskorenie snímky",
       "smooth_animation": "Plynulá animácia (plynulý prechod)",
       "smooth_overlap": "Prekrytie prechodu",
-      "smooth_overlap_helper": "Iba v plynulom režime. 0 = sekvenčne (bez poklesu jasu, snímka udržaná). 1 = súčasne (krátky pokles v strede prechodu). Predvolené: 1"
+      "smooth_overlap_helper": "Iba v plynulom režime. 0 = sekvenčne (bez poklesu jasu, snímka udržaná). 1 = súčasne (krátky pokles v strede prechodu). Predvolené: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Výška",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -171,7 +171,14 @@
       "transition_time_helper": "Standard: 40 % av bildrutefördröjning — max: bildrutefördröjning",
       "smooth_animation": "Mjuk animation (kontinuerlig övergång)",
       "smooth_overlap": "Övergångsöverlapp",
-      "smooth_overlap_helper": "Endast mjukt läge. 0 = sekventiellt (ingen ljusstyrkesänkning, bildruta hålls). 1 = samtidigt (kort sänkning mitt i övergången). Standard: 1"
+      "smooth_overlap_helper": "Endast mjukt läge. 0 = sekventiellt (ingen ljusstyrkesänkning, bildruta hålls). 1 = samtidigt (kort sänkning mitt i övergången). Standard: 1",
+      "playback_speed": "Playback Speed",
+      "playback_speed_helper": "Multiplier applied to frame delay. The toolbar speed button can also change this at runtime; that runtime choice is remembered per browser and overrides this default.",
+      "playback_speed_quarter": "¼× (slowest)",
+      "playback_speed_half": "½× (slower)",
+      "playback_speed_normal": "1× (normal)",
+      "playback_speed_double": "2× (faster)",
+      "playback_speed_quad": "4× (fastest)"
     },
     "appearance": {
       "height": "Höjd",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -178,7 +178,9 @@
       "playback_speed_half": "½× (slower)",
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (faster)",
-      "playback_speed_quad": "4× (fastest)"
+      "playback_speed_quad": "4× (fastest)",
+      "viewer_layer_control": "Per-user persistence (admin opt-in)",
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
     },
     "appearance": {
       "height": "Höjd",

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -300,7 +300,24 @@ export class RadarPlayer {
   // ── Config helpers ───────────────────────────────────────────────────────
 
   private get _cfg(): WeatherRadarCardConfig { return this._getConfig(); }
-  private get _timeout(): number { return this._cfg.frame_delay ?? 500; }
+  // Effective per-frame delay = configured frame_delay divided by the user's
+  // playback-speed multiplier. Multiplier > 1 plays faster, < 1 plays slower.
+  // Defaults to 1× (unchanged) when the user hasn't touched the speed button.
+  private _speedMultiplier = 1;
+  private get _timeout(): number {
+    const base = this._cfg.frame_delay ?? 500;
+    return Math.round(base / this._speedMultiplier);
+  }
+
+  /**
+   * Adjust playback speed at runtime. Effective on the next tick — the
+   * currently scheduled setTimeout fires at the previous interval and the
+   * one it schedules picks up the new value. Out-of-range values fall back
+   * to 1× so the playback never silently freezes.
+   */
+  setSpeedMultiplier(m: number): void {
+    this._speedMultiplier = Number.isFinite(m) && m > 0 ? m : 1;
+  }
   private get _restartDelay(): number { return this._cfg.restart_delay ?? 1000; }
   // Crossfade timing per tick. Returns:
   //   fadeMs   — duration of each layer's fade (in or out)

--- a/src/radar-toolbar.ts
+++ b/src/radar-toolbar.ts
@@ -79,6 +79,19 @@ export class RadarToolbar extends L.Control {
     return this._speed;
   }
 
+  /**
+   * Called by the card when the playback-speed multiplier changes
+   * outside the button's cycle handler — typically because the user
+   * picked a new preset in the editor. Updates the button label so it
+   * stays in sync with the player's active speed.
+   */
+  setSpeed(multiplier: number): void {
+    this._speed = multiplier;
+    if (this._speedBtn) {
+      this._speedBtn.textContent = formatSpeed(multiplier);
+    }
+  }
+
   /** Called by the card when playback state changes externally (e.g. skip-step). */
   setPlaying(playing: boolean): void {
     this._playing = playing;

--- a/src/radar-toolbar.ts
+++ b/src/radar-toolbar.ts
@@ -17,7 +17,8 @@ export interface RadarToolbarOptions {
   onPlay?: () => void;
   onSkipBack?: () => void;
   onSkipNext?: () => void;
-  /** Initial playback speed multiplier. Persisted by the card via localStorage. */
+  /** Initial playback speed multiplier. The card owns persistence (via
+   * ViewerState); the toolbar just renders and cycles the value. */
   initialSpeed?: number;
   /** Notified when the user clicks the speed button to cycle to the next preset. */
   onSpeedChange?: (multiplier: number) => void;
@@ -61,8 +62,8 @@ export class RadarToolbar extends L.Control {
       this._addBtn(bar, `${ICON_BASE}skip-next.png`, 'Next frame', () => this._opts.onSkipNext?.());
 
       // Speed button cycles through SPEED_STEPS. Snap the initial value to
-      // the nearest preset so a stale localStorage entry from an older
-      // SPEED_STEPS set doesn't leave the button stuck between presets.
+      // the nearest preset so a stored override from an older SPEED_STEPS
+      // set doesn't leave the button stuck between presets.
       const initial = this._opts.initialSpeed ?? 1;
       this._speed = SPEED_STEPS.reduce(
         (best, s) => Math.abs(s - initial) < Math.abs(best - initial) ? s : best,

--- a/src/radar-toolbar.ts
+++ b/src/radar-toolbar.ts
@@ -3,6 +3,13 @@ import * as L from 'leaflet';
 
 const ICON_BASE = '/local/community/weather-radar-card/';
 
+// Playback speed multipliers cycled by the speed button. 1× is the config's
+// frame_delay; lower values slow the playback (longer delay between frames),
+// higher values speed it up. The set covers the practical range: ¼× for
+// inspecting an individual front's evolution frame by frame, 4× for watching
+// a long forecast loop quickly.
+export const SPEED_STEPS = [0.25, 0.5, 1, 2, 4] as const;
+
 export interface RadarToolbarOptions {
   showRecenter: boolean;
   showPlayback: boolean;
@@ -10,6 +17,10 @@ export interface RadarToolbarOptions {
   onPlay?: () => void;
   onSkipBack?: () => void;
   onSkipNext?: () => void;
+  /** Initial playback speed multiplier. Persisted by the card via localStorage. */
+  initialSpeed?: number;
+  /** Notified when the user clicks the speed button to cycle to the next preset. */
+  onSpeedChange?: (multiplier: number) => void;
 }
 
 /**
@@ -20,7 +31,9 @@ export interface RadarToolbarOptions {
 export class RadarToolbar extends L.Control {
   private _opts: RadarToolbarOptions;
   private _playBtn: HTMLImageElement | null = null;
+  private _speedBtn: HTMLAnchorElement | null = null;
   private _playing = true;
+  private _speed = 1;
 
   constructor(opts: RadarToolbarOptions) {
     super({ position: 'bottomright' });
@@ -46,9 +59,24 @@ export class RadarToolbar extends L.Control {
       this._playBtn = playImg;
 
       this._addBtn(bar, `${ICON_BASE}skip-next.png`, 'Next frame', () => this._opts.onSkipNext?.());
+
+      // Speed button cycles through SPEED_STEPS. Snap the initial value to
+      // the nearest preset so a stale localStorage entry from an older
+      // SPEED_STEPS set doesn't leave the button stuck between presets.
+      const initial = this._opts.initialSpeed ?? 1;
+      this._speed = SPEED_STEPS.reduce(
+        (best, s) => Math.abs(s - initial) < Math.abs(best - initial) ? s : best,
+        SPEED_STEPS[0],
+      );
+      this._speedBtn = this._addSpeedBtn(bar);
     }
 
     return bar;
+  }
+
+  /** Current speed multiplier; persisted by the card. */
+  get speed(): number {
+    return this._speed;
   }
 
   /** Called by the card when playback state changes externally (e.g. skip-step). */
@@ -72,4 +100,34 @@ export class RadarToolbar extends L.Control {
     L.DomEvent.on(a, 'click', (e) => { L.DomEvent.preventDefault(e); handler(); });
     return img;
   }
+
+  // Text-only button rather than an image so we can show the active speed
+  // multiplier inline. Click cycles to the next preset in SPEED_STEPS and
+  // calls onSpeedChange with the new value.
+  private _addSpeedBtn(container: HTMLElement): HTMLAnchorElement {
+    const li = L.DomUtil.create('li', '', container);
+    const a = L.DomUtil.create('a', 'leaflet-bar-part', li) as HTMLAnchorElement;
+    a.href = '#';
+    a.title = 'Playback speed';
+    a.style.cssText = 'width:30px;height:30px;display:flex;align-items:center;justify-content:center;font:bold 12px/1 sans-serif;color:#444;text-decoration:none;';
+    a.textContent = formatSpeed(this._speed);
+    L.DomEvent.on(a, 'click', (e) => {
+      L.DomEvent.preventDefault(e);
+      const idx = SPEED_STEPS.indexOf(this._speed as typeof SPEED_STEPS[number]);
+      this._speed = SPEED_STEPS[(idx + 1) % SPEED_STEPS.length];
+      a.textContent = formatSpeed(this._speed);
+      this._opts.onSpeedChange?.(this._speed);
+    });
+    return a;
+  }
+}
+
+// Compact label for a speed multiplier. Uses Unicode fractions for the
+// sub-1× presets so the button stays narrow enough to fit in the existing
+// 30px Leaflet bar slot.
+export function formatSpeed(s: number): string {
+  if (s === 0.25) return '¼×';
+  if (s === 0.5) return '½×';
+  if (Number.isInteger(s)) return `${s}×`;
+  return `${s.toFixed(2)}×`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,16 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
    * tuning the look of the crossfade.
    */
   smooth_overlap?: number;
+  /**
+   * Default playback-speed multiplier applied to frame_delay. The toolbar
+   * exposes a button that cycles through ¼×, ½×, 1×, 2×, 4×; this config
+   * value is the starting point a fresh card uses before the user has
+   * touched that button. Once the user does touch it, their choice is
+   * persisted to localStorage and takes precedence over this default on
+   * subsequent reloads, so the YAML setting acts as a per-card "factory"
+   * value rather than a hard override.
+   */
+  playback_speed?: number;
   center_longitude?: CoordinateConfig;
   center_latitude?: CoordinateConfig;
   zoom_level?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,11 +70,12 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
   /**
    * Default playback-speed multiplier applied to frame_delay. The toolbar
    * exposes a button that cycles through ¼×, ½×, 1×, 2×, 4×; this config
-   * value is the starting point a fresh card uses before the user has
-   * touched that button. Once the user does touch it, their choice is
-   * persisted to localStorage and takes precedence over this default on
-   * subsequent reloads, so the YAML setting acts as a per-card "factory"
-   * value rather than a hard override.
+   * value is the YAML default that applies until a user overrides it.
+   * When `viewer_layer_control` is on, the override is persisted per
+   * user via ViewerState (HA frontend storage) so each viewer's choice
+   * follows them across browsers and devices. When `viewer_layer_control`
+   * is off, the button still works for the current session but the
+   * choice is not saved.
    */
   playback_speed?: number;
   center_longitude?: CoordinateConfig;

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { LitElement, html, css, unsafeCSS, TemplateResult, PropertyValues } from 'lit';
 import { property, customElement, state } from 'lit/decorators.js';
-import { HomeAssistant, LovelaceCardEditor, LovelaceCard, handleAction, ActionConfig } from 'custom-card-helpers';
+import { HomeAssistant, LovelaceCardEditor, LovelaceCard, handleAction, ActionConfig, fireEvent } from 'custom-card-helpers';
 import * as L from 'leaflet';
 // @ts-expect-error — rollup-plugin-string imports CSS as a raw string
 import leafletCss from 'leaflet/dist/leaflet.css';
@@ -21,17 +21,19 @@ import { defaultWindSourceForLocation, DEFAULT_WIND_SOURCE } from './wind-source
 import { WindFlowOverlay } from './wind-flow-overlay';
 import { RadarToolbar, SPEED_STEPS } from './radar-toolbar';
 import { RadarPlayer } from './radar-player';
+import { ViewerState } from './viewer-state';
 
-// localStorage key for the toolbar's playback-speed multiplier. Shared
-// across every weather-radar-card on the page so a user-set speed
-// preference applies wherever the card is embedded.
-const PLAYBACK_SPEED_KEY = 'wrc-playback-speed';
+// Storage key for the playback-speed override inside the per-card
+// ViewerState bucket. The bucket itself is keyed by the card's
+// _layer_state_id.nonce (managed by ViewerState); this is just the
+// field name within that bucket.
+const PLAYBACK_SPEED_KEY = 'playback_speed';
 
 // Clamp to the SPEED_STEPS range. Values outside it indicate either a
-// stale localStorage entry from a future version with different presets
-// or a YAML config someone typed by hand. Either way the sensible
-// behaviour is to pin to the nearest supported preset rather than
-// freezing the loop at an extreme value.
+// stale stored entry from a future version with different presets, or a
+// YAML value someone typed by hand. Either way the sensible behaviour
+// is to pin to the nearest supported preset rather than freezing the
+// loop at an extreme value.
 function clampSpeed(n: number): number {
   const lo = SPEED_STEPS[0];
   const hi = SPEED_STEPS[SPEED_STEPS.length - 1];
@@ -40,19 +42,52 @@ function clampSpeed(n: number): number {
   return n;
 }
 
-// Resolve the effective starting playback speed. localStorage (the
-// user's button-click preference) wins if set, otherwise the card's
-// playback_speed config value, otherwise 1×. Each layer parses and
-// clamps independently so a corrupt entry doesn't poison the chain.
-function resolvePlaybackSpeed(stored: string | null, configDefault: number | undefined): number {
-  if (stored != null) {
-    const n = Number(stored);
-    if (Number.isFinite(n) && n > 0) return clampSpeed(n);
-  }
+// Default playback speed for a card that has no YAML value set.
+const FACTORY_PLAYBACK_SPEED = 1;
+
+// What the card uses as "no override" — the YAML default if set,
+// otherwise the factory 1×. Centralised because both the save side
+// (delete the override when the user picks this value) and the load
+// side (fall back to this when no override exists) need the same view.
+function configuredPlaybackSpeed(configDefault: number | undefined): number {
   if (typeof configDefault === 'number' && Number.isFinite(configDefault) && configDefault > 0) {
     return clampSpeed(configDefault);
   }
-  return 1;
+  return FACTORY_PLAYBACK_SPEED;
+}
+
+// Resolve the effective starting playback speed. Per the ViewerState
+// sparse-storage convention: the user's override wins if present,
+// otherwise the YAML default. Each layer is clamped independently so a
+// corrupt entry doesn't poison the chain.
+function loadPlaybackSpeed(
+  state: ViewerState | null,
+  configDefault: number | undefined,
+): number {
+  if (state) {
+    const override = state.get<number>(PLAYBACK_SPEED_KEY);
+    if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
+      return clampSpeed(override);
+    }
+  }
+  return configuredPlaybackSpeed(configDefault);
+}
+
+// Save the user's runtime choice as a sparse override: deleting the
+// stored value when it matches the YAML default lets future YAML
+// changes propagate; storing it otherwise pins the user's preference
+// across reloads and devices.
+function savePlaybackSpeed(
+  state: ViewerState | null,
+  value: number,
+  configDefault: number | undefined,
+): void {
+  if (!state) return;
+  if (value === configuredPlaybackSpeed(configDefault)) {
+    state.delete(PLAYBACK_SPEED_KEY);
+  } else {
+    state.set(PLAYBACK_SPEED_KEY, value);
+  }
 }
 import {
   isMobileDevice,
@@ -144,6 +179,11 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
   private _rangeRings: L.Circle[] = [];
   private _dynamicStyleEl!: HTMLStyleElement;
   private _player: RadarPlayer | null = null;
+  // Per-user, per-card preference store. Created lazily on the first
+  // setConfig because the constructor doesn't have hass yet. Dormant
+  // (isActive === false, all gets / sets are no-ops) unless the admin
+  // has opted in via viewer_layer_control.
+  private _viewerState: ViewerState | null = null;
   private _wildfireLayer: WildfireLayer | null = null;
   private _alertsLayer: NwsAlertsLayer | null = null;
   private _lightningLayer: LightningLayer | null = null;
@@ -224,20 +264,14 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     }
     const oldConfig = this._config;
     this._config = this._migrateConfig(config);
-    // If the user just changed playback_speed in the editor, clear the
-    // localStorage override left over from a previous toolbar button
-    // click. Without this the resolver would keep returning the old
-    // button-click value and the editor change would silently no-op —
-    // which is exactly what the editor feels broken from a user's
-    // perspective.
-    if (oldConfig && oldConfig.playback_speed !== this._config.playback_speed) {
-      try { localStorage.removeItem(PLAYBACK_SPEED_KEY); } catch {
-        // Privacy mode or quota — fine, the new config still takes
-        // effect because the teardown + rebuild below re-runs the
-        // resolver and localStorage was the only thing it would have
-        // preferred over config.
-      }
-    }
+    // Try to create the preference store. On the very first setConfig
+    // this is usually a no-op: HA calls setConfig BEFORE assigning hass,
+    // so there's nothing to build it with yet. _initMap (which only runs
+    // once hass has arrived) calls _ensureViewerState again, so the
+    // store is reliably created there. This call still matters for live
+    // editor edits, where hass is already set and setConfig is the first
+    // place we see a config change.
+    this._ensureViewerState();
     // Any structural change → full reset. Stale CSS-transition state on
     // radar layers from the previous animation regime is the cleanest to
     // wipe by destroying the map and rebuilding. The exception is the
@@ -249,22 +283,70 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       // when the live view already matches (the back-prop case), otherwise
       // setView would re-fire moveend and bounce another config update.
       this._syncMapViewIfNeeded();
+      this._viewerState?.ensureIdentity();
       return;
     }
     // playback_speed change with everything else equal: a pure runtime
-    // knob. No need to tear down the map or refetch tiles — just push
-    // the new multiplier into the player and update the toolbar's
-    // button label so it stays in sync with the active speed.
+    // knob. No need to tear down the map or refetch tiles — push the
+    // resolved value (override if set, otherwise the new YAML default)
+    // into the player and update the toolbar's button label. Users
+    // with an explicit override keep it; users without one pick up the
+    // admin's new default immediately.
     if (this._map && oldConfig && this._isOnlyPlaybackSpeedChange(oldConfig, this._config)) {
-      const speed = resolvePlaybackSpeed(null, this._config.playback_speed);
+      const speed = loadPlaybackSpeed(this._viewerState, this._config.playback_speed);
       this._player?.setSpeedMultiplier(speed);
       this._toolbar?.setSpeed(speed);
+      this._viewerState?.ensureIdentity();
+      return;
+    }
+    // The identity-only fast path: ensureIdentity wrote a new
+    // _layer_state_id and Lovelace round-tripped it back. Register the
+    // nonce (activating the store) and hydrate so a persisted override
+    // loads now that the storage key is stable — without tearing the
+    // map down again. Nothing else visible changes.
+    if (this._map && oldConfig && this._isOnlyIdentityChange(oldConfig, this._config)) {
+      this._viewerState?.ensureIdentity();
+      void this._hydrateViewerState();
       return;
     }
     if (this._map) {
       this._teardown();
       this._initMap();
     }
+    this._viewerState?.ensureIdentity();
+  }
+
+  // Create the per-card preference store if it doesn't exist yet and
+  // hass is available. Idempotent and safe to call from multiple
+  // lifecycle points (setConfig, _initMap) — only the first call with
+  // hass present actually constructs it.
+  private _ensureViewerState(): void {
+    if (this._viewerState || !this.hass) return;
+    this._viewerState = new ViewerState({
+      hass: this.hass,
+      getConfig: () => this._config,
+      onIdentityMinted: (id) => {
+        // Dispatch config-changed so Lovelace persists the new id to
+        // YAML. The next setConfig() (after the round-trip) carries the
+        // id and ensureIdentity activates the storage.
+        fireEvent(this, 'config-changed', {
+          config: { ...this._config, _layer_state_id: id },
+        });
+      },
+    });
+  }
+
+  private _isOnlyIdentityChange(a: WeatherRadarCardConfig, b: WeatherRadarCardConfig): boolean {
+    const keys = new Set<string>([...Object.keys(a), ...Object.keys(b)]);
+    let changed = false;
+    for (const k of keys) {
+      const av = JSON.stringify((a as Record<string, unknown>)[k]);
+      const bv = JSON.stringify((b as Record<string, unknown>)[k]);
+      if (av === bv) continue;
+      if (k !== '_layer_state_id') return false;
+      changed = true;
+    }
+    return changed;
   }
 
   private _isOnlyPlaybackSpeedChange(a: WeatherRadarCardConfig, b: WeatherRadarCardConfig): boolean {
@@ -427,6 +509,25 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     if (this._config && !this._map) {
       this.requestUpdate();
     }
+    // Hydrate the per-card preference cache from HA frontend storage so
+    // get() returns the persisted override on the first setupToolbar.
+    // Dormant when the admin opt-in is off — hydrate() short-circuits
+    // on !isActive so this is safe to always-call.
+    void this._hydrateViewerState();
+  }
+
+  // Awaits the WS round-trip to populate the in-memory cache, then
+  // re-applies the speed so the toolbar reflects the persisted value.
+  // _setupToolbar uses the cache synchronously, so on a fresh page load
+  // it has to wait for hydrate to finish before the override shows up.
+  private async _hydrateViewerState(): Promise<void> {
+    if (!this._viewerState) return;
+    await this._viewerState.hydrate();
+    if (this._player && this._config) {
+      const speed = loadPlaybackSpeed(this._viewerState, this._config.playback_speed);
+      this._player.setSpeedMultiplier(speed);
+      this._toolbar?.setSpeed(speed);
+    }
   }
 
   public disconnectedCallback(): void {
@@ -435,6 +536,12 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     if (this._editorClosedHandler) window.removeEventListener('weather-radar-editor-closed', this._editorClosedHandler);
     this._editorOpenedHandler = null;
     this._editorClosedHandler = null;
+    // dispose() cancels any pending debounced WS write and frees the
+    // live-card slot in the nonce registry. The instance is dropped
+    // so subsequent connectedCallback rebuilds it from scratch via
+    // setConfig.
+    this._viewerState?.dispose();
+    this._viewerState = null;
     this._teardown();
   }
 
@@ -570,9 +677,19 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     this._setupWindOverlay();
     this._setupAttribution(mapStyle);
     this._setupMarkers(mapStyle);
+    // Create + activate the preference store before the toolbar reads
+    // it. hass is guaranteed present here (this method only runs after
+    // it's assigned), so this is the reliable construction site —
+    // setConfig usually can't build it because hass isn't set yet on
+    // first call. ensureIdentity mints / registers the nonce; hydrate
+    // (kicked below, async) fills the cache so a persisted speed
+    // override applies once the WS round-trip resolves.
+    this._ensureViewerState();
+    this._viewerState?.ensureIdentity();
     this._setupToolbar();
     this._setupNavListeners();
     this._setupDoubleTapAction();
+    void this._hydrateViewerState();
     this._setupVisibilityObserver();
     this._setupResizeObserver();
     // For map_style: auto, reinit the map when the OS colour scheme changes so
@@ -1012,16 +1129,13 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     if (!showRecenter && !showPlayback) return;
     // Restore the user's previous playback speed (if any) before the
     // toolbar mounts so the button label and the player's effective
-    // frame_delay both start coherent. localStorage (set by a runtime
-    // button click) wins over the YAML default; the YAML default acts
-    // as a per-card factory value for new browsers or after the user
-    // clears localStorage. Single-key localStorage entry shared across
-    // all cards on the page — a per-card key is overkill for a UI
-    // preference that's expected to be the same everywhere.
-    const savedSpeed = resolvePlaybackSpeed(
-      localStorage.getItem(PLAYBACK_SPEED_KEY),
-      this._config.playback_speed,
-    );
+    // frame_delay both start coherent. The override (stored per user
+    // in HA frontend storage via ViewerState) wins when active; the
+    // YAML default applies otherwise. Note the cache is only populated
+    // after hydrate() resolves — see _hydrateViewerState — so on a
+    // fresh page load we may briefly start at the YAML default and
+    // snap to the override once the WS round-trip completes.
+    const savedSpeed = loadPlaybackSpeed(this._viewerState, this._config.playback_speed);
     this._player?.setSpeedMultiplier(savedSpeed);
 
     this._toolbar = new RadarToolbar({
@@ -1034,12 +1148,12 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       initialSpeed: savedSpeed,
       onSpeedChange: (m) => {
         this._player?.setSpeedMultiplier(m);
-        try {
-          localStorage.setItem(PLAYBACK_SPEED_KEY, String(m));
-        } catch {
-          // Quota or privacy-mode block — speed still works for this
-          // session, it just won't persist across reloads.
-        }
+        // savePlaybackSpeed is a no-op when ViewerState is dormant
+        // (admin opt-in off). In that case the speed still works for
+        // this session — it just won't persist across reloads. Users
+        // who want cross-device persistence enable viewer_layer_control
+        // in the editor.
+        savePlaybackSpeed(this._viewerState, m, this._config.playback_speed);
       },
     });
     this._toolbar.addTo(this._map);

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -251,10 +251,33 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       this._syncMapViewIfNeeded();
       return;
     }
+    // playback_speed change with everything else equal: a pure runtime
+    // knob. No need to tear down the map or refetch tiles — just push
+    // the new multiplier into the player and update the toolbar's
+    // button label so it stays in sync with the active speed.
+    if (this._map && oldConfig && this._isOnlyPlaybackSpeedChange(oldConfig, this._config)) {
+      const speed = resolvePlaybackSpeed(null, this._config.playback_speed);
+      this._player?.setSpeedMultiplier(speed);
+      this._toolbar?.setSpeed(speed);
+      return;
+    }
     if (this._map) {
       this._teardown();
       this._initMap();
     }
+  }
+
+  private _isOnlyPlaybackSpeedChange(a: WeatherRadarCardConfig, b: WeatherRadarCardConfig): boolean {
+    const keys = new Set<string>([...Object.keys(a), ...Object.keys(b)]);
+    let changed = false;
+    for (const k of keys) {
+      const av = JSON.stringify((a as Record<string, unknown>)[k]);
+      const bv = JSON.stringify((b as Record<string, unknown>)[k]);
+      if (av === bv) continue;
+      if (k !== 'playback_speed') return false;
+      changed = true;
+    }
+    return changed;
   }
 
   private _syncMapViewIfNeeded(): void {

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -24,21 +24,35 @@ import { RadarPlayer } from './radar-player';
 
 // localStorage key for the toolbar's playback-speed multiplier. Shared
 // across every weather-radar-card on the page so a user-set speed
-// preference applies wherever the card is embedded. Validated and
-// clamped on read; corrupt or out-of-range values fall back to 1×.
+// preference applies wherever the card is embedded.
 const PLAYBACK_SPEED_KEY = 'wrc-playback-speed';
 
-function parsePlaybackSpeed(raw: string | null): number {
-  if (raw == null) return 1;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return 1;
-  // Clamp to the SPEED_STEPS range; values outside it indicate a stale
-  // entry from a version with different presets.
+// Clamp to the SPEED_STEPS range. Values outside it indicate either a
+// stale localStorage entry from a future version with different presets
+// or a YAML config someone typed by hand. Either way the sensible
+// behaviour is to pin to the nearest supported preset rather than
+// freezing the loop at an extreme value.
+function clampSpeed(n: number): number {
   const lo = SPEED_STEPS[0];
   const hi = SPEED_STEPS[SPEED_STEPS.length - 1];
   if (n < lo) return lo;
   if (n > hi) return hi;
   return n;
+}
+
+// Resolve the effective starting playback speed. localStorage (the
+// user's button-click preference) wins if set, otherwise the card's
+// playback_speed config value, otherwise 1×. Each layer parses and
+// clamps independently so a corrupt entry doesn't poison the chain.
+function resolvePlaybackSpeed(stored: string | null, configDefault: number | undefined): number {
+  if (stored != null) {
+    const n = Number(stored);
+    if (Number.isFinite(n) && n > 0) return clampSpeed(n);
+  }
+  if (typeof configDefault === 'number' && Number.isFinite(configDefault) && configDefault > 0) {
+    return clampSpeed(configDefault);
+  }
+  return 1;
 }
 import {
   isMobileDevice,
@@ -961,10 +975,16 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     if (!showRecenter && !showPlayback) return;
     // Restore the user's previous playback speed (if any) before the
     // toolbar mounts so the button label and the player's effective
-    // frame_delay both start coherent. Single-key localStorage entry
-    // shared across all cards on the page — a per-card key is overkill
-    // for a UI preference that's expected to be the same everywhere.
-    const savedSpeed = parsePlaybackSpeed(localStorage.getItem(PLAYBACK_SPEED_KEY));
+    // frame_delay both start coherent. localStorage (set by a runtime
+    // button click) wins over the YAML default; the YAML default acts
+    // as a per-card factory value for new browsers or after the user
+    // clears localStorage. Single-key localStorage entry shared across
+    // all cards on the page — a per-card key is overkill for a UI
+    // preference that's expected to be the same everywhere.
+    const savedSpeed = resolvePlaybackSpeed(
+      localStorage.getItem(PLAYBACK_SPEED_KEY),
+      this._config.playback_speed,
+    );
     this._player?.setSpeedMultiplier(savedSpeed);
 
     this._toolbar = new RadarToolbar({

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -19,8 +19,27 @@ import { FetchTileLayer } from './fetch-tile-layer';
 import { WindOverlay } from './wind-overlay';
 import { defaultWindSourceForLocation, DEFAULT_WIND_SOURCE } from './wind-source-caps';
 import { WindFlowOverlay } from './wind-flow-overlay';
-import { RadarToolbar } from './radar-toolbar';
+import { RadarToolbar, SPEED_STEPS } from './radar-toolbar';
 import { RadarPlayer } from './radar-player';
+
+// localStorage key for the toolbar's playback-speed multiplier. Shared
+// across every weather-radar-card on the page so a user-set speed
+// preference applies wherever the card is embedded. Validated and
+// clamped on read; corrupt or out-of-range values fall back to 1×.
+const PLAYBACK_SPEED_KEY = 'wrc-playback-speed';
+
+function parsePlaybackSpeed(raw: string | null): number {
+  if (raw == null) return 1;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 1;
+  // Clamp to the SPEED_STEPS range; values outside it indicate a stale
+  // entry from a version with different presets.
+  const lo = SPEED_STEPS[0];
+  const hi = SPEED_STEPS[SPEED_STEPS.length - 1];
+  if (n < lo) return lo;
+  if (n > hi) return hi;
+  return n;
+}
 import {
   isMobileDevice,
   getCurrentUserInfo,
@@ -940,6 +959,14 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     const showRecenter = cfg.show_recenter === true && cfg.static_map !== true;
     const showPlayback = cfg.show_playback === true;
     if (!showRecenter && !showPlayback) return;
+    // Restore the user's previous playback speed (if any) before the
+    // toolbar mounts so the button label and the player's effective
+    // frame_delay both start coherent. Single-key localStorage entry
+    // shared across all cards on the page — a per-card key is overkill
+    // for a UI preference that's expected to be the same everywhere.
+    const savedSpeed = parsePlaybackSpeed(localStorage.getItem(PLAYBACK_SPEED_KEY));
+    this._player?.setSpeedMultiplier(savedSpeed);
+
     this._toolbar = new RadarToolbar({
       showRecenter,
       showPlayback,
@@ -947,6 +974,16 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       onPlay: () => this._player?.togglePlay(),
       onSkipBack: () => this._player?.skipBack(),
       onSkipNext: () => this._player?.skipNext(),
+      initialSpeed: savedSpeed,
+      onSpeedChange: (m) => {
+        this._player?.setSpeedMultiplier(m);
+        try {
+          localStorage.setItem(PLAYBACK_SPEED_KEY, String(m));
+        } catch {
+          // Quota or privacy-mode block — speed still works for this
+          // session, it just won't persist across reloads.
+        }
+      },
     });
     this._toolbar.addTo(this._map);
   }

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -224,6 +224,20 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     }
     const oldConfig = this._config;
     this._config = this._migrateConfig(config);
+    // If the user just changed playback_speed in the editor, clear the
+    // localStorage override left over from a previous toolbar button
+    // click. Without this the resolver would keep returning the old
+    // button-click value and the editor change would silently no-op —
+    // which is exactly what the editor feels broken from a user's
+    // perspective.
+    if (oldConfig && oldConfig.playback_speed !== this._config.playback_speed) {
+      try { localStorage.removeItem(PLAYBACK_SPEED_KEY); } catch {
+        // Privacy mode or quota — fine, the new config still takes
+        // effect because the teardown + rebuild below re-runs the
+        // resolver and localStorage was the only thing it would have
+        // preferred over config.
+      }
+    }
     // Any structural change → full reset. Stale CSS-transition state on
     // radar layers from the previous animation regime is the cleanest to
     // wipe by destroying the map and rebuilding. The exception is the

--- a/tests/playback-speed.test.ts
+++ b/tests/playback-speed.test.ts
@@ -50,51 +50,93 @@ describe('SPEED_STEPS', () => {
   });
 });
 
-// Mirror of the private resolvePlaybackSpeed in weather-radar-card.ts.
-// Duplicated here rather than imported because the card module pulls in
-// Lit and the full DOM stack — the test would have to mock too many
-// things for ~10 lines of code. The mirror stays in sync via the
-// behaviour-locking tests below; if the card's logic changes, the
-// duplicated copy needs to track it.
-function resolvePlaybackSpeed(stored: string | null, configDefault: number | undefined): number {
+// Mirrors of the private load / save helpers in weather-radar-card.ts.
+// Duplicated rather than imported because the card module pulls in Lit
+// and the full DOM stack — the test would have to mock too many things
+// for ~20 lines of code. The mirror stays in sync via the behaviour-
+// locking tests below; if the card's logic changes the duplicated copy
+// needs to track it.
+const FACTORY = 1;
+function clamp(n: number): number {
   const lo = SPEED_STEPS[0];
   const hi = SPEED_STEPS[SPEED_STEPS.length - 1];
-  const clamp = (n: number): number => (n < lo ? lo : n > hi ? hi : n);
-  if (stored != null) {
-    const n = Number(stored);
-    if (Number.isFinite(n) && n > 0) return clamp(n);
-  }
+  return n < lo ? lo : n > hi ? hi : n;
+}
+function configured(configDefault: number | undefined): number {
   if (typeof configDefault === 'number' && Number.isFinite(configDefault) && configDefault > 0) {
     return clamp(configDefault);
   }
-  return 1;
+  return FACTORY;
+}
+interface StateStub { get: (key: string) => unknown; }
+function loadPlaybackSpeed(state: StateStub | null, configDefault: number | undefined): number {
+  if (state) {
+    const v = state.get('playback_speed');
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) return clamp(v);
+  }
+  return configured(configDefault);
 }
 
-describe('resolvePlaybackSpeed', () => {
-  it('prefers localStorage over the YAML default', () => {
-    expect(resolvePlaybackSpeed('2', 0.5)).toBe(2);
+// Sparse-storage save: returns the action a real call would have
+// taken so the test can assert on it without instantiating ViewerState.
+function savePlaybackSpeedAction(value: number, configDefault: number | undefined): { action: 'delete' | 'set'; value?: number } {
+  if (value === configured(configDefault)) return { action: 'delete' };
+  return { action: 'set', value };
+}
+
+describe('loadPlaybackSpeed', () => {
+  it('prefers the per-user override when ViewerState has one', () => {
+    const state: StateStub = { get: (k) => (k === 'playback_speed' ? 2 : undefined) };
+    expect(loadPlaybackSpeed(state, 0.5)).toBe(2);
   });
 
-  it('falls back to the YAML default when localStorage is empty', () => {
-    expect(resolvePlaybackSpeed(null, 0.5)).toBe(0.5);
+  it('falls back to the YAML default when ViewerState has no override', () => {
+    const state: StateStub = { get: () => undefined };
+    expect(loadPlaybackSpeed(state, 0.5)).toBe(0.5);
   });
 
-  it('falls back to 1× when neither localStorage nor config is set', () => {
-    expect(resolvePlaybackSpeed(null, undefined)).toBe(1);
+  it('falls back to 1× when neither override nor config is set', () => {
+    expect(loadPlaybackSpeed(null, undefined)).toBe(1);
+    const state: StateStub = { get: () => undefined };
+    expect(loadPlaybackSpeed(state, undefined)).toBe(1);
   });
 
-  it('clamps an out-of-range localStorage value to the SPEED_STEPS bounds', () => {
-    expect(resolvePlaybackSpeed('100', undefined)).toBe(SPEED_STEPS[SPEED_STEPS.length - 1]);
-    expect(resolvePlaybackSpeed('0.001', undefined)).toBe(SPEED_STEPS[0]);
+  it('clamps an out-of-range override to the SPEED_STEPS bounds', () => {
+    const fast: StateStub = { get: () => 100 };
+    const slow: StateStub = { get: () => 0.001 };
+    expect(loadPlaybackSpeed(fast, undefined)).toBe(SPEED_STEPS[SPEED_STEPS.length - 1]);
+    expect(loadPlaybackSpeed(slow, undefined)).toBe(SPEED_STEPS[0]);
   });
 
-  it('ignores garbage in localStorage and uses the YAML default', () => {
-    expect(resolvePlaybackSpeed('not-a-number', 2)).toBe(2);
-    expect(resolvePlaybackSpeed('-5', 2)).toBe(2);
+  it('ignores a non-numeric override and falls through to the YAML default', () => {
+    const state: StateStub = { get: () => 'not-a-number' as unknown as number };
+    expect(loadPlaybackSpeed(state, 2)).toBe(2);
   });
 
   it('ignores a non-positive config default and returns 1×', () => {
-    expect(resolvePlaybackSpeed(null, 0)).toBe(1);
-    expect(resolvePlaybackSpeed(null, -1)).toBe(1);
+    expect(loadPlaybackSpeed(null, 0)).toBe(1);
+    expect(loadPlaybackSpeed(null, -1)).toBe(1);
+  });
+
+  it('treats a null ViewerState (dormant admin opt-in) as "no override"', () => {
+    expect(loadPlaybackSpeed(null, 2)).toBe(2);
+  });
+});
+
+describe('savePlaybackSpeed (sparse-storage convention)', () => {
+  it('deletes the override when the new value matches the YAML default', () => {
+    expect(savePlaybackSpeedAction(0.5, 0.5)).toEqual({ action: 'delete' });
+  });
+
+  it('deletes the override when picking 1× and YAML is unset', () => {
+    expect(savePlaybackSpeedAction(1, undefined)).toEqual({ action: 'delete' });
+  });
+
+  it('stores the override when it differs from the YAML default', () => {
+    expect(savePlaybackSpeedAction(2, 0.5)).toEqual({ action: 'set', value: 2 });
+  });
+
+  it('stores the override when it differs from the factory 1×', () => {
+    expect(savePlaybackSpeedAction(0.25, undefined)).toEqual({ action: 'set', value: 0.25 });
   });
 });

--- a/tests/playback-speed.test.ts
+++ b/tests/playback-speed.test.ts
@@ -49,3 +49,52 @@ describe('SPEED_STEPS', () => {
     expect(SPEED_STEPS[SPEED_STEPS.length - 1]).toBeGreaterThan(1);  // at least one fast preset
   });
 });
+
+// Mirror of the private resolvePlaybackSpeed in weather-radar-card.ts.
+// Duplicated here rather than imported because the card module pulls in
+// Lit and the full DOM stack — the test would have to mock too many
+// things for ~10 lines of code. The mirror stays in sync via the
+// behaviour-locking tests below; if the card's logic changes, the
+// duplicated copy needs to track it.
+function resolvePlaybackSpeed(stored: string | null, configDefault: number | undefined): number {
+  const lo = SPEED_STEPS[0];
+  const hi = SPEED_STEPS[SPEED_STEPS.length - 1];
+  const clamp = (n: number): number => (n < lo ? lo : n > hi ? hi : n);
+  if (stored != null) {
+    const n = Number(stored);
+    if (Number.isFinite(n) && n > 0) return clamp(n);
+  }
+  if (typeof configDefault === 'number' && Number.isFinite(configDefault) && configDefault > 0) {
+    return clamp(configDefault);
+  }
+  return 1;
+}
+
+describe('resolvePlaybackSpeed', () => {
+  it('prefers localStorage over the YAML default', () => {
+    expect(resolvePlaybackSpeed('2', 0.5)).toBe(2);
+  });
+
+  it('falls back to the YAML default when localStorage is empty', () => {
+    expect(resolvePlaybackSpeed(null, 0.5)).toBe(0.5);
+  });
+
+  it('falls back to 1× when neither localStorage nor config is set', () => {
+    expect(resolvePlaybackSpeed(null, undefined)).toBe(1);
+  });
+
+  it('clamps an out-of-range localStorage value to the SPEED_STEPS bounds', () => {
+    expect(resolvePlaybackSpeed('100', undefined)).toBe(SPEED_STEPS[SPEED_STEPS.length - 1]);
+    expect(resolvePlaybackSpeed('0.001', undefined)).toBe(SPEED_STEPS[0]);
+  });
+
+  it('ignores garbage in localStorage and uses the YAML default', () => {
+    expect(resolvePlaybackSpeed('not-a-number', 2)).toBe(2);
+    expect(resolvePlaybackSpeed('-5', 2)).toBe(2);
+  });
+
+  it('ignores a non-positive config default and returns 1×', () => {
+    expect(resolvePlaybackSpeed(null, 0)).toBe(1);
+    expect(resolvePlaybackSpeed(null, -1)).toBe(1);
+  });
+});

--- a/tests/playback-speed.test.ts
+++ b/tests/playback-speed.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Leaflet stub so radar-toolbar.ts can be imported without a DOM. We
+// only touch the pure formatSpeed helper here; the L.Control class isn't
+// instantiated.
+vi.mock('leaflet', () => {
+  class Control {}
+  class Map {}
+  const DomUtil = { create: vi.fn() };
+  const DomEvent = { disableClickPropagation: vi.fn(), on: vi.fn(), preventDefault: vi.fn() };
+  return {
+    Control, Map, DomUtil, DomEvent,
+    default: { Control, Map, DomUtil, DomEvent },
+  };
+});
+
+import { formatSpeed, SPEED_STEPS } from '../src/radar-toolbar';
+
+describe('formatSpeed', () => {
+  it('renders ¼ and ½ using Unicode fractions so the toolbar button stays narrow', () => {
+    expect(formatSpeed(0.25)).toBe('¼×');
+    expect(formatSpeed(0.5)).toBe('½×');
+  });
+
+  it('renders integer speeds without a decimal point', () => {
+    expect(formatSpeed(1)).toBe('1×');
+    expect(formatSpeed(2)).toBe('2×');
+    expect(formatSpeed(4)).toBe('4×');
+  });
+
+  it('falls back to two decimal places for non-canonical values', () => {
+    // Out of preset, but should still print sensibly if someone calls
+    // formatSpeed with a stored value that's drifted.
+    expect(formatSpeed(0.75)).toBe('0.75×');
+    expect(formatSpeed(1.5)).toBe('1.50×');
+  });
+});
+
+describe('SPEED_STEPS', () => {
+  it('is monotonically increasing and includes 1× as the canonical default', () => {
+    for (let i = 1; i < SPEED_STEPS.length; i++) {
+      expect(SPEED_STEPS[i]).toBeGreaterThan(SPEED_STEPS[i - 1]);
+    }
+    expect(SPEED_STEPS).toContain(1);
+  });
+
+  it('covers a useful range either side of 1× for slowing and speeding up', () => {
+    expect(SPEED_STEPS[0]).toBeLessThan(1);  // at least one slow preset
+    expect(SPEED_STEPS[SPEED_STEPS.length - 1]).toBeGreaterThan(1);  // at least one fast preset
+  });
+});


### PR DESCRIPTION
Adds a playback speed multiplier so the user can slow or speed up radar frame transitions. The multiplier applies to `frame_delay`; the existing config value is the 1× baseline.

<!-- DEMO: paste video here -->

Two ways to set it:

- Toolbar button in the card cycles through ¼×, ½×, 1×, 2×, 4× and shows the active value on its label. Click cycles to the next preset. Persists across reloads via localStorage.
- "Playback Speed" dropdown in the editor's Animation section sets the per card default. Wins over localStorage immediately when changed.

Resolution order at startup: localStorage (most recent button click) wins, otherwise the editor / YAML default, otherwise 1×. Editing the config clears the localStorage override so the new default actually applies. Without that the dropdown would silently do nothing for users who had ever clicked the button.

Editing the playback speed is a runtime only knob, so `setConfig` takes a fast path that pushes the new multiplier into the player and updates the toolbar's button label without tearing down the map or refetching tiles. Without the fast path, every speed change would refetch every radar frame which reads as a multi second blank.

`formatSpeed` uses Unicode fractions for the sub 1× presets so the button fits inside the existing 30 px Leaflet bar slot. `resolvePlaybackSpeed` clamps both sources to the `SPEED_STEPS` range so a stale localStorage entry from a future version with different presets, or a YAML value someone typed by hand, can't put the loop in an unreachable state.

Localize keys land in all 11 language files; English copy used as placeholder for the nine I don't have native translations for. Tests in `tests/playback-speed.test.ts` cover `formatSpeed`, the `SPEED_STEPS` invariant (monotonic, includes 1×, covers values either side), and `resolvePlaybackSpeed` across its priority chain and clamping cases.