### PR TITLE
release: 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.5] - 2026-06-03
+
+> Patch release: two small QoL fixes (lightning distance in your HA-preferred unit; broken Blitzortung-integration link in the docs). Plus the per-user state framework lands on `main` as dormant infrastructure for v3.7. **No behaviour change for existing configs.**
+
+### Fixed
+
+- **Lightning strike distance now uses HA's preferred length unit** ([#176](https://github.com/jpettitt/weather-radar-card/pull/176)). The popup that opens when you click a lightning strike was always showing distance in "km" regardless of HA's `unit_system` setting. Imperial users had to mentally convert. Now reads `hass.config.unit_system.length` and formats as "45 km" or "28 mi" accordingly — same signal already used by the Leaflet scale control and range rings. Wildfire / NWS-alert popups don't display distances, so this only affects the lightning popup.
+- **Broken Blitzortung-integration link in docs** ([#177](https://github.com/jpettitt/weather-radar-card/pull/177)). README, configuration, overlays, and lightning-feature-design all linked the integration as `home-assistant.io/integrations/blitzortung/`, which is a 404 — there's no native HA Blitzortung integration. Pointed all references at the actual HACS integration at `github.com/mrk-its/homeassistant-blitzortung`. Caught by [@mweinelt](https://github.com/mweinelt). 🙏
+
+### Internal
+
+- **Per-user state framework added on `main`** ([#175](https://github.com/jpettitt/weather-radar-card/pull/175)). New `src/viewer-state.ts` wraps HA's frontend storage WebSocket API to support v3.7's per-user runtime customisation features (layer visibility panel, playback speed override). **Dormant in this release** — no consumer wired up yet, no behaviour change. Documented in [`docs/viewer-state-api.md`](docs/viewer-state-api.md) for contributors.
+
 ## [3.6.4] - 2026-05-26
 
 > Patch release: tablet-friendly timeline scrubbing for touchscreen dashboards (opt-in via YAML), a lightning-strike layering fix, and an internal HACS-on-PR ops cleanup. **No breaking changes, drop-in patch over 3.6.3.**
@@ -689,7 +702,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.4...HEAD
+[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.5...HEAD
+[3.6.5]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.4...v3.6.5
 [3.6.4]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.3...v3.6.4
 [3.6.3]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.2...v3.6.3
 [3.6.2]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.1...v3.6.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.4';
+export const CARD_VERSION = '3.6.5';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
## Summary

Patch release rolling up three things merged since 3.6.4:

- **Lightning strike distance now uses HA's preferred length unit** (#176). Popup distance reads \`hass.config.unit_system.length\` and formats as "45 km" or "28 mi". Was always km before.
- **Broken Blitzortung-integration link in docs** (#177). All four user-facing references corrected from the 404 \`home-assistant.io/integrations/blitzortung/\` URL to the real \`github.com/mrk-its/homeassistant-blitzortung\`. Caught and reported by @mweinelt.
- **Per-user state framework added on \`main\`** (#175). Dormant infrastructure for v3.7's runtime customisation features (layer visibility panel, playback speed override). **No user-visible behaviour change in this release** — framework only activates when a future consumer opts the card in.

**No breaking changes.** Drop-in patch over 3.6.4.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 489/489 vitest specs pass
- [x] \`npm run build\` — clean rebuild

**Manual / UI verification:** already done in the individual PRs (#175, #176, #177). This release PR adds only version bumps and CHANGELOG — no source changes since those merged.

## Risk

**Trivial.** Three files: \`package.json\` version, \`src/const.ts\` CARD_VERSION, \`CHANGELOG.md\` new entry + link refs. No code change.

## Docs touched

- [ ] \`README.md\`
- [x] \`CHANGELOG.md\` — new \`[3.6.5]\` section + link reference
- [ ] \`docs/todo.md\`
- [ ] n/a — internal change

## After merge

1. Tag \`v3.6.5\` from \`main\`.
2. Create GitHub release with notes; @mweinelt credited in the docs-fix section.
3. \`release.yml\` triggers + uploads \`dist/*\` as release assets.
4. HACS picks up the release automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)