### PR TITLE
release: 3.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.3] - 2026-05-23
+
+> Patch release: fixes the GUI editor showing empty/invisible input fields under LOCATION, ANIMATION, APPEARANCE, OVERLAYS, and several marker fields on current HA versions. **The card itself was unaffected** — only the GUI editor was broken; YAML editing always worked. Plus a small cosmetic polish on the marker action buttons.
+
+### Fixed
+
+- **GUI editor inputs invisible on current HA versions** ([#166](https://github.com/jpettitt/weather-radar-card/pull/166)). HA frontend removed `ha-textfield` on 2026-04-01 ([commit "Migrate all from ha-textfield to ha-input #30349"](https://github.com/home-assistant/frontend/pull/30349)), so all 14 of our textfield usages rendered as zero-height invisible elements. Users opening the editor saw section headers (LOCATION, ANIMATION, etc.) with empty space below them — centre coordinates, frame delays, transition time, height/width, wildfire min acres, wildfire radius, and marker positions were uneditable via the GUI. Migrated all usages to the replacement element `ha-input` (1-to-1 API mapping; `helper="..."` renamed to `hint="..."` per the new element's webawesome convention).
+
+### Changed
+
+- **Marker action buttons now use `ha-button`.** The Add Marker, Remove (per marker), and Reset Color (per marker) buttons in the Markers sub-page render with HA's native pill-button style (theme color, white text, ripple) instead of browser-default. Cosmetic only; behaviour unchanged.
+
+### Internal
+
+- Six other bare `<button>` elements (subpage navigation tiles and back links) deliberately stay bare — their custom 3-column / back-link layouts don't fit `ha-button` cleanly.
+
 ## [3.6.2] - 2026-05-22
 
 > Patch release: bandwidth optimisation for mobile users (`AbortController` on tile + data fetches), cleanup of phantom dependencies, and a doc-block above the markercluster race workaround. **No new features, no behaviour changes for existing configs.** The 3.6.1 wind-source registry stays Experimental.
@@ -651,7 +667,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.2...HEAD
+[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.3...HEAD
+[3.6.3]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.2...v3.6.3
 [3.6.2]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.1...v3.6.2
 [3.6.1]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.1-rc1...v3.6.1
 [3.6.1-rc1]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.0...v3.6.1-rc1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.2';
+export const CARD_VERSION = '3.6.3';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
## Summary

Patch release for the \`ha-textfield\` → \`ha-input\` migration that landed in #166. **The card itself is unaffected** — this only fixes the GUI editor; YAML config editing always worked.

- **Fixed:** GUI editor input fields (LOCATION lat/long, ANIMATION timings, APPEARANCE height/width, OVERLAYS wildfire knobs, marker positions) rendering as invisible zero-height elements on current HA versions. HA frontend removed \`ha-textfield\` on 2026-04-01.
- **Changed:** marker action buttons (Add / Remove / Reset) now use \`ha-button\` for HA-native pill styling. Cosmetic only.
- **No behaviour changes for existing configs.** Drop-in patch over 3.6.2.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 455/455 vitest specs pass
- [x] \`npm run build\` — clean rebuild

**Manual / UI verification:** already done in #166 (the underlying fix PR); this release PR adds only version bumps and CHANGELOG. No source code changed since #166 merged.

## Risk

**Trivial.** Three files: \`package.json\` version, \`src/const.ts\` CARD_VERSION, \`CHANGELOG.md\` new entry + link refs. No code change.

## Docs touched

- [ ] \`README.md\`
- [x] \`CHANGELOG.md\` — new \`[3.6.3]\` section + link reference
- [ ] \`docs/todo.md\`
- [ ] n/a — internal change

## After merge

1. Tag \`v3.6.3\` from \`main\` (\`git tag v3.6.3 && git push origin v3.6.3\`).
2. Create GitHub release from the tag — \`release.yml\` triggers on \`release: published\` and builds + uploads \`dist/*\` as release assets.
3. HACS picks up the release automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)