### PR TITLE
fix: show lightning strike distance in HA preferred unit (km / mi)

### DIFF
--- a/src/geo-utils.ts
+++ b/src/geo-utils.ts
@@ -58,3 +58,15 @@ export function haversineKm(lat1: number, lon1: number, lat2: number, lon2: numb
     * Math.sin(dLon / 2) ** 2;
   return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
 }
+
+// Format a kilometre distance for display in HA's preferred length unit.
+// `lengthUnit` is `hass.config.unit_system.length` ('km' or 'mi'). Anything
+// other than 'mi' defaults to metric — matches the fallback convention used
+// elsewhere in the card (Leaflet scale control, range rings).
+const KM_TO_MILES = 0.621371;
+export function formatDistance(distKm: number, lengthUnit: string | undefined): string {
+  if (lengthUnit === 'mi') {
+    return `${Math.round(distKm * KM_TO_MILES)} mi`;
+  }
+  return `${Math.round(distKm)} km`;
+}

--- a/src/lightning-layer.ts
+++ b/src/lightning-layer.ts
@@ -4,7 +4,7 @@ import { HomeAssistant } from 'custom-card-helpers';
 import { WeatherRadarCardConfig } from './types';
 import { LIGHTNING_BOLT_PATH, LIGHTNING_PLUS_PATH } from './marker-icon';
 import { localize } from './localize/localize';
-import { haversineKm } from './geo-utils';
+import { haversineKm, formatDistance } from './geo-utils';
 import { escapeHtml } from './string-utils';
 import {
   BOLT_DURATION_SEC,
@@ -488,7 +488,7 @@ export class LightningLayer {
     const ageSec = this._ageSec(strike);
     const rel = relativeTime(ageSec);
 
-    const distLabel = `${Math.round(distKm)} km ${localize(`ui.lightning.bearing.${bearing}`)}`;
+    const distLabel = `${formatDistance(distKm, this._hass?.config?.unit_system?.length)} ${localize(`ui.lightning.bearing.${bearing}`)}`;
     const relLabel = rel.key === 'just_now'
       ? localize('ui.lightning.relative.just_now')
       : localize(`ui.lightning.relative.${rel.key}`).replace('{n}', String(rel.n));

--- a/tests/geo-utils.test.ts
+++ b/tests/geo-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { geometryLngLatBounds, centroidLngLat, haversineKm } from '../src/geo-utils';
+import { geometryLngLatBounds, centroidLngLat, haversineKm, formatDistance } from '../src/geo-utils';
 
 // A simple unit-square Polygon centred on the origin — easy to reason about
 // for bounds and centroid tests.
@@ -119,5 +119,38 @@ describe('haversineKm', () => {
     const d = haversineKm(0, 0, 0, 180);
     // πR ≈ 20015 km
     expect(d).toBeCloseTo(20015, 0);
+  });
+});
+
+describe('formatDistance — display in HA preferred length unit', () => {
+  it('formats km when unit is "km"', () => {
+    expect(formatDistance(45.4, 'km')).toBe('45 km');
+    expect(formatDistance(99.6, 'km')).toBe('100 km');
+  });
+
+  it('formats miles when unit is "mi"', () => {
+    // 45 km × 0.621371 ≈ 27.96 → 28
+    expect(formatDistance(45, 'mi')).toBe('28 mi');
+    // 100 km × 0.621371 ≈ 62.14 → 62
+    expect(formatDistance(100, 'mi')).toBe('62 mi');
+  });
+
+  it('defaults to km when unit is undefined or unknown', () => {
+    expect(formatDistance(12, undefined)).toBe('12 km');
+    expect(formatDistance(12, '')).toBe('12 km');
+    // Future-proof: HA could theoretically introduce a new unit code; we
+    // default to metric rather than guessing.
+    expect(formatDistance(12, 'lightyears')).toBe('12 km');
+  });
+
+  it('rounds sub-1-unit distances to 0 (pinned behaviour from the original popup logic)', () => {
+    expect(formatDistance(0.3, 'km')).toBe('0 km');
+    // 0.5 km × 0.621371 ≈ 0.31 mi → 0
+    expect(formatDistance(0.5, 'mi')).toBe('0 mi');
+  });
+
+  it('handles exactly zero distance', () => {
+    expect(formatDistance(0, 'km')).toBe('0 km');
+    expect(formatDistance(0, 'mi')).toBe('0 mi');
   });
 });


### PR DESCRIPTION
## Summary

- **The bug:** clicking a lightning strike opens a popup showing distance from map centre in "km" regardless of HA's \`unit_system\` setting. Imperial users (en-US default) had to mentally convert.
- **The fix:** read \`hass.config.unit_system.length\` (the same signal used by the Leaflet scale control and range rings) and format the distance accordingly. Anything other than \`'mi'\` defaults to metric, matching the existing fallback convention used elsewhere in the card.
- **Helper extracted:** \`formatDistance(distKm, lengthUnit)\` added to \`src/geo-utils.ts\` so future popup additions (wildfire / NWS alert distance displays, if we ever add them) can reuse it.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 489/489 vitest specs pass (484 → 489, +5 from \`formatDistance\` tests)
- [x] \`npm run build\` — clean rebuild

**Manual / UI verification:** could test in the Docker testbed by waiting for a Blitzortung strike, but real-world strikes are unreliable to time. The mechanism is simple enough that the unit tests cover it (km / mi / fallback / zero / sub-1-unit rounding to 0) — happy to spin up the testbed if you want a visual check.

## Risk

- **Trivial.** One-call-site fix; 3 lines changed in \`src/lightning-layer.ts\`, +12 in \`src/geo-utils.ts\`, +35 in tests.
- **Scope verified narrow** — \`grep\` for \`distance\` / \`km\` / \`miles\` across all popup-rendering layers (wildfire, NWS alerts) confirmed they use \`haversineKm\` only for internal proximity filtering, never displayed to the user. So this is the only user-visible distance in the card.
- **Pinned legacy behaviour:** sub-1-unit distances continue to round to "0 km" / "0 mi" — matches what the original \`Math.round(distKm)\` did. If we ever decide that's confusing for very close strikes we can switch to one-decimal rendering, but that's a separate UX call.

## Docs touched

- [ ] \`README.md\`
- [ ] \`CHANGELOG.md\` — could be noted under \`[Unreleased]\` if you want it called out in the next release; I left it for the release PR to decide
- [ ] \`docs/todo.md\`
- [ ] n/a — internal change (per-layer fix, no API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)