### PR TITLE
ops: skip HACS validation on PRs (false-negative on fork PRs)

### DIFF
--- a/.github/workflows/hacs-action.yml
+++ b/.github/workflows/hacs-action.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
+
+# Note: pull_request trigger removed deliberately. The HACS action queries
+# GitHub's API for the repo being validated, not the workspace — so for a
+# PR opened from a fork it tries to validate the fork's repo, which has
+# neither a committed dist/weather-radar-card.js (we stopped tracking that
+# in PR #165) nor any GitHub releases. The check fails on every fork PR
+# while the contributor's actual code is fine. Code-side validation is
+# covered by build.yml (lint + test + build matrix on Node 20 + 22) which
+# does run on PRs. HACS-spec compliance is caught here on push-to-main
+# and the daily cron.
 
 # Cancel an older run of the same workflow on the same ref when a new push
 # arrives. Saves CI minutes on rapid force-pushes / quick fixups.


### PR DESCRIPTION
## Summary

- HACS validation has been failing on every fork PR since #165 untracked \`dist/weather-radar-card.js\` from git. The HACS action queries GitHub's API for the repo it's validating — for a fork PR, that's the fork's repo, which has neither a committed JS bundle nor a GitHub release with one attached. So HACS reports "Repository structure ... is not compliant" while the contributor's actual code is fine.
- Observed today on PR #172 (cgjolberg's tablet-friendly timeline scrub work). Code passes lint + tests + build cleanly on Node 20 and 22 — only HACS shows red.
- This PR removes the \`pull_request\` trigger from \`hacs-action.yml\`. Push-to-main and the daily cron continue to validate; PRs rely on \`build.yml\` for code-side validation (lint + test + build matrix).
- Also adds \`workflow_dispatch\` so HACS can be manually re-run from the Actions tab against any branch.

## What we lose

Nothing material. HACS-spec compliance (the only thing this action actually checks) is gated by \`hacs.json\` shape and the release artifact format — both of which only change on \`main\`, not in PRs.

## Test plan

- [ ] \`npm run lint\` — n/a, workflow yaml only
- [ ] \`npm test\` — n/a
- [ ] \`npm run build\` — n/a

**Verification (post-merge):** click "Re-run all jobs" on PR #172 in the Actions tab. Re-runs of \`pull_request\` events use the workflow definition from the **base branch** (main), so the updated config takes effect immediately. Expected: only the Build / Test build (20) + (22) checks run; no HACS check. PR #172 turns fully green.

## Risk

- **Low.** Workflow trigger scope reduction. No jobs changed, no scripts changed.
- Push-to-main validation preserved — every merge into main still runs HACS validation post-merge.
- Daily cron preserved — drift caught within 24 h.
- Manual run preserved via the new \`workflow_dispatch\`.

## Docs touched

- [ ] \`README.md\`
- [ ] \`CHANGELOG.md\` — internal ops change, no user-visible behaviour shift
- [ ] \`docs/todo.md\`
- [ ] \`AGENTS.md\`
- [ ] n/a — internal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)