### PR TITLE
fix: migrate ha-textfield → ha-input (LOCATION/ANIMATION/etc. invisible in editor)

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -218,20 +218,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         <!-- LOCATION -->
         <h3 class="section-header">${localize('editor.section.location')}</h3>
         <div class="side-by-side">
-          <ha-textfield
+          <ha-input
             label=${localize('editor.location.centre_latitude')}
             .value=${this._formatCoordinateValue(config.center_latitude)}
             .configValue=${'center_latitude'}
             @input=${this._valueChangedCoordinate}
-            helper=${localize('editor.location.number_or_entity')}
-          ></ha-textfield>
-          <ha-textfield
+            hint=${localize('editor.location.number_or_entity')}
+          ></ha-input>
+          <ha-input
             label=${localize('editor.location.centre_longitude')}
             .value=${this._formatCoordinateValue(config.center_longitude)}
             .configValue=${'center_longitude'}
             @input=${this._valueChangedCoordinate}
-            helper=${localize('editor.location.number_or_entity')}
-          ></ha-textfield>
+            hint=${localize('editor.location.number_or_entity')}
+          ></ha-input>
         </div>
 
         <!-- MARKERS AND OVERLAYS -->
@@ -373,20 +373,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         <!-- ANIMATION -->
         <h3 class="section-header">${localize('editor.section.animation')}</h3>
         <div class="side-by-side">
-          <ha-textfield
+          <ha-input
             label=${localize('editor.animation.frame_delay')}
             .value=${config.frame_delay ? config.frame_delay : ''}
             .configValue=${'frame_delay'}
             @input=${this._valueChangedNumber}
-            helper=${localize('editor.animation.default_500')}
-          ></ha-textfield>
-          <ha-textfield
+            hint=${localize('editor.animation.default_500')}
+          ></ha-input>
+          <ha-input
             label=${localize('editor.animation.restart_delay')}
             .value=${config.restart_delay ? config.restart_delay : ''}
             .configValue=${'restart_delay'}
             @input=${this._valueChangedNumber}
-            helper=${localize('editor.animation.default_1000')}
-          ></ha-textfield>
+            hint=${localize('editor.animation.default_1000')}
+          ></ha-input>
         </div>
         <label>
           <ha-switch
@@ -397,14 +397,14 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
           <span>${localize('editor.animation.animated_transitions')}</span>
         </label>
         ${config.animated_transitions !== false ? html`
-          <ha-textfield
+          <ha-input
             label=${localize('editor.animation.transition_time')}
             .value=${config.transition_time !== undefined ? config.transition_time : ''}
             .configValue=${'transition_time'}
             @input=${this._valueChangedNumber}
-            helper=${localize('editor.animation.transition_time_helper')}
+            hint=${localize('editor.animation.transition_time_helper')}
             ?disabled=${config.smooth_animation === true}
-          ></ha-textfield>
+          ></ha-input>
           <label>
             <ha-switch
               .checked=${config.smooth_animation === true}
@@ -428,20 +428,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         <!-- APPEARANCE -->
         <h3 class="section-header">${localize('editor.section.appearance')}</h3>
         <div class="side-by-side">
-          <ha-textfield
+          <ha-input
             label=${localize('editor.appearance.height')}
             .value=${config.height ? config.height : ''}
             .configValue=${'height'}
             @input=${this._valueChangedString}
-            helper=${localize('editor.appearance.height_helper')}
-          ></ha-textfield>
-          <ha-textfield
+            hint=${localize('editor.appearance.height_helper')}
+          ></ha-input>
+          <ha-input
             label=${localize('editor.appearance.width')}
             .value=${config.width ? config.width : ''}
             .configValue=${'width'}
             @input=${this._valueChangedString}
-            helper=${localize('editor.appearance.width_helper')}
-          ></ha-textfield>
+            hint=${localize('editor.appearance.width_helper')}
+          ></ha-input>
         </div>
         <ha-selector
           .hass=${this.hass}
@@ -578,20 +578,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         </label>
         ${config.show_wildfires === true ? html`
           <div class="side-by-side">
-            <ha-textfield
+            <ha-input
               label=${localize('editor.overlays.wildfire_min_acres')}
               .value=${config.wildfire_min_acres !== undefined ? String(config.wildfire_min_acres) : ''}
-              helper=${localize('editor.overlays.wildfire_min_acres_helper')}
+              hint=${localize('editor.overlays.wildfire_min_acres_helper')}
               .configValue=${'wildfire_min_acres'}
               @input=${this._valueChangedNumber}
-            ></ha-textfield>
-            <ha-textfield
+            ></ha-input>
+            <ha-input
               label=${localize('editor.overlays.wildfire_radius_km')}
               .value=${config.wildfire_radius_km !== undefined ? String(config.wildfire_radius_km) : ''}
-              helper=${localize('editor.overlays.wildfire_radius_km_helper')}
+              hint=${localize('editor.overlays.wildfire_radius_km_helper')}
               .configValue=${'wildfire_radius_km'}
               @input=${this._valueChangedNumber}
-            ></ha-textfield>
+            ></ha-input>
           </div>
         ` : ''}
 
@@ -622,13 +622,13 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
             .configValue=${'alerts_min_severity'}
             @value-changed=${this._handleSelectorChanged}
           ></ha-selector>
-          <ha-textfield
+          <ha-input
             label=${localize('editor.overlays.alerts_radius_km')}
             .value=${config.alerts_radius_km !== undefined ? String(config.alerts_radius_km) : ''}
-            helper=${localize('editor.overlays.alerts_radius_km_helper')}
+            hint=${localize('editor.overlays.alerts_radius_km_helper')}
             .configValue=${'alerts_radius_km'}
             @input=${this._valueChangedNumber}
-          ></ha-textfield>
+          ></ha-input>
           <p class="section-description" style="margin-top:12px">${localize('editor.overlays.alerts_categories_label')}</p>
           ${this._renderAlertCategoryToggles(config)}
         ` : ''}
@@ -659,13 +659,13 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         <span>${localize('editor.display.show_lightning')}</span>
       </label>
       ${config.show_lightning === true && integrationLoaded ? html`
-        <ha-textfield
+        <ha-input
           label=${localize('editor.overlays.lightning_max_age_minutes')}
           .value=${config.lightning_max_age_minutes !== undefined ? String(config.lightning_max_age_minutes) : ''}
-          helper=${localize('editor.overlays.lightning_max_age_minutes_helper')}
+          hint=${localize('editor.overlays.lightning_max_age_minutes_helper')}
           .configValue=${'lightning_max_age_minutes'}
           @input=${this._valueChangedNumber}
-        ></ha-textfield>
+        ></ha-input>
       ` : ''}
     `;
   }
@@ -717,7 +717,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         </button>
         <h3 class="section-header">${localize('editor.section.markers')}</h3>
         ${markers.map((m, i) => this._renderMarkerRow(m, i))}
-        <button class="add-marker-btn" @click=${this._addMarker}>${localize('editor.markers.add')}</button>
+        <ha-button class="add-marker-btn" @click=${this._addMarker}>${localize('editor.markers.add')}</ha-button>
       </div>
     `;
   }
@@ -741,7 +741,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
       <div class="marker-row">
         <div class="marker-row-header">
           <span class="marker-row-label">${localize('editor.markers.label', '{n}', String(i + 1))}</span>
-          <button class="remove-marker-btn" @click=${() => this._removeMarker(i)}>${localize('editor.markers.remove')}</button>
+          <ha-button class="remove-marker-btn" @click=${() => this._removeMarker(i)}>${localize('editor.markers.remove')}</ha-button>
         </div>
         <ha-selector
           .hass=${this.hass}
@@ -762,20 +762,20 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
         ></ha-selector>
         ${!m.entity ? html`
           <div class="side-by-side">
-            <ha-textfield
+            <ha-input
               label=${localize('editor.markers.latitude')}
               .value=${m.latitude !== undefined ? String(m.latitude) : ''}
               .markerIndex=${i}
               .markerField=${'latitude'}
               @input=${this._updateMarkerFieldNumber}
-            ></ha-textfield>
-            <ha-textfield
+            ></ha-input>
+            <ha-input
               label=${localize('editor.markers.longitude')}
               .value=${m.longitude !== undefined ? String(m.longitude) : ''}
               .markerIndex=${i}
               .markerField=${'longitude'}
               @input=${this._updateMarkerFieldNumber}
-            ></ha-textfield>
+            ></ha-input>
           </div>
         ` : ''}
         ${m.entity && m.entity.startsWith('person.') ? html`
@@ -798,13 +798,13 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
             @value-changed=${this._updateMarkerSelector}
           ></ha-icon-picker>
         ` : html`
-          <ha-textfield
+          <ha-input
             label=${localize('editor.markers.icon_entity')}
             .value=${m.icon_entity || ''}
             .markerIndex=${i}
             .markerField=${'icon_entity'}
             @input=${this._updateMarkerField}
-          ></ha-textfield>
+          ></ha-input>
         `}
         <ha-selector
           .hass=${this.hass}
@@ -825,7 +825,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
               @input=${this._updateMarkerColor}
             />
             ${m.color ? html`
-              <button class="clear-color-btn" @click=${() => this._clearMarkerColor(i)}>${localize('editor.markers.reset')}</button>
+              <ha-button class="clear-color-btn" @click=${() => this._clearMarkerColor(i)}>${localize('editor.markers.reset')}</ha-button>
             ` : ''}
           </div>
         ` : ''}
@@ -1285,7 +1285,7 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
   static styles: CSSResultGroup = css`
     ha-select,
     ha-selector,
-    ha-textfield {
+    ha-input {
       margin-bottom: 16px;
       display: block;
     }


### PR DESCRIPTION
## Summary

- **Real bug:** \`ha-textfield\` was removed from the HA frontend on 2026-04-01 (commit "Migrate all from ha-textfield to ha-input #30349"). The element no longer registers, so every \`<ha-textfield>\` in our editor renders invisible with zero height. Users opening the GUI editor see empty space where LOCATION lat/long, ANIMATION timings, APPEARANCE height/width, OVERLAYS wildfire knobs, and marker position fields should be. YAML editing is the only workaround.
- **Fix:** mechanical migration to the replacement element \`<ha-input>\`. API mapping verified against HA frontend source + @home-assistant/webawesome wa-input typings — \`.value\`, \`.configValue\`, \`@input\`, \`?disabled\`, \`label\` all unchanged; \`helper="..."\` renamed to \`hint="..."\`.
- **Bonus (rolled in by request):** three cosmetic \`<button>\` → \`<ha-button>\` swaps for the marker action buttons (Add / Remove / Reset). Verified via Test A that ha-button registers reliably in the editor context.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 455/455 vitest specs pass
- [x] \`npm run build\` — clean rebuild

**Manual / UI verification (in Docker HA testbed, \`npm run ha:up\`):**
- [x] LOCATION section: lat/long input fields now visible; typed values save and persist across editor reopens
- [x] ANIMATION: Frame Delay, Restart Delay, Transition Time inputs all render
- [x] APPEARANCE: Height, Width inputs render
- [x] OVERLAYS: Wildfire Min Acres, Wildfire Radius inputs render
- [x] MARKERS sub-page: Add / Remove / Reset buttons render as proper HA pill buttons on first paint
- [x] Browser DevTools console: zero errors mentioning \`ha-input\`, \`ha-textfield\`, "unknown element", or property warnings

## Risk

- **Low.** One-for-one element swap with verified-equivalent API. Worst-case failure mode if there's an undocumented behaviour difference: a specific input field behaves slightly differently (e.g. number-input keyboard hint on mobile), caught by further manual testing or a user report. No data-shape change, no config migration, no breaking API.
- **What this PR does NOT touch (deliberate scope discipline):**
  - \`ha-selector\` (6 \`.helper=\` property bindings) — different element, unchanged API, working fine
  - \`type="number"\` on numeric inputs — would be a mobile-UX polish (numeric keyboard, spin buttons) but it's scope creep on a bug fix. Worth a follow-up enhancement.
  - 6 other bare \`<button>\` elements (subpage-nav-row tiles, subpage-back links) — their custom 3-column / back-link layouts don't fit \`<ha-button>\` cleanly. Stay bare.

## Docs touched

- [ ] \`README.md\`
- [ ] \`CHANGELOG.md\` (internal-only bug fix, no shape change; can be added if you want it noted for HACS users though)
- [ ] \`docs/todo.md\`
- [ ] \`AGENTS.md\`
- [ ] \`CLAUDE.md\`
- [x] n/a — internal change

## Background

Diagnosis discovered while testing a one-line \`<ha-button>\` experiment (Test A in the audit thread). Opening the editor revealed the LOCATION section was empty in current HA — investigation traced it to the ha-textfield removal. The user's global Claude memory notes \`ha-textfield\` as "the worst offender" for HA element reliability, which matched the symptom exactly. Per the diagnostic discipline in [AGENTS.md](AGENTS.md), root cause was confirmed (HA commit + replacement-element source) before any code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)