### PR TITLE
perf: AbortController for tile + wildfire + alerts + RainViewer-meta fetches

### DIFF
--- a/src/fetch-tile-layer.ts
+++ b/src/fetch-tile-layer.ts
@@ -68,11 +68,16 @@ interface Coords extends L.Point {
 // On a busy mobile connection this cuts wire bandwidth substantially:
 // a low-zoom continental pan can trigger dozens of tile fetches that
 // would otherwise complete after the user has already moved past them.
-interface TileWithAbort extends HTMLImageElement {
+//
+// Exported (with TileWithAbort) so the abort-integration tests can
+// exercise wireAbortLifecycle and createFetchTile against minimal layer
+// stubs without needing a full L.TileLayer instance.
+export interface TileWithAbort extends HTMLImageElement {
   __wrcAbort?: AbortController | null;
 }
 
-function createFetchTile(
+/** @internal — exported for tests/fetch-abort.test.ts integration coverage. */
+export function createFetchTile(
   this: FetchTileLayer | FetchWmsTileLayer,
   coords: Coords,
   done: L.DoneCallback,
@@ -170,7 +175,9 @@ function createFetchTile(
 // Hook Leaflet's tileunload event so we abort the underlying fetch when
 // a tile leaves the DOM. Also hook the layer's `remove` event for the
 // bulk teardown case (layer removed from the map, card teardown).
-function wireAbortLifecycle(layer: FetchTileLayer | FetchWmsTileLayer): void {
+//
+// @internal — exported for tests/fetch-abort.test.ts integration coverage.
+export function wireAbortLifecycle(layer: FetchTileLayer | FetchWmsTileLayer): void {
   layer.on('tileunload', (e: L.TileEvent) => {
     const tile = e.tile as TileWithAbort;
     tile.__wrcAbort?.abort();

--- a/src/fetch-tile-layer.ts
+++ b/src/fetch-tile-layer.ts
@@ -57,13 +57,28 @@ interface Coords extends L.Point {
   z: number;
 }
 
+// Each in-flight tile fetch gets an AbortController so a tile that
+// Leaflet decides to unload (pan-out-of-view, zoom-change, layer remove)
+// can have its underlying HTTP request cancelled rather than letting the
+// browser download bytes we'll immediately discard. The controller is
+// stored on the tile element itself (`__wrcAbort`) so the tileunload
+// handler can find it without a separate map. On success/failure the
+// pointer is cleared so we don't try to abort a settled fetch.
+//
+// On a busy mobile connection this cuts wire bandwidth substantially:
+// a low-zoom continental pan can trigger dozens of tile fetches that
+// would otherwise complete after the user has already moved past them.
+interface TileWithAbort extends HTMLImageElement {
+  __wrcAbort?: AbortController | null;
+}
+
 function createFetchTile(
   this: FetchTileLayer | FetchWmsTileLayer,
   coords: Coords,
   done: L.DoneCallback,
 ): HTMLElement {
   const layer = this;
-  const tile = document.createElement('img');
+  const tile = document.createElement('img') as TileWithAbort;
   tile.setAttribute('role', 'presentation');
 
   const url = layer.getTileUrl(coords);
@@ -80,6 +95,7 @@ function createFetchTile(
     tile.src = TRANSPARENT;
     layer._tilePending--;
     layer._tileFailed++;
+    tile.__wrcAbort = null;
     done(undefined, tile);
   };
 
@@ -90,7 +106,16 @@ function createFetchTile(
     }
     limiter?.record(url);
 
-    fetch(url, { referrer: window.location.href, referrerPolicy: 'no-referrer-when-downgrade' })
+    // Fresh controller for each attempt — retries get their own so
+    // aborting one in-flight retry doesn't poison the next.
+    const ctrl = new AbortController();
+    tile.__wrcAbort = ctrl;
+
+    fetch(url, {
+      referrer: window.location.href,
+      referrerPolicy: 'no-referrer-when-downgrade',
+      signal: ctrl.signal,
+    })
       .then((r) => {
         if (r.status === 404) { const e: any = new Error('404'); e.status = 404; throw e; }
         if (r.status === 429) { const e: any = new Error('429'); e.status = 429; throw e; }
@@ -108,9 +133,19 @@ function createFetchTile(
         limiter?.recordSuccess(url);
         layer._tilePending--;
         layer._tileLoaded++;
+        tile.__wrcAbort = null;
         done(undefined, tile);
       })
       .catch((err: any) => {
+        // Deliberately-cancelled fetch (tile unloaded / layer removed).
+        // Decrement pending so the loading-spinner / segment counter
+        // stays accurate, but don't count as a failure and don't retry.
+        // Don't call done() — Leaflet has already moved on from this tile.
+        if (err.name === 'AbortError') {
+          layer._tilePending--;
+          tile.__wrcAbort = null;
+          return;
+        }
         if (err.status === 404) {
           fail();
         } else if (err.status === 429 || (limiter && !err.status)) {
@@ -130,6 +165,31 @@ function createFetchTile(
 
   tryFetch();
   return tile;
+}
+
+// Hook Leaflet's tileunload event so we abort the underlying fetch when
+// a tile leaves the DOM. Also hook the layer's `remove` event for the
+// bulk teardown case (layer removed from the map, card teardown).
+function wireAbortLifecycle(layer: FetchTileLayer | FetchWmsTileLayer): void {
+  layer.on('tileunload', (e: L.TileEvent) => {
+    const tile = e.tile as TileWithAbort;
+    tile.__wrcAbort?.abort();
+    tile.__wrcAbort = null;
+  });
+  layer.on('remove', () => {
+    // Walk Leaflet's internal _tiles map for any still-pending fetches.
+    // tileunload generally fires for each before remove, but the
+    // contract is fuzzy under fast tear-downs; this is belt-and-braces.
+    const tiles = (layer as any)._tiles as Record<string, { el: HTMLElement }> | undefined;
+    if (!tiles) return;
+    for (const key in tiles) {
+      const tile = tiles[key]?.el as TileWithAbort | undefined;
+      if (tile?.__wrcAbort) {
+        tile.__wrcAbort.abort();
+        tile.__wrcAbort = null;
+      }
+    }
+  });
 }
 
 // _updateOpacity body shared by FetchTileLayer and FetchWmsTileLayer when
@@ -166,6 +226,7 @@ export class FetchTileLayer extends L.TileLayer {
     this._tileFailed = 0;
     this._tileLoaded = 0;
     (L.TileLayer.prototype as any).initialize.call(this, url, options);
+    wireAbortLifecycle(this);
   }
 
   createTile(coords: L.Coords, done: L.DoneCallback): HTMLElement {
@@ -201,6 +262,7 @@ export class FetchWmsTileLayer extends L.TileLayer.WMS {
     const { rateLimiter, on429, animationOwnsOpacity, pixelFilter, ...wmsOptions } = options;
     (L.TileLayer.WMS.prototype as any).initialize.call(this, url, wmsOptions);
     Object.assign(this.options, { rateLimiter, on429, animationOwnsOpacity, pixelFilter });
+    wireAbortLifecycle(this);
   }
 
   createTile(coords: L.Coords, done: L.DoneCallback): HTMLElement {

--- a/src/nws-alerts-layer.ts
+++ b/src/nws-alerts-layer.ts
@@ -89,6 +89,13 @@ export class NwsAlertsLayer {
   // Used by resume() to decide whether to refetch immediately.
   private _pausedAt: number | null = null;
   private _gen = 0;
+  // Cancellation for the alerts-list fetch (set per _fetch call) and the
+  // per-zone fetches (single shared controller — they all become stale
+  // together when the layer tears down or the alert list is replaced).
+  // The gen check already discards stale responses; aborting just stops
+  // the wire bandwidth too.
+  private _abortCtrl: AbortController | null = null;
+  private _zoneAbortCtrl: AbortController | null = null;
 
   constructor(
     map: L.Map,
@@ -106,6 +113,10 @@ export class NwsAlertsLayer {
 
   clear(): void {
     this._gen++;   // invalidates any in-flight WFIGS / zone fetches
+    this._abortCtrl?.abort();
+    this._abortCtrl = null;
+    this._zoneAbortCtrl?.abort();
+    this._zoneAbortCtrl = null;
     if (this._timer) { clearTimeout(this._timer); this._timer = null; }
     if (this._polygonLayer) { this._map.removeLayer(this._polygonLayer); this._polygonLayer = null; }
     this._features = [];
@@ -151,13 +162,27 @@ export class NwsAlertsLayer {
 
   private async _fetch(): Promise<void> {
     const myGen = ++this._gen;
+    // Abort any previous alerts-list fetch and the in-flight zone fetches.
+    // The new alerts list will trigger a fresh _resolveZones pass on the
+    // affected-zones from the new payload; zones for alerts that dropped
+    // off the list are no longer interesting.
+    this._abortCtrl?.abort();
+    this._zoneAbortCtrl?.abort();
+    const ctrl = new AbortController();
+    this._abortCtrl = ctrl;
     let features: GeoJSON.Feature[] = [];
     try {
-      const res = await fetch(NWS_ALERTS_URL, { headers: { Accept: 'application/geo+json' } });
+      const res = await fetch(NWS_ALERTS_URL, {
+        headers: { Accept: 'application/geo+json' },
+        signal: ctrl.signal,
+      });
       if (!res.ok) throw new Error(`NWS fetch ${res.status}`);
       const data = await res.json() as GeoJSON.FeatureCollection;
       features = data?.features ?? [];
     } catch (err) {
+      // Deliberate cancellation (teardown / superseded). Drop silently;
+      // the new fetch is already in flight or the layer is going away.
+      if ((err as Error)?.name === 'AbortError') return;
       // Transient: NWS occasionally returns 5xx during outages. Retry on
       // the next scheduled interval; don't blow away currently-displayed
       // alerts (this._features is left intact below if features stays []).
@@ -166,6 +191,7 @@ export class NwsAlertsLayer {
       return;
     }
     if (myGen !== this._gen) return;   // stale
+    if (this._abortCtrl === ctrl) this._abortCtrl = null;
 
     // Filter, then sort lexicographically by (severity, urgency,
     // certainty) so the most actionable alerts paint last and end up
@@ -200,13 +226,21 @@ export class NwsAlertsLayer {
     }
     if (needed.size === 0) return;
 
+    // Shared controller for this batch — a fresh _fetch() that
+    // supersedes the current alerts list aborts the entire in-flight
+    // zone batch in one go (it's the new feature list that decides
+    // which zones are still relevant).
+    const ctrl = new AbortController();
+    this._zoneAbortCtrl = ctrl;
+
     // _fetchZone self-registers in _zoneFetches as its first action so the
     // entry exists before any sync return path (e.g. localStorage hit) can
     // hit the matching `finally { delete }`. We just collect the promises
     // here for the Promise.all join.
-    const promises = Array.from(needed, (url) => this._fetchZone(url));
+    const promises = Array.from(needed, (url) => this._fetchZone(url, ctrl.signal));
     await Promise.all(promises);
     if (myGen !== this._gen) return;   // stale (cleared / reconfigured during the fetch)
+    if (this._zoneAbortCtrl === ctrl) this._zoneAbortCtrl = null;
 
     // Skip-if-unchanged still applies — only the features whose zones
     // actually arrived will see their decision strings flip, so this is
@@ -214,7 +248,7 @@ export class NwsAlertsLayer {
     this._render({ skipIfDecisionsUnchanged: true });
   }
 
-  private async _fetchZone(url: string): Promise<void> {
+  private async _fetchZone(url: string, signal: AbortSignal): Promise<void> {
     // Self-register so concurrent callers dedupe. Registration must happen
     // BEFORE the localStorage early-return path so the matching `finally
     // { delete }` always pairs with a real entry, never a stale one. If
@@ -238,6 +272,7 @@ export class NwsAlertsLayer {
       const myGen = this._gen;
       const res = await fetch(url, {
         headers: { Accept: 'application/geo+json' },
+        signal,
       });
       if (!res.ok) throw new Error(`zone fetch ${res.status}`);
       const data = await res.json();
@@ -250,6 +285,9 @@ export class NwsAlertsLayer {
         writeZoneToLocalStorage(url, geom);
       }
     } catch (err) {
+      // Deliberate cancellation — alert list was replaced; new
+      // _resolveZones pass will refetch any still-relevant zones.
+      if ((err as Error)?.name === 'AbortError') return;
       // Per-zone failures are common (404s on retired zones, transient
       // network blips). Log once and move on; the alert's other zones
       // may still resolve and render.

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -222,6 +222,12 @@ export class RadarPlayer {
   private _frameStatuses: FrameStatus[] = [];
   private _radarReady = false;
   private _frameGeneration = 0;
+  // Abort the RainViewer JSON metadata fetch (called from _fetchPaths)
+  // when a new generation supersedes the previous one or the player is
+  // torn down. The generation check already discards stale responses;
+  // aborting just stops the wire bandwidth too. Only used by the
+  // RainViewer path; DWD / NOAA derive frame timestamps locally.
+  private _pathsAbortCtrl: AbortController | null = null;
   private _configFrameCount = 5;
   private _doRadarUpdate = false;
 
@@ -356,6 +362,8 @@ export class RadarPlayer {
   clear(): void {
     this._stopLoop();
     this._clearLayers();
+    this._pathsAbortCtrl?.abort();
+    this._pathsAbortCtrl = null;
     this._map?.off('zoomend', this._onZoomEnd);
     if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
     this._worker?.terminate();
@@ -933,8 +941,23 @@ export class RadarPlayer {
       }
       return frames;
     }
-    const res = await fetch('https://api.rainviewer.com/public/weather-maps.json');
-    const data = await res.json();
+    this._pathsAbortCtrl?.abort();
+    const ctrl = new AbortController();
+    this._pathsAbortCtrl = ctrl;
+    let data: { host?: string; radar?: { past?: unknown[] } };
+    try {
+      const res = await fetch('https://api.rainviewer.com/public/weather-maps.json', {
+        signal: ctrl.signal,
+      });
+      data = await res.json();
+    } catch (err) {
+      // Aborted by a fresh _fetchPaths or by teardown — the caller's
+      // generation check will discard the empty result we return below.
+      if ((err as Error)?.name === 'AbortError') return [];
+      throw err;
+    } finally {
+      if (this._pathsAbortCtrl === ctrl) this._pathsAbortCtrl = null;
+    }
     const host: string = data.host ?? 'https://tilecache.rainviewer.com';
     const past: RadarFrame[] = (data?.radar?.past ?? []).map((f: any) => ({
       time: f.time, path: f.path, host,

--- a/src/wildfire-layer.ts
+++ b/src/wildfire-layer.ts
@@ -87,6 +87,10 @@ export class WildfireLayer {
   // resolve point doesn't match, the fetch is stale (config changed mid-flight,
   // teardown happened, etc.) and we discard the result.
   private _gen = 0;
+  // Abort the in-flight fetches (NIFC + InciWeb) when a new fetch starts
+  // or the layer tears down, so the browser doesn't keep downloading
+  // payloads we've already decided to discard via the gen check.
+  private _abortCtrl: AbortController | null = null;
   private _zoomHandler: (() => void) | null = null;
 
   constructor(
@@ -110,6 +114,8 @@ export class WildfireLayer {
 
   clear(): void {
     this._gen++;   // invalidate any in-flight fetches
+    this._abortCtrl?.abort();   // cancel the HTTP requests too, not just the response handling
+    this._abortCtrl = null;
     if (this._timer) { clearTimeout(this._timer); this._timer = null; }
     if (this._zoomHandler) {
       this._map.off('zoomend', this._zoomHandler);
@@ -161,13 +167,20 @@ export class WildfireLayer {
 
   private async _fetch(): Promise<void> {
     const myGen = ++this._gen;
+    // Abort any previous in-flight fetches so their bytes stop hitting
+    // the wire — the gen check below would discard the response anyway,
+    // but on mobile we'd rather not pay the bandwidth.
+    this._abortCtrl?.abort();
+    const ctrl = new AbortController();
+    this._abortCtrl = ctrl;
     // Fetch WFIGS perimeters and the InciWeb incident index in parallel —
     // they're independent and we want the latest of both before re-rendering.
     const [features, inciwebSlugs] = await Promise.all([
-      this._fetchWfigs(),
-      this._fetchInciwebSlugs(),
+      this._fetchWfigs(ctrl.signal),
+      this._fetchInciwebSlugs(ctrl.signal),
     ]);
     if (myGen !== this._gen) return;   // stale — abandon
+    if (this._abortCtrl === ctrl) this._abortCtrl = null;
 
     this._features = this._filter(features);
     if (inciwebSlugs) {
@@ -178,13 +191,16 @@ export class WildfireLayer {
     this._scheduleNext();
   }
 
-  private async _fetchWfigs(): Promise<GeoJSON.Feature[]> {
+  private async _fetchWfigs(signal: AbortSignal): Promise<GeoJSON.Feature[]> {
     try {
-      const res = await fetch(NIFC_URL);
+      const res = await fetch(NIFC_URL, { signal });
       if (!res.ok) throw new Error(`NIFC fetch ${res.status}`);
       const data = await res.json() as GeoJSON.FeatureCollection;
       return (data?.features ?? []).filter((f): f is GeoJSON.Feature => !!f?.geometry);
     } catch (err) {
+      // Deliberate cancellation (teardown / superseded by a fresh fetch).
+      // Not a real failure — caller's gen check will discard the result anyway.
+      if ((err as Error)?.name === 'AbortError') return [];
       // Transient — NIFC's ArcGIS endpoint occasionally rate-limits or
       // returns 503. Next scheduled fetch will retry.
       console.warn('Wildfire layer: WFIGS fetch failed', err);
@@ -195,9 +211,9 @@ export class WildfireLayer {
   // Fetch InciWeb's RSS and extract the slug (path segment) from every
   // incident link. Returns null on failure so the caller can leave the
   // existing slug set in place (avoid blowing it away on a transient error).
-  private async _fetchInciwebSlugs(): Promise<Set<string> | null> {
+  private async _fetchInciwebSlugs(signal: AbortSignal): Promise<Set<string> | null> {
     try {
-      const res = await fetch(INCIWEB_RSS_URL);
+      const res = await fetch(INCIWEB_RSS_URL, { signal });
       if (!res.ok) throw new Error(`InciWeb RSS fetch ${res.status}`);
       const text = await res.text();
       const doc = new DOMParser().parseFromString(text, 'application/xml');
@@ -210,6 +226,9 @@ export class WildfireLayer {
       });
       return slugs;
     } catch (err) {
+      // Deliberate cancellation (teardown / superseded by a fresh fetch).
+      // Not a real failure — return null so the caller keeps the prior slug set.
+      if ((err as Error)?.name === 'AbortError') return null;
       // CORS, network, or parse failure. Leave the previous set intact and
       // fall back to "show link" behaviour for new fires until next refresh.
       console.warn('Wildfire layer: InciWeb RSS fetch failed', err);

--- a/tests/fetch-abort.test.ts
+++ b/tests/fetch-abort.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+// Stub Leaflet — fetch-tile-layer.ts imports from 'leaflet' but the
+// internal helpers we exercise don't touch any real L.* class. Provide
+// just enough so the import resolves; the helpers operate on plain
+// objects we pass in.
+vi.mock('leaflet', () => {
+  class TileLayer {}
+  class WMS {}
+  return {
+    TileLayer: Object.assign(TileLayer, { WMS }),
+    default: { TileLayer: Object.assign(TileLayer, { WMS }) },
+  };
+});
+
+import { wireAbortLifecycle, createFetchTile, type TileWithAbort } from '../src/fetch-tile-layer';
+
 // Regression guards for the AbortController pattern the fetcher code
 // relies on. The actual layer integration (FetchTileLayer, WildfireLayer,
 // NwsAlertsLayer, RadarPlayer) isn't exercised here — those need full
@@ -173,5 +188,196 @@ describe('Fetcher pattern: abort-previous on supersession + abort on teardown', 
     // After success, teardown should be a no-op for an already-settled fetch.
     expect(() => f.teardown()).not.toThrow();
     expect(f.abortedCount).toBe(0);
+  });
+});
+
+// ── wireAbortLifecycle integration ────────────────────────────────────────
+// Exercises the actual fetch-tile-layer helper that hooks Leaflet's
+// tileunload + remove events. Uses a minimal layer stub so we don't
+// need a real L.TileLayer instance (consistent with the project's
+// "stub leaflet, test the helpers" convention from wind-helpers.test.ts).
+
+describe('wireAbortLifecycle (fetch-tile-layer)', () => {
+  // Minimal mock that quacks like a Leaflet TileLayer for the bits the
+  // helper touches: .on() to register listeners, ._tiles record of
+  // mounted tiles. Layers from FetchTileLayer / FetchWmsTileLayer
+  // would supply the same shape with real Leaflet plumbing behind it.
+  function makeMockLayer(): {
+    listeners: Map<string, (e: { tile?: HTMLElement }) => void>;
+    on: ReturnType<typeof vi.fn>;
+    _tiles: Record<string, { el: HTMLElement }>;
+  } {
+    const listeners = new Map<string, (e: { tile?: HTMLElement }) => void>();
+    return {
+      listeners,
+      on: vi.fn((event: string, fn: (e: { tile?: HTMLElement }) => void) => {
+        listeners.set(event, fn);
+      }),
+      _tiles: {},
+    };
+  }
+
+  function makeTileWithAbort(): { tile: TileWithAbort; ctrl: AbortController } {
+    const tile = document.createElement('img') as TileWithAbort;
+    const ctrl = new AbortController();
+    tile.__wrcAbort = ctrl;
+    return { tile, ctrl };
+  }
+
+  it('registers tileunload and remove handlers on the layer', () => {
+    const layer = makeMockLayer();
+    wireAbortLifecycle(layer as never);
+    expect(layer.on).toHaveBeenCalledWith('tileunload', expect.any(Function));
+    expect(layer.on).toHaveBeenCalledWith('remove', expect.any(Function));
+  });
+
+  it('tileunload aborts the unloading tile\'s controller and clears the pointer', () => {
+    const layer = makeMockLayer();
+    wireAbortLifecycle(layer as never);
+    const { tile, ctrl } = makeTileWithAbort();
+    const unloadHandler = layer.listeners.get('tileunload')!;
+    unloadHandler({ tile });
+    expect(ctrl.signal.aborted).toBe(true);
+    expect(tile.__wrcAbort).toBeNull();
+  });
+
+  it('tileunload on a tile without __wrcAbort is a safe no-op (settled fetch)', () => {
+    const layer = makeMockLayer();
+    wireAbortLifecycle(layer as never);
+    const tile = document.createElement('img') as TileWithAbort;
+    // Either undefined (never set) or null (cleared by success/failure).
+    const unloadHandler = layer.listeners.get('tileunload')!;
+    expect(() => unloadHandler({ tile })).not.toThrow();
+  });
+
+  it('remove aborts every still-pending tile in the layer\'s _tiles map', () => {
+    const layer = makeMockLayer();
+    wireAbortLifecycle(layer as never);
+    const a = makeTileWithAbort();
+    const b = makeTileWithAbort();
+    const c = makeTileWithAbort();
+    layer._tiles = {
+      '0:0:0': { el: a.tile },
+      '0:0:1': { el: b.tile },
+      '0:0:2': { el: c.tile },
+    };
+    const removeHandler = layer.listeners.get('remove')!;
+    removeHandler({});
+    expect(a.ctrl.signal.aborted).toBe(true);
+    expect(b.ctrl.signal.aborted).toBe(true);
+    expect(c.ctrl.signal.aborted).toBe(true);
+    expect(a.tile.__wrcAbort).toBeNull();
+    expect(b.tile.__wrcAbort).toBeNull();
+    expect(c.tile.__wrcAbort).toBeNull();
+  });
+
+  it('remove skips already-settled tiles (no double-abort, no throw)', () => {
+    const layer = makeMockLayer();
+    wireAbortLifecycle(layer as never);
+    const settled = document.createElement('img') as TileWithAbort;
+    // settled.__wrcAbort already null — typical of a tile whose fetch
+    // succeeded earlier. remove must not crash on it.
+    const inflight = makeTileWithAbort();
+    layer._tiles = {
+      '0:0:0': { el: settled },
+      '0:0:1': { el: inflight.tile },
+    };
+    const removeHandler = layer.listeners.get('remove')!;
+    expect(() => removeHandler({})).not.toThrow();
+    expect(inflight.ctrl.signal.aborted).toBe(true);
+  });
+});
+
+// ── createFetchTile integration ───────────────────────────────────────────
+
+describe('createFetchTile (fetch-tile-layer)', () => {
+  let fetchCalls: Array<{ url: string; signal: AbortSignal | undefined; resolve: (b: Blob) => void; reject: (err: Error) => void }>;
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    global.fetch = vi.fn((url: string | URL, init?: RequestInit) => {
+      let resolve!: (b: Blob) => void;
+      let reject!: (err: Error) => void;
+      const responsePromise = new Promise<Response>((res, rej) => {
+        resolve = (b: Blob) => res(new Response(b, { status: 200 }));
+        reject = (err: Error) => rej(err);
+      });
+      const signal = init?.signal as AbortSignal | undefined;
+      if (signal) {
+        const onAbort = (): void => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          reject(e);
+        };
+        if (signal.aborted) onAbort();
+        else signal.addEventListener('abort', onAbort, { once: true });
+      }
+      fetchCalls.push({ url: String(url), signal, resolve, reject });
+      return responsePromise;
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  // Minimal layer stub with the surface createFetchTile reads:
+  //   getTileUrl(coords) → string
+  //   options (FetchTileOptions — rateLimiter etc.)
+  //   _tilePending / _tileFailed / _tileLoaded counters
+  function makeFetchLayerStub(): {
+    getTileUrl: ReturnType<typeof vi.fn>;
+    options: Record<string, unknown>;
+    _tilePending: number;
+    _tileFailed: number;
+    _tileLoaded: number;
+  } {
+    return {
+      getTileUrl: vi.fn(() => 'https://tiles.test/0/0/0.png'),
+      options: { maxRetries: 1, retryDelay: 0 },
+      _tilePending: 0,
+      _tileFailed: 0,
+      _tileLoaded: 0,
+    };
+  }
+
+  it('passes an AbortSignal to fetch and stores the controller on the tile', () => {
+    const layer = makeFetchLayerStub();
+    const done = vi.fn();
+    const tile = createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done) as TileWithAbort;
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].signal).toBeInstanceOf(AbortSignal);
+    expect(tile.__wrcAbort).toBeInstanceOf(AbortController);
+    // Both should reference the same underlying controller.
+    expect(fetchCalls[0].signal).toBe(tile.__wrcAbort!.signal);
+    expect(layer._tilePending).toBe(1);
+  });
+
+  it('aborting the tile\'s controller decrements pending without counting as failure', async () => {
+    const layer = makeFetchLayerStub();
+    const done = vi.fn();
+    const tile = createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done) as TileWithAbort;
+    expect(layer._tilePending).toBe(1);
+    tile.__wrcAbort!.abort();
+    // Settle microtasks so the fetch rejection's .catch handler runs.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(layer._tilePending).toBe(0);
+    expect(layer._tileFailed).toBe(0);          // aborts are not failures
+    expect(layer._tileLoaded).toBe(0);
+    expect(done).not.toHaveBeenCalled();        // tile is already off the map
+    expect(tile.__wrcAbort).toBeNull();
+  });
+
+  it('a real HTTP failure still increments tileFailed and calls done', async () => {
+    const layer = makeFetchLayerStub();
+    const done = vi.fn();
+    createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+    fetchCalls[0].reject(new Error('boom'));
+    // Wait for the retry-then-fail chain (maxRetries: 1, retryDelay: 0).
+    await new Promise((r) => setTimeout(r, 5));
+    expect(layer._tilePending).toBe(0);
+    expect(layer._tileFailed).toBe(1);
+    expect(done).toHaveBeenCalled();
   });
 });

--- a/tests/fetch-abort.test.ts
+++ b/tests/fetch-abort.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Regression guards for the AbortController pattern the fetcher code
+// relies on. The actual layer integration (FetchTileLayer, WildfireLayer,
+// NwsAlertsLayer, RadarPlayer) isn't exercised here — those need full
+// Leaflet/DOM mocking that the existing test suite avoids on principle.
+// Instead these tests lock in the contract our error-handler branches
+// depend on, so a future "simplification" that drops the
+// `.name === 'AbortError'` check or assumes a different exception type
+// breaks loud rather than silently.
+
+describe('AbortController + AbortSignal contract (regression guard)', () => {
+  it('AbortError thrown by signal.throwIfAborted has name "AbortError"', () => {
+    // Our layer error handlers all branch on `(err as Error)?.name ===
+    // 'AbortError'` to distinguish user-initiated cancellation from
+    // network failure. If the runtime ever switched to a different name
+    // (DOMException codes, custom errors, etc.) every layer's error
+    // path would silently mis-classify the cancellation as a real error.
+    const ctrl = new AbortController();
+    ctrl.abort();
+    try {
+      ctrl.signal.throwIfAborted();
+      throw new Error('throwIfAborted should have thrown');
+    } catch (err) {
+      expect((err as Error).name).toBe('AbortError');
+    }
+  });
+
+  it('aborting after settlement is a no-op (does not throw)', () => {
+    // After a fetch resolves, we null out the stored controller. If the
+    // layer is torn down later, ctrl?.abort() may target a controller
+    // whose fetch already settled. The spec guarantees that's safe;
+    // pin against any runtime change to that.
+    const ctrl = new AbortController();
+    expect(() => ctrl.abort()).not.toThrow();
+    expect(() => ctrl.abort()).not.toThrow();
+  });
+
+  it('aborted signal reports aborted=true and reason="AbortError"', () => {
+    const ctrl = new AbortController();
+    expect(ctrl.signal.aborted).toBe(false);
+    ctrl.abort();
+    expect(ctrl.signal.aborted).toBe(true);
+    expect((ctrl.signal.reason as Error)?.name).toBe('AbortError');
+  });
+});
+
+// Replicate the pattern used in wildfire-layer / nws-alerts-layer /
+// radar-player so we can test it without Leaflet. If this helper's
+// behaviour drifts from the real code, we should refactor to share —
+// for now the simplicity wins. Both layers call:
+//   this._ctrl?.abort();
+//   const ctrl = new AbortController();
+//   this._ctrl = ctrl;
+//   try { ... } catch (err) { if (err.name === 'AbortError') return; }
+//   finally { if (this._ctrl === ctrl) this._ctrl = null; }
+class Fetcher {
+  private _ctrl: AbortController | null = null;
+  abortedCount = 0;
+  succeededCount = 0;
+  erroredCount = 0;
+
+  async fetchUrl(url: string): Promise<string | null> {
+    this._ctrl?.abort();
+    const ctrl = new AbortController();
+    this._ctrl = ctrl;
+    try {
+      const res = await fetch(url, { signal: ctrl.signal });
+      const text = await res.text();
+      this.succeededCount++;
+      return text;
+    } catch (err) {
+      if ((err as Error)?.name === 'AbortError') {
+        this.abortedCount++;
+        return null;
+      }
+      this.erroredCount++;
+      throw err;
+    } finally {
+      if (this._ctrl === ctrl) this._ctrl = null;
+    }
+  }
+
+  teardown(): void {
+    this._ctrl?.abort();
+    this._ctrl = null;
+  }
+}
+
+describe('Fetcher pattern: abort-previous on supersession + abort on teardown', () => {
+  // Mock fetch with controllable promises so the tests don't depend on
+  // network or happy-dom's quirky AbortError handling.
+  let fetchCalls: Array<{ url: string; signal: AbortSignal; resolve: (text: string) => void; reject: (err: Error) => void }>;
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    global.fetch = vi.fn((url: string | URL, init?: RequestInit) => {
+      let resolve!: (text: string) => void;
+      let reject!: (err: Error) => void;
+      const responsePromise = new Promise<Response>((res, rej) => {
+        resolve = (text: string) => res(new Response(text));
+        reject = (err: Error) => rej(err);
+      });
+      const signal = init?.signal as AbortSignal;
+      // Wire abort → reject(AbortError) so the mock matches browser
+      // fetch's behaviour. happy-dom's fetch doesn't do this reliably.
+      if (signal) {
+        const onAbort = (): void => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          reject(e);
+        };
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+      fetchCalls.push({ url: String(url), signal, resolve, reject });
+      return responsePromise;
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('a fresh fetch aborts the in-flight previous one and is counted as AbortError', async () => {
+    const f = new Fetcher();
+    const first = f.fetchUrl('https://a.test/1');
+    // Second call should abort the first before issuing its own request.
+    const second = f.fetchUrl('https://a.test/2');
+    // Resolve the second so the test doesn't hang on its unresolved promise.
+    expect(fetchCalls.length).toBe(2);
+    fetchCalls[1].resolve('second-body');
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult).toBeNull();      // first caught AbortError → returned null
+    expect(secondResult).toBe('second-body');
+    expect(f.abortedCount).toBe(1);
+    expect(f.succeededCount).toBe(1);
+    expect(f.erroredCount).toBe(0);
+    // The first call's signal should report aborted; the second's should not.
+    expect(fetchCalls[0].signal.aborted).toBe(true);
+    expect(fetchCalls[1].signal.aborted).toBe(false);
+  });
+
+  it('teardown aborts the in-flight fetch', async () => {
+    const f = new Fetcher();
+    const inflight = f.fetchUrl('https://a.test/3');
+    expect(fetchCalls.length).toBe(1);
+    f.teardown();
+    const result = await inflight;
+    expect(result).toBeNull();
+    expect(f.abortedCount).toBe(1);
+    expect(fetchCalls[0].signal.aborted).toBe(true);
+  });
+
+  it('non-AbortError exceptions propagate (do not get swallowed as cancellations)', async () => {
+    const f = new Fetcher();
+    const p = f.fetchUrl('https://a.test/4');
+    fetchCalls[0].reject(new Error('network blew up'));
+    await expect(p).rejects.toThrow('network blew up');
+    expect(f.erroredCount).toBe(1);
+    expect(f.abortedCount).toBe(0);
+  });
+
+  it('a successful fetch clears the stored controller so teardown does not double-abort', async () => {
+    const f = new Fetcher();
+    const p = f.fetchUrl('https://a.test/5');
+    fetchCalls[0].resolve('ok');
+    expect(await p).toBe('ok');
+    // After success, teardown should be a no-op for an already-settled fetch.
+    expect(() => f.teardown()).not.toThrow();
+    expect(f.abortedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

On a mobile or rate-limited connection, a user panning rapidly burns bandwidth on tile fetches that get immediately superseded. The existing generation-counter trick correctly discards stale **responses**, but the browser still downloads the full payload first. This PR adds per-fetch `AbortController` so superseded fetches stop hitting the wire.

Identified during the Gemini code review pass — issue #3 of 4. (The other three are tracked separately: phantom-deps + MarkerCluster comment already on master; TS module augmentation deferred to a 3.8 health pass; Worker for the DWD pixel filter deferred until profiling shows main-thread spikes.)

## Four sites instrumented

| File | Pattern | Trigger |
|---|---|---|
| `fetch-tile-layer.ts` | Per-tile `AbortController` stored on the tile element as `__wrcAbort` | Leaflet's `tileunload` event (pan/zoom-out), `remove` event (teardown) |
| `wildfire-layer.ts` | Per-refresh `AbortController` shared by NIFC + InciWeb fetches | New `_fetch()` supersedes prior, `clear()` |
| `nws-alerts-layer.ts` | Two controllers: alerts-list + shared zone batch | New `_fetch()` supersedes, `clear()` |
| `radar-player.ts` | Per-`_fetchPaths` controller for RainViewer JSON metadata | Generation bump, teardown |

## Skipped intentionally

`wind-grid-fetcher.ts` uses request-coalescing across multiple callers. Aborting it correctly requires reference-counting consumers; the 60s cache TTL already provides similar bandwidth conservation. Revisit when explicit per-card cancellation becomes a real need (e.g., the layer-control panel work scheduled for 3.7).

## Error-handler contract

All four sites branch on `(err as Error)?.name === 'AbortError'` to distinguish user-initiated cancellation from a real network error. Cancelled fetches don't trigger retry logic, don't increment failure counters, and don't call Leaflet's `done(undefined, tile)` callback (the tile is already off the map by the time abort fires).

## Tests: 440 → 455 (+15)

Two new test groups in `tests/fetch-abort.test.ts`:

- **Pattern tests** (+7) — pin the `AbortController` / `AbortSignal` contracts the error-handler branches depend on (`name === 'AbortError'`, double-abort is safe, etc.), and the abort-previous-on-supersession pattern via a small `Fetcher` helper.
- **Integration tests** (+8) — exercise `wireAbortLifecycle` and `createFetchTile` directly via minimal layer stubs. Confirms `tileunload` aborts the tile's controller, `remove` aborts every pending tile in `_tiles`, and real HTTP failures still go through the failure path (aborts ≠ failures).

Two internal helpers in `fetch-tile-layer.ts` exported with `@internal` markers to enable the integration tests without requiring a full `L.TileLayer` instance — same convention as `wind-helpers.test.ts`.

## Test plan

- [x] Lint clean
- [x] 455/455 tests pass
- [x] Rollup build succeeds
- [x] Local browser verification: panning rapidly at low zoom now shows tile requests with status `(canceled)` in DevTools Network tab. Previously all completed as `200 OK`.
- [x] No regression in steady-state playback (tiles recycle without unloading → no aborts, correct).
- [x] No console output from the abort path (verified — the "fetch finished" lines were Chrome's "Log network activity" option, not us).

## Target release

**3.6.2** patch. Bundles with the two batch-1 housekeeping commits already on master (phantom-deps removal + MarkerCluster doc-block). No new features, no experimental items, all cleanup / perf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)