### PR TITLE
ops: deduplicate CI workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,17 @@ name: "Build"
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     branches:
       - main
   workflow_dispatch:
+
+# Cancel an older run of the same workflow on the same ref when a new push
+# arrives. Saves CI minutes on rapid force-pushes / quick fixups.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/hacs-action.yml
+++ b/.github/workflows/hacs-action.yml
@@ -2,9 +2,19 @@ name: HACS Action
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * *'
+
+# Cancel an older run of the same workflow on the same ref when a new push
+# arrives. Saves CI minutes on rapid force-pushes / quick fixups.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- Each PR commit was triggering **4 redundant Build runs** (Node 20 + 22 matrix × \`push\` + \`pull_request\` overlap) and **2 redundant HACS validations** on the same SHA.
- Root cause: \`build.yml\` had \`push: branches: ['**']\` (scaffolding for the auto-\`commit-dist\` job removed in #165) overlapping with \`pull_request: branches: [main]\`. \`hacs-action.yml\` was worse — bare \`push:\` and \`pull_request:\` with no branch filters at all.
- Both workflows now run on \`push\` only for \`main\` (the merge commit post-review) and on \`pull_request\` for PRs targeting \`main\`. Each PR commit now triggers **exactly 1 Build per Node version + 1 HACS validation**.
- Bonus: adds a \`concurrency\` block to each workflow to cancel stale in-flight runs when a branch gets force-pushed quickly. Saves CI minutes on the "pushed, found a typo, force-pushed again" pattern.

## Test plan

n/a — workflow file changes only; the effect is observable post-merge by watching the next PR's check list.

- [ ] \`npm run lint\`
- [ ] \`npm test\`
- [ ] \`npm run build\`

## Risk

- **Low.** Workflow trigger scopes only. The jobs themselves are unchanged.
- **Trade-off worth naming:** a contributor pushing a feature branch without opening a PR gets no CI feedback. For this repo, all contributions go through PR review anyway — this matches actual practice and the explicit guidance in [AGENTS.md](AGENTS.md). Worth revisiting if fork-based contributors need pre-PR validation.
- **release.yml is untouched** — its trigger is \`release: published\` and can't duplicate.
- **Daily HACS cron is preserved** — still runs at 00:00 UTC.

## Observable verification (post-merge)

After this lands and the next PR is pushed, the check list at the bottom of the PR page should show exactly 3 in-progress checks instead of 6:
- Build / Test build (20) (pull_request)
- Build / Test build (22) (pull_request)
- HACS Action / validate (pull_request)

No more duplicated \`(push)\` siblings for the same PR commit.

## Docs touched

- [ ] \`README.md\`
- [ ] \`CHANGELOG.md\` — internal ops change, no user-visible behaviour shift
- [ ] \`docs/todo.md\`
- [ ] \`AGENTS.md\`
- [ ] n/a — internal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)