### PR TITLE
release: 3.7.0-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0-alpha1] - 2026-06-08
+
+> **Alpha pre-release.** First user-visible consumer of the per-user state framework that shipped dormant in 3.6.5 ([#175](https://github.com/jpettitt/weather-radar-card/pull/175)). Two weeks of feedback expected before promotion through beta / rc / stable, in line with the 3.6.1-rc1 → 3.6.1 cadence. **Not recommended for production dashboards** — install only if you want to exercise the persistence path and report findings.
+
+### Added
+
+- **Adjustable playback speed** ([#157](https://github.com/jpettitt/weather-radar-card/pull/157)) — toolbar button cycles ¼× / ½× / 1× / 2× / 4×, editor dropdown sets the YAML default. Sparse-storage convention: a user's runtime override clears automatically when the chosen value matches the YAML default, so an admin editing the YAML default propagates to every viewer who hasn't explicitly overridden. **Contributed by [@genericJE](https://github.com/genericJE)** — third contribution after [#155](https://github.com/jpettitt/weather-radar-card/pull/155) and [#172](https://github.com/jpettitt/weather-radar-card/pull/172); built on top of the viewer-state framework from #175.
+
+  ```yaml
+  type: 'custom:weather-radar-card'
+  show_playback: true
+  playback_speed: 1            # YAML default; user can override via toolbar
+  viewer_layer_control: true   # admin opt-in to persist overrides per-user across browsers/devices
+  ```
+
+- **`viewer_layer_control` admin toggle** in the editor's Animation section — opt-in to per-user, per-card preference persistence via Home Assistant's frontend storage. Off by default; when off, the toolbar speed button still works but the value is session-only. The first activation auto-mints a `_layer_state_id` nonce into the card YAML — the per-card storage key that lets a user have different preferences on different cards (e.g. local rain view vs continental forecast view).
+
+### Internal
+
+- First end-to-end exercise of the per-card identity nonce + ViewerState hydrate path introduced in 3.6.5's framework. The hydration WS round-trip races against the toolbar's first paint — on a fresh page load with a non-1× override stored, the speed button label briefly shows the YAML default then snaps to the override once HA's `frontend/get_user_data` resolves (typically one render frame). Documented for awareness; alpha audience can confirm whether this single-frame flicker is acceptable.
+
 ## [3.6.5] - 2026-06-03
 
 > Patch release: two small QoL fixes (lightning distance in your HA-preferred unit; broken Blitzortung-integration link in the docs). Plus the per-user state framework lands on `main` as dormant infrastructure for v3.7. **No behaviour change for existing configs.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.5",
+  "version": "3.7.0-alpha1",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.6.5';
+export const CARD_VERSION = '3.7.0-alpha1';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
## Summary

- Bumps `CARD_VERSION` / `package.json` from 3.6.5 → 3.7.0-alpha1.
- Adds CHANGELOG entry for the 3.7.0-alpha1 pre-release.
- Surfaces the per-user state framework from [#175](https://github.com/jpettitt/weather-radar-card/pull/175) to end users via its first consumer ([#157](https://github.com/jpettitt/weather-radar-card/pull/157), @genericJE): adjustable playback speed with optional per-user persistence.

Marked **alpha** rather than rc because this is the storage subsystem's first end-to-end exercise. Plan is to feedback-cycle through beta and rc before promotion to 3.7.0 stable, matching the 3.6.1-rc1 → 3.6.1 cadence.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 534 pass (518 baseline + 16 new from #157)
- [x] `npm run build` — bundle produced
- [x] Smoke-tested locally in the HA Docker testbed — toolbar speed button cycles, editor dropdown sets default, viewer_layer_control toggle activates per-user persistence, override clears when chosen value matches YAML default

## Risk

- Version-only PR — no code changes beyond the version constants + CHANGELOG.
- The features themselves landed in #157 (just merged) and #175 (shipped dormant in 3.6.5). This PR is purely the release marker.
- Pre-release tag means HACS users won't get it automatically — they have to opt in to "show beta versions" in the HACS settings, which is the intended audience for an alpha.

## Docs touched

- [x] CHANGELOG.md — new 3.7.0-alpha1 entry
- n/a — no user-facing config docs added (configuration.md was updated as part of #157's merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)