### PR TITLE
fix(region-warning): suppress DWD/NOAA warnings when map shows real coverage

### DIFF
--- a/src/region-warning.ts
+++ b/src/region-warning.ts
@@ -20,6 +20,33 @@ const DWD_COVERAGE_COUNTRIES = new Set([
   'DE', 'NL', 'BE', 'LU', 'FR', 'CH', 'AT', 'CZ', 'PL', 'DK',
 ]);
 
+// Map-centre coverage bboxes. Used to suppress the radar-source warnings
+// when the user has explicitly centred the map on real coverage area
+// regardless of their HA-configured country. Symmetric to the country
+// allowlist above — country is a coarse proxy, centre coordinates are the
+// precise check. Bounds are generous (include some ocean / border regions)
+// because a missed suppression is worse than an over-eager one: the false
+// positive in this direction is a too-cautious banner that the user can
+// dismiss, while a false negative would be a misleading "this won't work
+// for you" warning over a map that's working fine.
+//
+// DWD bbox: Germany + immediate radar overlap into neighbours.
+const DWD_COVERAGE_BBOX = { minLat: 44.0, maxLat: 56.5, minLon: 1.0, maxLon: 18.0 };
+// NOAA NEXRAD bbox: CONUS + AK + HI + PR/USVI. Wide because Hawaii is
+// low-latitude and Alaska extends across the dateline; intentional that
+// it sweeps in some ocean and the western Caribbean.
+const US_COVERAGE_BBOX = { minLat: 15.0, maxLat: 72.0, minLon: -180.0, maxLon: -64.0 };
+
+function inBbox(
+  lat: unknown,
+  lon: unknown,
+  b: { minLat: number; maxLat: number; minLon: number; maxLon: number },
+): boolean {
+  return typeof lat === 'number' && typeof lon === 'number'
+    && lat >= b.minLat && lat <= b.maxLat
+    && lon >= b.minLon && lon <= b.maxLon;
+}
+
 export function getRegionWarnings(
   hass: HomeAssistant | undefined,
   cfg: WeatherRadarCardConfig,
@@ -31,10 +58,32 @@ export function getRegionWarnings(
 
   const messages: string[] = [];
 
+  // Effective map centre: config literal wins, fall back to HA's home
+  // location. Entity-tracked coordinates (CoordinateConfig as a string or
+  // EntityCoordinate object) aren't resolved here — they'd require hass
+  // state lookup at banner-render time. Conservative fallback: when the
+  // centre can't be resolved as a literal number, coverage check returns
+  // false and the warning fires as it did before this change.
+  const centreLat = typeof cfg.center_latitude === 'number'
+    ? cfg.center_latitude
+    : (hass?.config as any)?.latitude;
+  const centreLon = typeof cfg.center_longitude === 'number'
+    ? cfg.center_longitude
+    : (hass?.config as any)?.longitude;
+  const showingUs = inBbox(centreLat, centreLon, US_COVERAGE_BBOX);
+  const showingDwd = inBbox(centreLat, centreLon, DWD_COVERAGE_BBOX);
+
   // Catalogue of features that only have US data coverage. Each entry's
   // `key` is the localize suffix used for its individual banner; when more
   // than one is enabled at once we collapse to a single combined banner
   // instead of stacking near-identical messages.
+  //
+  // NOAA's `enabled` ANDs in the coverage check: a user with NOAA selected
+  // whose map is centred on the US is successfully viewing NOAA data
+  // regardless of where they live, so the warning is misleading and we
+  // suppress it. Wildfires / alerts don't get the same treatment — their
+  // overlays only ever have US data, so the warning informs the user the
+  // feature will be empty for them. Map centre doesn't change that.
   const usOnly: Array<{ enabled: boolean; key: string; label: string }> = [
     {
       enabled: cfg.show_wildfires === true,
@@ -47,7 +96,7 @@ export function getRegionWarnings(
       label: localize('ui.region_warning.label.alerts'),
     },
     {
-      enabled: (cfg.data_source ?? '').toUpperCase() === 'NOAA',
+      enabled: (cfg.data_source ?? '').toUpperCase() === 'NOAA' && !showingUs,
       key: 'noaa_us_only',
       label: localize('ui.region_warning.label.noaa'),
     },
@@ -70,11 +119,13 @@ export function getRegionWarnings(
 
   // DWD is a separate region (Germany + immediate neighbours). Stand-alone
   // banner — collapsing it into the US block would read as "X and DWD radar
-  // are US-only", which is wrong. The warning fires for any country outside
-  // DWD_COVERAGE_COUNTRIES so users in e.g. ES or GB selecting DWD see a
-  // visible explanation rather than a silently grey map.
+  // are US-only", which is wrong. Fires when DWD is selected AND the user's
+  // country is outside DWD_COVERAGE_COUNTRIES AND the map centre is outside
+  // the DWD coverage bbox — i.e. when the user neither lives in DWD coverage
+  // nor is explicitly viewing it.
   if ((cfg.data_source ?? '').toUpperCase() === 'DWD'
-      && !DWD_COVERAGE_COUNTRIES.has(country)) {
+      && !DWD_COVERAGE_COUNTRIES.has(country)
+      && !showingDwd) {
     messages.push(localize('ui.region_warning.dwd_de_only'));
   }
 

--- a/tests/region-warning.test.ts
+++ b/tests/region-warning.test.ts
@@ -5,7 +5,12 @@ import { WeatherRadarCardConfig } from '../src/types';
 
 // Lightweight hass-with-country mock — the real mockHass helper doesn't
 // include `country`, which is what the region-warning logic keys off.
-function hassFor(country: string | undefined): HomeAssistant | undefined {
+// Optional `home` overrides HA's configured latitude/longitude (the
+// fallback for the coverage-bbox check when cfg has no centre literal).
+function hassFor(
+  country: string | undefined,
+  home?: { latitude: number; longitude: number },
+): HomeAssistant | undefined {
   if (country === undefined) {
     // Simulate the case where hass.config.country isn't populated yet —
     // we should silently skip the warning rather than firing false
@@ -13,7 +18,7 @@ function hassFor(country: string | undefined): HomeAssistant | undefined {
     // doing" branch in region-warning.ts.)
     return { config: {} } as unknown as HomeAssistant;
   }
-  return { config: { country } } as unknown as HomeAssistant;
+  return { config: { country, ...(home ?? {}) } } as unknown as HomeAssistant;
 }
 
 function cfg(overrides: Partial<WeatherRadarCardConfig> = {}): WeatherRadarCardConfig {
@@ -148,5 +153,117 @@ describe('getRegionWarnings — DWD coverage', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toMatch(/NWS/);
     expect(result[1]).toMatch(/DWD/);
+  });
+});
+
+// Centre-aware suppression: even when the country check would fire,
+// suppress the warning if the map is explicitly centred on real coverage.
+// The user has gone out of their way to view that region — assume they
+// know what they're doing.
+describe('getRegionWarnings — coverage-bbox suppression', () => {
+  // Reference points used across tests.
+  const BERLIN  = { latitude: 52.52, longitude: 13.40 };  // inside DWD bbox
+  const NYC     = { latitude: 40.71, longitude: -74.01 }; // inside US bbox
+  const HONOLULU = { latitude: 21.31, longitude: -157.86 }; // US bbox (HI corner)
+  const LONDON  = { latitude: 51.51, longitude: -0.13 };  // outside both
+
+  it('suppresses the DWD warning when map centre is in DWD coverage (US user, Berlin centre)', () => {
+    const result = getRegionWarnings(
+      hassFor('US'),
+      cfg({ data_source: 'DWD', center_latitude: BERLIN.latitude, center_longitude: BERLIN.longitude }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('fires the DWD warning when map centre is OUTSIDE DWD coverage (US user, NYC centre)', () => {
+    const [msg, ...rest] = getRegionWarnings(
+      hassFor('US'),
+      cfg({ data_source: 'DWD', center_latitude: NYC.latitude, center_longitude: NYC.longitude }),
+    );
+    expect(rest).toEqual([]);
+    expect(msg).toMatch(/DWD/);
+  });
+
+  it('suppresses the NOAA warning when map centre is in US coverage (DE user, NYC centre)', () => {
+    const result = getRegionWarnings(
+      hassFor('DE'),
+      cfg({ data_source: 'NOAA', center_latitude: NYC.latitude, center_longitude: NYC.longitude }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('suppresses the NOAA warning for the Hawaii corner of the bbox', () => {
+    const result = getRegionWarnings(
+      hassFor('DE'),
+      cfg({ data_source: 'NOAA', center_latitude: HONOLULU.latitude, center_longitude: HONOLULU.longitude }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('fires the NOAA warning when map centre is OUTSIDE US coverage (DE user, Berlin centre)', () => {
+    const [msg, ...rest] = getRegionWarnings(
+      hassFor('DE'),
+      cfg({ data_source: 'NOAA', center_latitude: BERLIN.latitude, center_longitude: BERLIN.longitude }),
+    );
+    expect(rest).toEqual([]);
+    expect(msg).toMatch(/NOAA/);
+  });
+
+  it('falls back to HA home location when cfg centre is unset (US user with German home → no DWD warning)', () => {
+    // Pathological setup but real: HA reports country=US but the location coords
+    // are in Berlin. Without an explicit cfg centre, fallback uses hass home,
+    // which is in DWD coverage → warning suppressed.
+    const result = getRegionWarnings(
+      hassFor('US', BERLIN),
+      cfg({ data_source: 'DWD' }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('wildfires + alerts warnings are NOT coverage-suppressed (semantic is different)', () => {
+    // Wildfires and alerts only have US data. A non-US user who centres on the
+    // US still sees the overlays empty unless THEIR map has US overlay data —
+    // the warning is about the overlay never having content outside the US, not
+    // about radar tile coverage. Suppression by map centre would be misleading.
+    const result = getRegionWarnings(
+      hassFor('DE'),
+      cfg({ show_wildfires: true, center_latitude: NYC.latitude, center_longitude: NYC.longitude }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatch(/wildfire/i);
+  });
+
+  it('NOAA suppression interacts cleanly with combined message: NOAA suppressed → wildfires-only fires alone', () => {
+    // DE user, NOAA + wildfires both enabled, map on NYC. NOAA gets suppressed
+    // (showingUs=true); wildfires stays enabled. Result is just the wildfires
+    // message, not the combined "wildfires and NOAA radar" template.
+    const result = getRegionWarnings(
+      hassFor('DE'),
+      cfg({
+        data_source: 'NOAA',
+        show_wildfires: true,
+        center_latitude: NYC.latitude,
+        center_longitude: NYC.longitude,
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatch(/wildfire/i);
+    expect(result[0]).not.toMatch(/NOAA/);
+  });
+
+  it('entity-coord centre falls back to no-suppression (warning still fires)', () => {
+    // CoordinateConfig as a string entity reference means the literal coords
+    // aren't in cfg. Without HA home coords either, the bbox check can't
+    // succeed → warning fires as it did before this change. Conservative.
+    const result = getRegionWarnings(
+      hassFor('US'),  // no home coords
+      cfg({
+        data_source: 'DWD',
+        center_latitude: 'sensor.berlin_lat' as unknown as number,
+        center_longitude: 'sensor.berlin_lon' as unknown as number,
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatch(/DWD/);
   });
 });


### PR DESCRIPTION
## Summary

- When a user explicitly centres the map on a region with real radar coverage, the "this source is X-only" warnings were firing anyway because the gate was on \`hass.config.country\` only, not on what the map was actually showing.
- Now: each warning ANDs in a bbox check against the effective map centre. US-based user viewing DWD with map on Germany is silent; DE-based user viewing NOAA with map on the US is silent.
- Wildfires / alerts warnings deliberately stay country-only — their semantic is "this overlay has no data outside the US" which doesn't depend on map centre.

## Concrete fix

| Scenario | Before | After |
|---|---|---|
| US country + DWD + map on Berlin | "DWD is Germany-only" warning | silent ✓ |
| DE country + NOAA + map on NYC | "NOAA is US-only" warning | silent ✓ |
| US country + DWD + map on NYC | "DWD is Germany-only" warning | unchanged (warning still fires) ✓ |
| DE country + NOAA + map on Berlin | "NOAA is US-only" warning | unchanged ✓ |
| DE country + NOAA + wildfires both enabled + map on NYC | "wildfires and NOAA are US-only" combined message | "wildfires is US-only" alone (NOAA suppressed, combined collapses) ✓ |
| DE country + wildfires + map on NYC | "wildfires is US-only" | unchanged (overlay has no data regardless of centre) ✓ |
| Entity-tracked centre (\`center_latitude: sensor.x\`) | warning fires | unchanged — conservative fallback (warning still fires) ✓ |

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 498/498 vitest specs pass (489 → 498, +9 new for coverage suppression)
- [x] \`npm run build\` — clean rebuild

**Manual / UI verification:** none required — pure logic change, exercised entirely by unit tests. Could verify in HA testbed by configuring a US-located HA with DWD + German centre, but the test cases cover the same scenarios deterministically.

## Risk

- **Low.** No API change, no config-shape change. Existing behaviour preserved when the new coverage-bbox check returns false (entity-coord centre, missing HA home coords, map centred outside coverage).
- **Bbox false-positives** documented in code: NOAA bbox is wide (covers some ocean and the western Caribbean) and DWD bbox covers Germany + immediate radar overlap. Suppressing the warning in those areas is no worse than today's behaviour (warning fires for everyone non-US/non-DE without coverage-awareness).

## Docs touched

- [ ] \`README.md\`
- [ ] \`CHANGELOG.md\` — could be noted under \`[Unreleased]\` for the next release; left for the release PR to decide
- [ ] \`docs/todo.md\`
- [ ] n/a — internal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)