### PR TITLE
feat(radar): motion compensation via pyramidal Lucas-Kanade (supersedes #156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **NOAA frame interval bumped from 5 → 10 min** to match the source's empirical publication cadence (`SOURCE_CAPS.NOAA.intervalMin`). NOAA's eventdriven WMS service has been observed to publish at irregular ~5–9 min intervals (mean ~7), and the server snaps any TIME within a publication window to the same physical frame. Requesting at a finer 5-min stride was returning duplicate frames for every other request — `dist/`-side dedup tolerated that gracefully but the loop bandwidth was wasted. Quantising to 10 min eliminates the duplicates at the source. **Behaviour change for NOAA users**: the same `past_minutes` value now yields half as many frames in the loop, but every frame is unique. Legacy `frame_count: N` configs auto-migrate to the new stride preserving frame count (a `frame_count: 12` config gets `past_minutes: 110` instead of `55`, keeping 12 distinct frames but covering twice the real time span). Tracking a server-side fix upstream at the NOAA / weather.gov API repo — if NOAA exposes a metadata endpoint for actual publication times, we'll drop this conservative quantisation.
+
+### Added
+
+- **Motion compensation for radar transitions** (opt-in via `motion_compensation: true`). During each crossfade, the new frame slides in from where its rain *would have been* at the previous frame's time, and the outgoing frame slides out toward where its rain *would be* at the new frame's time. The composite reads as one drifting rain field rather than two crossfading frames at separated positions. Built on top of [#156](https://github.com/jpettitt/weather-radar-card/pull/156) by [@genericJE](https://github.com/genericJE) — kept the snapshot-capture infrastructure, swapped the SAD block-matcher for pyramidal Lucas-Kanade optical flow with a distance-from-white intensity channel so the feature works for all three radar sources (DWD, RainViewer, NOAA) instead of being DWD-only. LK runs in a Web Worker by default so slow devices stay smooth; falls back to synchronous main-thread execution under strict CSPs. Auto-skipped on frame pairs without enough gradient signal for a confident vector (light rain, clear sky). NOAA-specific: post-load `_dedupFrames()` removes byte-identical frames produced by NOAA's coarser publication cycle so the deduped loop animates only unique frames. See [`docs/configuration.md#motion-compensation`](docs/configuration.md#motion-compensation). Default off.
+
+  ```yaml
+  type: 'custom:weather-radar-card'
+  smooth_animation: true
+  smooth_overlap: 0
+  motion_compensation: true
+  ```
+
 ## [3.7.0-alpha1] - 2026-06-08
 
 > **Alpha pre-release.** First user-visible consumer of the per-user state framework that shipped dormant in 3.6.5 ([#175](https://github.com/jpettitt/weather-radar-card/pull/175)). Two weeks of feedback expected before promotion through beta / rc / stable, in line with the 3.6.1-rc1 → 3.6.1 cadence. **Not recommended for production dashboards** — install only if you want to exercise the persistence path and report findings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale frames on resume from long-hidden / device-sleep windows.** The existing visibility-visible handler did a single `_updateRadar` to catch the most recent missed publication, which is enough for a few-minute tab switch. After longer hidden periods (device sleep, hours-tabbed-away) the single-frame update left the *rest* of the loop holding hour-old timestamps — the displayed radar would show one fresh frame and N-1 stale ones. Now tracks the wall-clock time of the last frame fetch; on visibility-visible, if more than ~10 min (= 2× the refresh period) has elapsed, scraps the loop entirely and re-fetches every slot from scratch via `_initRadar`. Brief load state on resume from sleep, but the loop content is correct.
+
 ### Changed
 
 - **NOAA frame interval bumped from 5 → 10 min** to match the source's empirical publication cadence (`SOURCE_CAPS.NOAA.intervalMin`). NOAA's eventdriven WMS service has been observed to publish at irregular ~5–9 min intervals (mean ~7), and the server snaps any TIME within a publication window to the same physical frame. Requesting at a finer 5-min stride was returning duplicate frames for every other request — `dist/`-side dedup tolerated that gracefully but the loop bandwidth was wasted. Quantising to 10 min eliminates the duplicates at the source. **Behaviour change for NOAA users**: the same `past_minutes` value now yields half as many frames in the loop, but every frame is unique. Legacy `frame_count: N` configs auto-migrate to the new stride preserving frame count (a `frame_count: 12` config gets `past_minutes: 110` instead of `55`, keeping 12 distinct frames but covering twice the real time span). Tracking a server-side fix upstream at the NOAA / weather.gov API repo — if NOAA exposes a metadata endpoint for actual publication times, we'll drop this conservative quantisation.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Home Assistant rain radar card using tiled radar imagery from RainViewer, NOAA
 
 ## Description
 
-This card displays animated weather radar loops within Home Assistant. It supports multiple radar data sources and map styles, and can be zoomed and panned seamlessly. Markers, hazard overlays (US wildfires + NWS watches & warnings), a forecast nowcast (DWD), full sections-grid resize support, and 11 languages.
+This card displays animated weather radar loops within Home Assistant. It supports multiple radar data sources and map styles, and can be zoomed and panned seamlessly. Markers, hazard overlays (US wildfires + NWS watches & warnings), a forecast nowcast (DWD), opt-in [motion-compensated playback](https://github.com/jpettitt/weather-radar-card/blob/main/docs/configuration.md#motion-compensation) (rain drifts between frames instead of teleporting), full sections-grid resize support, and 11 languages.
 
 ![Weather Radar card](weather-radar-card.gif)
 
@@ -46,6 +46,7 @@ Full backlog: [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob
 | [Wildfire feature design](https://github.com/jpettitt/weather-radar-card/blob/main/docs/wildfire-feature-design.md) | Internal: NIFC WFIGS feed, render decisions, InciWeb gating, refresh cadence |
 | [NWS alerts feature design](https://github.com/jpettitt/weather-radar-card/blob/main/docs/nws-alerts-feature-design.md) | Internal: api.weather.gov polling, zone resolution + caching, severity sort, popup chrome |
 | [Wind feature design](https://github.com/jpettitt/weather-radar-card/blob/main/docs/wind-feature-design.md) | Internal: bulk WCS fetch + adaptive scaling, coalescing cache, zoom-aware streamlines, layering |
+| [Motion compensation feature design](https://github.com/jpettitt/weather-radar-card/blob/main/docs/motion-compensation-feature-design.md) | Internal: pyramidal Lucas-Kanade optical flow, distance-from-white channel, inline-Blob worker pattern, crossfade-time translate |
 | [Backlog / TODO](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) | Open and shipped features |
 | [Contributing](https://github.com/jpettitt/weather-radar-card/blob/main/CONTRIBUTING.md) | Local dev setup including the Docker HA testbed (`npm run ha:up`) |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ All options can be configured using the GUI editor — there is no need to edit 
 | transition_time           | number          | **Optional**   | Crossfade duration in ms. Default is 40% of `frame_delay`. Ignored when `smooth_animation: true`.                                                                                                                                                      | auto                                  |
 | smooth_animation          | boolean         | **Optional**   | When `true`, the crossfade auto-calibrates so the full cycle equals `frame_delay` — the radar appears to flow continuously instead of stepping. Overrides `transition_time`.                                                                           | `false`                               |
 | smooth_overlap            | number          | **Optional**   | Cross-fade overlap fraction when `smooth_animation: true`. `0` = sequential (no brightness dip; previous frame held at full opacity, then fades out). `1` = fully simultaneous (brief mid-transition brightness dip). Tune for your basemap.           | `1`                                   |
+| motion_compensation       | boolean         | **Optional**   | Slide each radar layer in the estimated direction of rain motion during the crossfade, so rain drifts between frames instead of teleporting. See [Motion compensation](#motion-compensation).                                                          | `false`                               |
 | radar_opacity             | number          | **Optional**   | Opacity of the active radar frame (0.1–1.0). Lower values let more of the basemap show through                                                                                                                                                         | `1.0`                                 |
 | zoom_level                | number          | **Optional**   | Initial zoom level, 3–10                                                                                                                                                                                                                               | `7`                                   |
 | center_latitude           | number / string | **Optional**   | Initial map center latitude — number or entity ID                                                                                                                                                                                                      | HA instance location                  |
@@ -109,6 +110,25 @@ The relative timing of the two fades when `smooth_animation: true` is controlled
 | `1` (default) | Fully simultaneous — both fades run together. Brief mid-transition brightness dip but the smoothest motion.          |
 
 Tune for your basemap: lighter bases benefit from lower `smooth_overlap` to avoid pulsing.
+
+### Motion compensation
+
+`motion_compensation: true` slides each radar layer in the estimated direction of rain motion during the crossfade. The new frame slides in from where its rain *would have been* at the previous frame's time, and the old frame slides out toward where its rain *would be* at the new frame's time. The two layers' rain positions stay overlapped throughout the transition, so the composite reads as one drifting precipitation field rather than two crossfading frames at different positions.
+
+The motion vector is recovered from the frame pair itself — pyramidal Lucas-Kanade optical flow on a 96 × 96 intensity grid extracted from the visible tiles. No external wind data, no source-specific dispatch. Works for **all three radar sources** (DWD, RainViewer, NOAA).
+
+Runs in a Web Worker by default so the LK compute (~2 ms on a fast desktop, ~10–25 ms on a low-end mobile/tablet) doesn't block the main thread during the animation. Falls back to synchronous main-thread execution if Worker construction is blocked (e.g. by a strict CSP); a console line records the fallback.
+
+Auto-skipped on frame pairs where LK doesn't find enough gradient signal to produce a confident vector (light rain, clear skies, near-uniform palette). Those transitions render as the regular static crossfade — no jitter, no slide on noise.
+
+Pairs naturally with `smooth_overlap: 0` (sequential timing) so the composite stays at full opacity through the slide. Higher overlap values still work but let the alpha dip be slightly visible mid-slide.
+
+```yaml
+type: 'custom:weather-radar-card'
+smooth_animation: true
+smooth_overlap: 0
+motion_compensation: true
+```
 
 **Loop boundary snap** — when the loop wraps from the last frame back to the first after `restart_delay`, the transition is a hard cut rather than a fade. The pause has already broken perceived continuity, so a smooth crossfade across the loop reads as "time ran backwards"; a snap reads as "the loop restarted".
 

--- a/docs/motion-compensation-feature-design.md
+++ b/docs/motion-compensation-feature-design.md
@@ -1,0 +1,292 @@
+# Motion Compensation — Feature Design
+
+Status: **shipped** (initial implementation on `feature/lk-motion-compensation`)
+Builds on: [#156](https://github.com/jpettitt/weather-radar-card/pull/156) (`@genericJE`)
+
+## TL;DR
+
+`motion_compensation: true` slides each radar layer in the estimated
+direction of rain motion during the crossfade, so rain appears to
+drift between frames instead of teleporting to the new position while
+the old one fades. Motion is recovered by pyramidal Lucas-Kanade
+optical flow on consecutive frame snapshots — no external wind data,
+no source-specific dispatch. Works for all three sources (DWD,
+RainViewer, NOAA). Runs in a Web Worker by default; falls back to
+synchronous main-thread execution under strict CSPs.
+
+## Background
+
+### What `@genericJE`'s PR #156 contributed
+
+[#156](https://github.com/jpettitt/weather-radar-card/pull/156) added
+motion compensation by comparing two consecutive radar frames with
+**sum-of-absolute-differences (SAD) block matching** on the alpha
+channel. The contribution was substantial: it established the
+snapshot-capture pipeline (canvas readback from
+`img.leaflet-tile-loaded`), the `_frameSnapshot` / `_frameMotion`
+arrays, the generation-guarded invalidation on pan/zoom/resize, and
+the dual-translate animation in `_showSlot`. **This feature reuses
+that infrastructure directly** — the only swap is the algorithm and
+the channel extraction.
+
+The original PR's algorithm was source-agnostic on paper but in
+practice only produced useful vectors for **DWD**:
+
+| Source | Palette shape | Alpha signal |
+|---|---|---|
+| DWD (`Niederschlagsradar`) | Banded, with smooth alpha gradients at each intensity step | Strong — SAD finds real motion |
+| RainViewer | Smooth colour ramp, mostly-binary alpha (rain vs. no rain) | Weak — alpha is flat where rain is, SAD locks onto edges only |
+| NOAA MRMS | Similar to RainViewer; smooth-ish coloured palette, near-binary alpha | Weak — same problem |
+
+Testing in the dev HA testbed confirmed: motion compensation worked
+visibly on DWD, but on RainViewer / NOAA it either produced zero
+motion or noisy motion that jittered the layer.
+
+### Why LK can do what SAD cannot
+
+SAD asks "does this block from frame 0 match a block from frame 1
+within ±R pixels?" — it needs both blocks to contain similar pixel
+intensities. On a smooth palette where most of the moving content has
+near-uniform alpha, there isn't enough block-level texture for the
+metric to discriminate.
+
+LK asks a different question: "given the spatial gradients of frame
+0, what displacement most consistently explains the temporal
+difference between the two frames?" It uses Sobel gradients, which
+fire on **any continuous brightness transition** — including the
+smooth-ramp interiors where SAD struggles. The over-determined
+least-squares solve aggregates evidence across the whole frame, so
+even a few thousand weak-gradient pixels produce a stable estimate.
+
+Pyramidal LK additionally handles motion much larger than its
+per-level convergence radius (~5 px) by starting at a coarse
+resolution and refining up — at 3 levels the coarsest sees 30 px of
+native motion as ~7 px, comfortably within range. SAD would need a
+search radius scaling with the largest expected motion.
+
+## Algorithm
+
+### Pyramidal Lucas-Kanade (single global vector)
+
+For each consecutive frame pair (I0, I1), produce a single
+displacement `(dx, dy)` such that warping I1 by `+(dx, dy)` brings it
+into alignment with I0. The displacement is the bulk motion of the
+rain field between the two frame times.
+
+Algorithm steps (see [`src/lk.ts`](../src/lk.ts) for the full
+implementation):
+
+1. **Build pyramids** — `buildPyramid` halves each level's
+   dimensions, with each output pixel being the 2×2 average of its
+   source block. Stops when a halved dimension would fall below 4 px
+   (the LK window can't operate below that).
+2. **Walk coarsest → finest.** At each level:
+   - Compute Sobel gradients (Ix, Iy) of I0 once.
+   - Accumulate the gradient tensor `[[sum Ix², sum Ix·Iy], [sum Ix·Iy, sum Iy²]]`.
+   - Iteratively refine `(vx, vy)` by:
+     - Warping I1 by the current `(vx, vy)`.
+     - Computing temporal differences `It = I1_warped - I0`.
+     - Solving `A·v = -b` for the LK update via Cramer's rule.
+     - Breaking when the update magnitude drops below 0.005 px.
+   - Scale the result up by 2 before passing to the next-finer level.
+3. **Return** `(dx, dy)` from the finest level, plus a Shi-Tomasi
+   confidence (minimum eigenvalue of the gradient tensor, normalised
+   by pixel count) used to gate whether to apply the vector.
+
+Defaults: 3 pyramid levels, 5 refinement iterations per level. Pinned
+constants — no config exposure for v1.
+
+### Channel extraction: distance-from-white
+
+PR #156 extracted alpha. We extract **distance-from-white**
+(`255 - min(R, G, B)`, gated and weighted by alpha):
+
+- **DWD banded palette** — distance-from-white correlates with
+  intensity, so the signal is at least as strong as alpha.
+- **RainViewer / NOAA smooth colour palettes** — distance-from-white
+  reads the colour ramp as a continuous gradient. This is the unlock
+  that makes motion compensation source-agnostic.
+- **NOAA near-binary alpha** — alpha would have been useless; this
+  gets real signal.
+
+Edge case: rare palettes that include white as a valid colour would
+underweight white pixels. None of the supported sources do; flag if a
+future source adds one.
+
+### Confidence floor
+
+Vectors with Shi-Tomasi confidence below 5 (the "borderline" band
+from prototype experiments) are dropped — the gradient field is too
+flat for the estimate to be trustworthy. Those transitions render as
+the regular static crossfade, no jitter.
+
+### Why linear distance-from-white, not squared
+
+Empirically observed during dev: outlines drift smoothly while storm
+cores "jump" between frames. Hypothesis was that LK's gradient signal
+is dominated by the strong no-rain → light-blue outline transition,
+so the bulk vector tracks outline motion and leaves cores under-
+corrected. **Tried** squaring the extraction (`d² / 255` instead of
+`d`) to re-weight LK toward saturated red/yellow pixels. **Result**:
+no visible improvement. The residual core motion is apparently storm
+evolution (cell rotation, decay, splitting, internal reorganisation),
+not translation that LK could track better. Reverted to linear; the
+right fix for core-tracking is dense per-region flow (a v2 project
+needing a new rendering path), not better single-vector weighting.
+
+Documenting so the next contributor with the same hypothesis doesn't
+re-run the experiment.
+
+## Architecture
+
+### File layout
+
+| File | Purpose |
+|---|---|
+| [`src/lk.ts`](../src/lk.ts) | Algorithm in pure TypeScript. Used directly for tests and as the sync-fallback path. ~270 lines. |
+| [`src/lk-worker.ts`](../src/lk-worker.ts) | Worker factory + `LkWorkerClient` (promise wrapper) + `estimateMotionLk` helper with sync fallback. Embeds the algorithm as a JS string (see "Worker without a build step" below). ~340 lines. |
+| [`src/radar-player.ts`](../src/radar-player.ts) | Snapshot capture, motion-vector lifecycle, crossfade-time translate. Reuses PR #156's structure with the algorithm swap. |
+| [`src/types.ts`](../src/types.ts) | `motion_compensation?: boolean` config option. |
+| [`tests/lk.test.ts`](../tests/lk.test.ts) | Five synthetic scenarios + primitive coverage + worker↔TS parity tests. 20 tests. |
+
+### Worker without a build step
+
+The standard way to add a Web Worker to a Rollup bundle is to add a
+second entry point in `rollup.config.js` (so the worker is emitted as
+its own chunk and loaded via
+`new Worker(new URL('./lk-worker.ts', import.meta.url))`). [AGENTS.md
+hard-no #4](../AGENTS.md) marks `rollup.config.js` as off-limits
+without explicit approval, and the existing
+setTimeout-shim worker in `radar-player.ts` already uses an
+**inline-Blob** pattern that avoids the build-config change entirely.
+We follow that precedent.
+
+The cost is one real duplication: the algorithm exists both as
+TypeScript in `src/lk.ts` (executed on the main thread for the sync
+fallback and tests) and as a JS template-string constant
+`LK_ALGORITHM_SOURCE` in `src/lk-worker.ts` (concatenated with the
+message-handler and Blob-URL'd as the worker source). A parity test
+in `tests/lk.test.ts` evaluates the embedded string via `new
+Function` and asserts byte-for-byte agreement with the TypeScript
+version on the same fixtures — any drift fails CI before review.
+
+### Result handling
+
+LK is called asynchronously (Promise-based), regardless of whether
+the worker is used or not (the sync fallback wraps in
+`Promise.resolve` to keep the API uniform). Snapshots are captured
+synchronously on the `'load'` event; motion-vector computation
+returns a promise that resolves later.
+
+The animation in `_showSlot` reads `_frameMotion[newFi]` *at tick
+time*. If the LK call hasn't resolved by the next tick, the
+transition renders un-compensated for that frame. There's no special
+"waiting" state — the next tick just gets the vector if it's there,
+and the one after that almost certainly will. On a 60 FPS display
+with a 500 ms `frame_delay`, the LK call has 30+ frame budgets to
+land before the next tick fires.
+
+Stale results from a previous viewport (pan, zoom, resize between
+call and resolve) are discarded via the `_snapshotGen` counter —
+bumped on every invalidation, captured at call time, compared on
+resolve.
+
+### Crossfade translate
+
+When `_frameMotion[newFi]` is present at tick time:
+- **Incoming layer** starts at `translate(-dx, -dy)` — where its rain
+  *would have been* at the previous frame's time — and transitions
+  linearly to `translate(0, 0)` over `frame_delay` ms.
+- **Outgoing layer** starts at `translate(0, 0)` and transitions to
+  `translate(+dx, +dy)` — where its rain *would be* at the new
+  frame's time — over the same window.
+
+At any instant the two layers' rain positions overlap, so the
+composite reads as one drifting field. Linear easing keeps the
+perceived drift speed constant.
+
+Disabled when:
+- `opts.snap` (loop-restart) — sliding across the loop reads wrong.
+- `useChain` is false (animations off) — no transition to slide on.
+- `motion_compensation` config is off.
+- Vector unavailable (snapshot pending, low confidence, etc.).
+
+### Lifecycle integration
+
+| Event | Behaviour |
+|---|---|
+| Layer `'load'` (per-frame, via `wireSpinner`) | Capture snapshot for that frame, compute motion into/out of it. |
+| Map `'moveend'` | Invalidate all snapshots + resnapshot (handles cached-pan where Leaflet doesn't refetch tiles). |
+| Map `'zoomend'` | Same — plus update `_pinnedNativeZoom`. |
+| Map `'resize'` | Same — Leaflet will re-fetch tiles and `'load'` will fire again, but we don't wait for it. |
+| `_initRadar` per-frame load | Snapshot + compute as each frame becomes 'loaded' (frames load newest-first). |
+| `_updateRadar` refresh | Shift `_frameSnapshot` / `_frameMotion` arrays alongside the frame arrays. |
+| `clear()` | Bump `_snapshotGen` to discard in-flight results; dispose the `LkWorkerClient`. |
+
+## Decisions
+
+- **Single global vector over dense per-cell flow.** The differential
+  test scenario (two cells moving in different directions) showed
+  ~0.5 px residual error from a single bulk vector — sub-pixel,
+  visually invisible. Dense flow would need either WebGL or a layer
+  mesh for per-region translation, a separate larger project.
+- **Distance-from-white over alpha.** Works for all three sources
+  including the smooth-palette ones the PR #156 algorithm couldn't
+  handle.
+- **Worker mandatory (with sync fallback).** ~2 ms on a fast desktop
+  implies ~10–25 ms on low-end devices; that's enough to drop a
+  render frame during the crossfade. Sync fallback for strict-CSP
+  environments where blob: workers are blocked.
+- **Inline-Blob worker over rollup config change.** Matches the
+  precedent already in `radar-player.ts` for the setTimeout-shim
+  worker. Avoids AGENTS.md hard-no #4. The algorithm duplication is
+  guarded by a parity test.
+- **Async result, first-paint-uncompensated over synchronous-blocking.**
+  Keeps the worker call off the critical render path. At 60 FPS with
+  500 ms `frame_delay`, the LK result almost always lands before the
+  next tick anyway.
+- **Pinned LK parameters (no config exposure).** One user knob
+  (`motion_compensation: bool`) matches the existing PR's contract
+  and the "minimum viable surface" principle. Parameters can be
+  promoted to config if real-world reports demand tuning.
+- **No motion smoothing for v1.** PR #156 used median-of-5 on adjacent
+  motion vectors to absorb SAD jitter. LK output was clean enough in
+  synthetic tests that smoothing felt premature. Easy to add an EMA
+  later if reports indicate frame-to-frame jitter.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Worker construction blocked by CSP | Low (HA is permissive by default) | Sync fallback path; logged once at startup |
+| LK assumes brightness constancy; palette intensity transitions slightly violate this | Low impact | Pyramid averaging absorbs most of the residual; bias is sub-pixel |
+| Heterogeneous storm with cells moving in opposite directions | Real but uncommon | Single vector approximates bulk; visible mismatch is the entry condition for a future dense-flow project |
+| Algorithm-vs-string drift between `lk.ts` and `LK_ALGORITHM_SOURCE` | Low (caught by CI) | Parity test in `tests/lk.test.ts` evaluates the embedded source and asserts equivalence |
+| Bundle size growth | Low — ~6 KB added net | Acceptable for a behaviour-improving feature |
+
+## Out of scope (deliberate)
+
+- **Per-cell dense flow.** Requires a different rendering pipeline.
+- **User-visible confidence indicator.** Could surface "high/low
+  confidence" badges in the card UI; defer until users ask.
+- **Storm-cell tracking / wind arrows.** Different problem; LK output
+  could feed those but is not the goal here.
+- **Configurable LK parameters.** Pinned until reports demand
+  exposure.
+
+## Tuning knobs (for future iteration)
+
+If real-world experience indicates problems, here are the levers and
+where to find them:
+
+- `SNAPSHOT_GRID` — `src/radar-player.ts`. Default 96. Higher =
+  better sub-pixel resolution, more compute (quadratic).
+- `CONFIDENCE_FLOOR` — `src/radar-player.ts`. Default 5. Raise to be
+  stricter about which vectors to apply.
+- LK `levels` / `iterations` — `src/lk.ts` and `LK_ALGORITHM_SOURCE`
+  in `src/lk-worker.ts`. Defaults 3 / 5. Promotable to options on
+  `estimateMotionLk` if needed.
+- Channel extraction mode — `src/lk.ts` `extractChannel`. Currently
+  hard-coded to `'distance-from-white'` in `_captureFrameSnapshot`.
+  Other modes available (`'alpha'`, `'luminance'`, `'saturation'`)
+  for per-source dispatch if ever needed.

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -423,6 +423,15 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
             .disabled=${config.smooth_animation !== true}
             @value-changed=${this._handleSelectorChanged}
           ></ha-selector>
+          <label>
+            <ha-switch
+              .checked=${config.motion_compensation === true}
+              .configValue=${'motion_compensation'}
+              @change=${this._valueChangedSwitch}
+            ></ha-switch>
+            <span>${localize('editor.animation.motion_compensation')}</span>
+          </label>
+          <div class="section-description">${localize('editor.animation.motion_compensation_helper')}</div>
         ` : ''}
         <ha-selector
           .hass=${this.hass}

--- a/src/lk-worker.ts
+++ b/src/lk-worker.ts
@@ -1,0 +1,353 @@
+// Web Worker wrapper around the LK optical flow algorithm.
+//
+// Why: a single LK call is ~2 ms on a fast desktop, ~10–25 ms on a
+// low-end mobile / tablet. Even 25 ms blocks the main thread enough
+// to drop a render frame during the crossfade animation. Pushing the
+// LK call to a worker keeps the UI smooth regardless of device speed.
+//
+// Why this file inlines the algorithm as a string rather than
+// importing from lk.ts at runtime:
+//
+//   1. The card ships as a single Rollup bundle (dist/weather-radar-card.js);
+//      Workers in the browser need a separate URL to load source from,
+//      and adding a second Rollup output for the worker would require
+//      modifying rollup.config.js, which is a hard-no per AGENTS.md
+//      without explicit user approval.
+//
+//   2. The existing setTimeout-shim worker in radar-player.ts uses the
+//      same Blob-URL pattern, so this matches established convention.
+//
+//   3. eval / new Function violate HA's frontend CSP, so we can't pull
+//      the function bodies out of lk.ts at runtime via .toString().
+//
+// The duplication is real but bounded: a test in tests/lk.test.ts runs
+// both the TypeScript and the inlined-worker implementations against
+// the same synthetic fixtures and asserts identical output, so any
+// drift is caught immediately. When updating the algorithm, modify
+// BOTH src/lk.ts and the LK_ALGORITHM_SOURCE constant below.
+
+import { lucasKanadePyramidal, type LkOptions, type LkResult } from './lk';
+
+// ── Algorithm source (hand-translated from src/lk.ts to plain JS) ────────
+//
+// **MUST stay equivalent to the TypeScript implementation in lk.ts.**
+// `tests/lk.test.ts` pins the two against each other; any divergence
+// fails CI. The structure mirrors lk.ts exactly — same function names,
+// same parameter order, same conventions (warp uses `x + vx, y + vy`,
+// not `x - vx, y - vy`). The only intentional difference is the
+// stripping of TypeScript types and interface declarations.
+
+export const LK_ALGORITHM_SOURCE = `
+function buildPyramid(img, width, height, levels) {
+  var pyramid = [{ data: img, width: width, height: height }];
+  for (var i = 1; i < levels; i++) {
+    var prev = pyramid[i - 1];
+    var w = prev.width >> 1;
+    var h = prev.height >> 1;
+    if (w < 4 || h < 4) break;
+    var out = new Float32Array(w * h);
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        var sx = x << 1;
+        var sy = y << 1;
+        var a = prev.data[sy * prev.width + sx];
+        var b = prev.data[sy * prev.width + sx + 1];
+        var c = prev.data[(sy + 1) * prev.width + sx];
+        var d = prev.data[(sy + 1) * prev.width + sx + 1];
+        out[y * w + x] = (a + b + c + d) * 0.25;
+      }
+    }
+    pyramid.push({ data: out, width: w, height: h });
+  }
+  return pyramid;
+}
+
+function sobel(img, width, height) {
+  var Ix = new Float32Array(width * height);
+  var Iy = new Float32Array(width * height);
+  for (var y = 1; y < height - 1; y++) {
+    for (var x = 1; x < width - 1; x++) {
+      var i = y * width + x;
+      var tl = img[i - width - 1]; var tc = img[i - width]; var tr = img[i - width + 1];
+      var ml = img[i - 1]; var mr = img[i + 1];
+      var bl = img[i + width - 1]; var bc = img[i + width]; var br = img[i + width + 1];
+      Ix[i] = ((tr + 2 * mr + br) - (tl + 2 * ml + bl)) * 0.125;
+      Iy[i] = ((bl + 2 * bc + br) - (tl + 2 * tc + tr)) * 0.125;
+    }
+  }
+  return { Ix: Ix, Iy: Iy };
+}
+
+function sampleBilinear(img, width, height, x, y) {
+  if (x < 0 || y < 0 || x > width - 1 || y > height - 1) return 0;
+  var x0 = Math.floor(x);
+  var y0 = Math.floor(y);
+  var x1 = Math.min(x0 + 1, width - 1);
+  var y1 = Math.min(y0 + 1, height - 1);
+  var fx = x - x0;
+  var fy = y - y0;
+  var a = img[y0 * width + x0];
+  var b = img[y0 * width + x1];
+  var c = img[y1 * width + x0];
+  var d = img[y1 * width + x1];
+  return a * (1 - fx) * (1 - fy)
+       + b * fx * (1 - fy)
+       + c * (1 - fx) * fy
+       + d * fx * fy;
+}
+
+function warp(img, width, height, vx, vy) {
+  var out = new Float32Array(width * height);
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      out[y * width + x] = sampleBilinear(img, width, height, x + vx, y + vy);
+    }
+  }
+  return out;
+}
+
+function lkSingleLevel(I0, I1, width, height, vx0, vy0, iterations) {
+  var vx = vx0;
+  var vy = vy0;
+  var grads = sobel(I0, width, height);
+  var Ix = grads.Ix;
+  var Iy = grads.Iy;
+
+  var sIxIx = 0; var sIxIy = 0; var sIyIy = 0;
+  for (var i = 0; i < I0.length; i++) {
+    sIxIx += Ix[i] * Ix[i];
+    sIxIy += Ix[i] * Iy[i];
+    sIyIy += Iy[i] * Iy[i];
+  }
+  var det = sIxIx * sIyIy - sIxIy * sIxIy;
+
+  var trace = sIxIx + sIyIy;
+  var sqrtDisc = Math.sqrt(Math.max(0, trace * trace * 0.25 - det));
+  var minEig = trace * 0.5 - sqrtDisc;
+  var confidence = minEig / I0.length;
+
+  if (det < 1e-6) {
+    return { vx: vx, vy: vy, confidence: 0, iterations: 0 };
+  }
+
+  var actualIters = 0;
+  for (var iter = 0; iter < iterations; iter++) {
+    actualIters++;
+    var I1w = warp(I1, width, height, vx, vy);
+    var sIxIt = 0; var sIyIt = 0;
+    for (var j = 0; j < I0.length; j++) {
+      var it = I1w[j] - I0[j];
+      sIxIt += Ix[j] * it;
+      sIyIt += Iy[j] * it;
+    }
+    var dvx = (sIyIy * (-sIxIt) - sIxIy * (-sIyIt)) / det;
+    var dvy = (sIxIx * (-sIyIt) - sIxIy * (-sIxIt)) / det;
+    vx += dvx;
+    vy += dvy;
+    if (Math.abs(dvx) < 0.005 && Math.abs(dvy) < 0.005) break;
+  }
+  return { vx: vx, vy: vy, confidence: confidence, iterations: actualIters };
+}
+
+function lucasKanadePyramidal(I0, I1, width, height, opts) {
+  opts = opts || {};
+  var levels = Math.max(1, Math.min(opts.levels !== undefined ? opts.levels : 3, 5));
+  var iterations = Math.max(1, Math.min(opts.iterations !== undefined ? opts.iterations : 5, 20));
+
+  var pyr0 = buildPyramid(I0, width, height, levels);
+  var pyr1 = buildPyramid(I1, width, height, levels);
+  var actualLevels = Math.min(pyr0.length, pyr1.length);
+
+  var vx = 0;
+  var vy = 0;
+  var confidence = 0;
+  var perLevel = [];
+
+  for (var level = actualLevels - 1; level >= 0; level--) {
+    if (level < actualLevels - 1) {
+      vx *= 2;
+      vy *= 2;
+    }
+    var result = lkSingleLevel(
+      pyr0[level].data, pyr1[level].data,
+      pyr0[level].width, pyr0[level].height,
+      vx, vy, iterations
+    );
+    vx = result.vx;
+    vy = result.vy;
+    confidence = result.confidence;
+    perLevel.push({
+      level: level,
+      width: pyr0[level].width,
+      height: pyr0[level].height,
+      vx: result.vx,
+      vy: result.vy,
+      confidence: result.confidence,
+      iterationsUsed: result.iterations,
+    });
+  }
+
+  return {
+    dx: vx,
+    dy: vy,
+    confidence: confidence,
+    magnitude: Math.hypot(vx, vy),
+    angleDeg: (Math.atan2(vy, vx) * 180 / Math.PI + 360) % 360,
+    perLevel: perLevel,
+  };
+}
+`;
+
+// ── Message-handler boilerplate ──────────────────────────────────────────
+//
+// Wire protocol:
+//   main → worker: { id, I0: ArrayBuffer, I1: ArrayBuffer, width, height, opts }
+//   worker → main: { id, ...LkResult, elapsedMs }
+//
+// Buffers are sent as Transferable Objects (zero-copy) — the main
+// thread loses access to its Float32Array after posting, but the
+// channel-extracted snapshots are throwaway anyway.
+
+const MESSAGE_HANDLER_SOURCE = `
+self.addEventListener('message', function (e) {
+  var id = e.data.id;
+  var t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+  var I0 = new Float32Array(e.data.I0);
+  var I1 = new Float32Array(e.data.I1);
+  var result = lucasKanadePyramidal(I0, I1, e.data.width, e.data.height, e.data.opts);
+  var t1 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+  result.id = id;
+  result.elapsedMs = t1 - t0;
+  self.postMessage(result);
+});
+`;
+
+// ── Worker factory ───────────────────────────────────────────────────────
+
+/**
+ * Create a Worker running the LK algorithm. Returns null when the
+ * Worker constructor is unavailable (rare — happens under some CSPs
+ * and in tests). Caller is responsible for cleaning up the returned
+ * Worker (call `terminate()` and revoke the blob URL — see usage in
+ * radar-player.ts).
+ *
+ * The returned object includes the blob URL so the caller can revoke
+ * it during teardown.
+ */
+export function createLkWorker(): { worker: Worker; blobUrl: string } | null {
+  if (typeof Worker === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined') {
+    return null;
+  }
+  try {
+    const source = LK_ALGORITHM_SOURCE + MESSAGE_HANDLER_SOURCE;
+    const blob = new Blob([source], { type: 'application/javascript' });
+    const blobUrl = URL.createObjectURL(blob);
+    const worker = new Worker(blobUrl);
+    return { worker, blobUrl };
+  } catch {
+    // Some CSP setups block blob: workers. Caller falls back to
+    // synchronous main-thread execution.
+    return null;
+  }
+}
+
+// ── Pending-request bookkeeping ──────────────────────────────────────────
+
+interface PendingLkRequest {
+  resolve: (result: LkResult & { elapsedMs: number }) => void;
+  reject: (err: Error) => void;
+}
+
+/**
+ * Wraps a Worker with promise-based async API. Use {@link estimateMotionLk}
+ * directly when possible; the underlying primitives are exported for
+ * tests and for callers that need explicit lifecycle control.
+ */
+export class LkWorkerClient {
+  private _worker: Worker;
+  private _blobUrl: string;
+  private _pending = new Map<number, PendingLkRequest>();
+  private _nextId = 0;
+
+  constructor(worker: Worker, blobUrl: string) {
+    this._worker = worker;
+    this._blobUrl = blobUrl;
+    this._worker.addEventListener('message', this._onMessage);
+    this._worker.addEventListener('error', this._onError);
+  }
+
+  /**
+   * Submit a frame pair for LK estimation. Returns a promise that
+   * resolves with the LK result + elapsed wall-clock time inside the
+   * worker. Buffers are transferred zero-copy — caller's Float32Array
+   * is detached after this call.
+   */
+  estimate(
+    I0: Float32Array, I1: Float32Array, width: number, height: number,
+    opts: LkOptions = {},
+  ): Promise<LkResult & { elapsedMs: number }> {
+    return new Promise((resolve, reject) => {
+      const id = this._nextId++;
+      this._pending.set(id, { resolve, reject });
+      this._worker.postMessage(
+        { id, I0: I0.buffer, I1: I1.buffer, width, height, opts },
+        [I0.buffer, I1.buffer],
+      );
+    });
+  }
+
+  /** Terminate the worker and revoke its blob URL. */
+  dispose(): void {
+    this._worker.removeEventListener('message', this._onMessage);
+    this._worker.removeEventListener('error', this._onError);
+    this._worker.terminate();
+    URL.revokeObjectURL(this._blobUrl);
+    // Reject any still-pending requests so callers don't hang.
+    for (const pending of this._pending.values()) {
+      pending.reject(new Error('LkWorkerClient disposed'));
+    }
+    this._pending.clear();
+  }
+
+  private _onMessage = (e: MessageEvent): void => {
+    const { id, ...result } = e.data as LkResult & { id: number; elapsedMs: number };
+    const pending = this._pending.get(id);
+    if (!pending) return;
+    this._pending.delete(id);
+    pending.resolve(result as LkResult & { elapsedMs: number });
+  };
+
+  private _onError = (e: ErrorEvent): void => {
+    // A worker-level error fails ALL pending requests — the worker
+    // process is dead, no in-flight request will ever resolve.
+    const err = new Error(`LK worker error: ${e.message}`);
+    for (const pending of this._pending.values()) pending.reject(err);
+    this._pending.clear();
+  };
+}
+
+// ── Top-level estimation helper (with sync fallback) ─────────────────────
+
+/**
+ * Estimate motion between two frames. Uses the supplied worker client
+ * when available; otherwise runs the LK algorithm synchronously on
+ * the calling thread. Always returns a promise so call-sites don't
+ * need to branch.
+ *
+ * Note: the buffers are NOT transferred when running synchronously
+ * (so callers can keep reading them); they ARE transferred when
+ * routed through a worker (caller's Float32Array becomes detached).
+ * If caller behaviour depends on this, copy before calling.
+ */
+export async function estimateMotionLk(
+  I0: Float32Array, I1: Float32Array, width: number, height: number,
+  opts: LkOptions = {},
+  client: LkWorkerClient | null = null,
+): Promise<LkResult> {
+  if (client) {
+    return client.estimate(I0, I1, width, height, opts);
+  }
+  // Synchronous fallback — wrap in a microtask so the API surface is
+  // uniformly async.
+  return Promise.resolve(lucasKanadePyramidal(I0, I1, width, height, opts));
+}

--- a/src/lk.ts
+++ b/src/lk.ts
@@ -1,0 +1,390 @@
+// Pyramidal Lucas-Kanade optical flow for radar tile pairs.
+//
+// Given two consecutive radar frame snapshots (Float32 intensity grids)
+// of equal dimensions, returns the single global displacement (dx, dy)
+// that best aligns the pair. Used by radar-player.ts during the
+// crossfade to translate each layer in the direction of motion so the
+// rain appears to drift between frames instead of teleport.
+//
+// Pure: no DOM, no Leaflet, no module-level state. Browser-safe and
+// safe to run inside a Web Worker via lk-worker.ts (which inlines the
+// algorithm as a JS string — see the doc-block in that file for the
+// duplication rationale).
+//
+// Algorithm: Lucas-Kanade least-squares optical flow run over a 3-level
+// Gaussian-like pyramid (256 → 128 → 64 by default). Each level
+// iteratively refines a single (vx, vy) by solving the over-determined
+// system A^T A v = -A^T b where A is the spatial gradient and b the
+// temporal gradient, summed over all pixels. Coarsest level starts at
+// (0, 0); each finer level inherits the previous level's estimate
+// scaled up by 2. Pyramidal coverage means motion much larger than the
+// per-level convergence radius is still recovered cleanly (the
+// coarsest level sees 30 px of motion as ~7 px).
+//
+// Why a single global vector rather than dense per-cell flow: a
+// rendering pipeline that can show different translations per region
+// needs WebGL or a sub-layer mesh, which is a separate, larger
+// project. Validation against synthetic test scenarios in the
+// prototype (.dev/lk-prototype/) showed that a single global vector
+// approximates differential storm-cell motion to within sub-pixel
+// residual, so dense flow isn't warranted for v1.
+
+export interface LkOptions {
+  /** Pyramid levels (1..5). Level 0 = original resolution. Default 3. */
+  levels?: number;
+  /** Per-level LK refinement iterations (1..20). Default 5. */
+  iterations?: number;
+}
+
+export interface LkPerLevelResult {
+  level: number;
+  width: number;
+  height: number;
+  vx: number;
+  vy: number;
+  confidence: number;
+  iterationsUsed: number;
+}
+
+export interface LkResult {
+  /** Global x displacement in pixels. Positive = source content moved right. */
+  dx: number;
+  /** Global y displacement in pixels. Positive = source content moved down. */
+  dy: number;
+  /**
+   * Shi-Tomasi gradient-tensor confidence at the finest level, normalised
+   * by pixel count. Empirical bands (see prototype README):
+   *   > 50  strong   — clear texture, trustworthy
+   *   5–50 borderline — direction probably right, magnitude uncertain
+   *   < 5  low signal — image too flat for LK to find structure
+   * The radar-player gates motion-compensation on this threshold.
+   */
+  confidence: number;
+  /** Hypot of (dx, dy). */
+  magnitude: number;
+  /** atan2(dy, dx) in degrees, 0..360 (mathematical convention, +x = 0°). */
+  angleDeg: number;
+  /** Per-level breakdown for diagnosis — useful in the prototype harness. */
+  perLevel: LkPerLevelResult[];
+}
+
+// ── Pyramid construction ──────────────────────────────────────────────────
+
+interface PyramidLevel { data: Float32Array; width: number; height: number; }
+
+/**
+ * Build a Gaussian-like pyramid. Each level halves the previous
+ * level's width and height; each output pixel is the 2×2 average of
+ * the corresponding source block. Not a true Gaussian (no σ-tuned
+ * kernel), but sufficient as a low-pass step before LK — coarsely
+ * suppressing high-frequency detail is enough for the iterative
+ * refinement to converge.
+ *
+ * Stops adding levels once a halved level would fall below 4 px in
+ * either dimension — the LK gradient window can't operate below that
+ * and finer-level estimates would dominate anyway.
+ */
+export function buildPyramid(
+  img: Float32Array, width: number, height: number, levels: number,
+): PyramidLevel[] {
+  const pyramid: PyramidLevel[] = [{ data: img, width, height }];
+  for (let i = 1; i < levels; i++) {
+    const prev = pyramid[i - 1];
+    const w = prev.width >> 1;
+    const h = prev.height >> 1;
+    if (w < 4 || h < 4) break;
+    const out = new Float32Array(w * h);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const sx = x << 1;
+        const sy = y << 1;
+        const a = prev.data[sy * prev.width + sx];
+        const b = prev.data[sy * prev.width + sx + 1];
+        const c = prev.data[(sy + 1) * prev.width + sx];
+        const d = prev.data[(sy + 1) * prev.width + sx + 1];
+        out[y * w + x] = (a + b + c + d) * 0.25;
+      }
+    }
+    pyramid.push({ data: out, width: w, height: h });
+  }
+  return pyramid;
+}
+
+// ── Spatial gradients (Sobel) ─────────────────────────────────────────────
+
+interface Gradients { Ix: Float32Array; Iy: Float32Array; }
+
+/**
+ * 3×3 Sobel gradient in one pass. Border pixels are zero — they
+ * contribute zero to every LK accumulator naturally, so no special
+ * border handling is needed downstream.
+ */
+export function sobel(img: Float32Array, width: number, height: number): Gradients {
+  const Ix = new Float32Array(width * height);
+  const Iy = new Float32Array(width * height);
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      const i = y * width + x;
+      const tl = img[i - width - 1]; const tc = img[i - width]; const tr = img[i - width + 1];
+      const ml = img[i - 1]; const mr = img[i + 1];
+      const bl = img[i + width - 1]; const bc = img[i + width]; const br = img[i + width + 1];
+      Ix[i] = ((tr + 2 * mr + br) - (tl + 2 * ml + bl)) * 0.125;
+      Iy[i] = ((bl + 2 * bc + br) - (tl + 2 * tc + tr)) * 0.125;
+    }
+  }
+  return { Ix, Iy };
+}
+
+// ── Bilinear sampler + warp ──────────────────────────────────────────────
+
+function sampleBilinear(
+  img: Float32Array, width: number, height: number, x: number, y: number,
+): number {
+  if (x < 0 || y < 0 || x > width - 1 || y > height - 1) return 0;
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const x1 = Math.min(x0 + 1, width - 1);
+  const y1 = Math.min(y0 + 1, height - 1);
+  const fx = x - x0;
+  const fy = y - y0;
+  const a = img[y0 * width + x0];
+  const b = img[y0 * width + x1];
+  const c = img[y1 * width + x0];
+  const d = img[y1 * width + x1];
+  return a * (1 - fx) * (1 - fy)
+       + b * fx * (1 - fy)
+       + c * (1 - fx) * fy
+       + d * fx * fy;
+}
+
+/**
+ * Warp img by displacement (vx, vy): output pixel at (x, y) samples
+ * img at (x + vx, y + vy). Convention: (vx, vy) is the displacement of
+ * source content from I0 to I1. If rain moved from I0(p) to
+ * I1(p + d), then warp(I1, +d) brings the rain back to position p —
+ * aligning I1 with I0. This matches the textbook LK formulation
+ * `I1(x + v) ≈ I0(x)` that the update equation in lkSingleLevel
+ * derives from. Inverting the sign here was the bug that produced
+ * "double paint at 1x" in the prototype before the fix.
+ */
+function warp(
+  img: Float32Array, width: number, height: number, vx: number, vy: number,
+): Float32Array {
+  const out = new Float32Array(width * height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      out[y * width + x] = sampleBilinear(img, width, height, x + vx, y + vy);
+    }
+  }
+  return out;
+}
+
+// ── Single-level Lucas-Kanade ────────────────────────────────────────────
+
+export interface LkSingleLevelResult {
+  vx: number;
+  vy: number;
+  confidence: number;
+  iterations: number;
+}
+
+/**
+ * Iterative LK at one pyramid level. Returns refined (vx, vy) plus
+ * Shi-Tomasi confidence (min eigenvalue of the gradient tensor,
+ * normalised by pixel count) and the number of refinement iterations
+ * actually used (may be less than the cap if convergence kicked in).
+ *
+ * Inputs are already at this level's resolution. Initial guess
+ * (vx0, vy0) comes from the coarser level scaled up by 2; coarsest
+ * level passes (0, 0).
+ *
+ * The gradient tensor is computed once from I0 and reused across
+ * iterations — it doesn't change as v changes. The per-iteration cost
+ * is the warp + temporal-gradient accumulation.
+ */
+export function lkSingleLevel(
+  I0: Float32Array, I1: Float32Array, width: number, height: number,
+  vx0: number, vy0: number, iterations: number,
+): LkSingleLevelResult {
+  let vx = vx0;
+  let vy = vy0;
+  const { Ix, Iy } = sobel(I0, width, height);
+
+  let sIxIx = 0; let sIxIy = 0; let sIyIy = 0;
+  for (let i = 0; i < I0.length; i++) {
+    sIxIx += Ix[i] * Ix[i];
+    sIxIy += Ix[i] * Iy[i];
+    sIyIy += Iy[i] * Iy[i];
+  }
+  const det = sIxIx * sIyIy - sIxIy * sIxIy;
+
+  // Shi-Tomasi confidence: min eigenvalue of the symmetric tensor
+  // [[sIxIx, sIxIy], [sIxIy, sIyIy]]. Normalised by pixel count so the
+  // scale is roughly comparable across pyramid resolutions.
+  const trace = sIxIx + sIyIy;
+  const sqrtDisc = Math.sqrt(Math.max(0, trace * trace * 0.25 - det));
+  const minEig = trace * 0.5 - sqrtDisc;
+  const confidence = minEig / I0.length;
+
+  if (det < 1e-6) {
+    return { vx, vy, confidence: 0, iterations: 0 };
+  }
+
+  let actualIters = 0;
+  for (let iter = 0; iter < iterations; iter++) {
+    actualIters++;
+    const I1w = warp(I1, width, height, vx, vy);
+    let sIxIt = 0; let sIyIt = 0;
+    for (let i = 0; i < I0.length; i++) {
+      const it = I1w[i] - I0[i];
+      sIxIt += Ix[i] * it;
+      sIyIt += Iy[i] * it;
+    }
+    const dvx = (sIyIy * (-sIxIt) - sIxIy * (-sIyIt)) / det;
+    const dvy = (sIxIx * (-sIyIt) - sIxIy * (-sIxIt)) / det;
+    vx += dvx;
+    vy += dvy;
+    // Convergence threshold of 0.005 px tracks the prototype's tuning
+    // — finer than radar can plausibly resolve, but cheap enough that
+    // tightening doesn't cost much when iterations are already capped.
+    if (Math.abs(dvx) < 0.005 && Math.abs(dvy) < 0.005) break;
+  }
+  return { vx, vy, confidence, iterations: actualIters };
+}
+
+// ── Pyramidal LK (public entry point) ────────────────────────────────────
+
+/**
+ * Pyramidal Lucas-Kanade. Walks coarsest level → finest, scaling the
+ * estimate up by 2 between levels. Returns the global motion vector,
+ * a confidence score, and a per-level breakdown that's mostly useful
+ * for debugging (the prototype harness uses it).
+ *
+ * Defaults: 3 pyramid levels, 5 refinement iterations per level.
+ * Empirically (.dev/lk-prototype/) these defaults converge cleanly on
+ * synthetic test scenarios at all motion magnitudes up to ~30 px.
+ *
+ * @param I0  First frame (intensity, typically distance-from-white values 0..255)
+ * @param I1  Second frame (same dims as I0)
+ */
+export function lucasKanadePyramidal(
+  I0: Float32Array, I1: Float32Array, width: number, height: number,
+  opts: LkOptions = {},
+): LkResult {
+  const levels = Math.max(1, Math.min(opts.levels ?? 3, 5));
+  const iterations = Math.max(1, Math.min(opts.iterations ?? 5, 20));
+
+  const pyr0 = buildPyramid(I0, width, height, levels);
+  const pyr1 = buildPyramid(I1, width, height, levels);
+  const actualLevels = Math.min(pyr0.length, pyr1.length);
+
+  let vx = 0;
+  let vy = 0;
+  let confidence = 0;
+  const perLevel: LkPerLevelResult[] = [];
+
+  for (let level = actualLevels - 1; level >= 0; level--) {
+    if (level < actualLevels - 1) {
+      vx *= 2;
+      vy *= 2;
+    }
+    const result = lkSingleLevel(
+      pyr0[level].data, pyr1[level].data,
+      pyr0[level].width, pyr0[level].height,
+      vx, vy, iterations,
+    );
+    vx = result.vx;
+    vy = result.vy;
+    confidence = result.confidence;
+    perLevel.push({
+      level,
+      width: pyr0[level].width,
+      height: pyr0[level].height,
+      vx: result.vx,
+      vy: result.vy,
+      confidence: result.confidence,
+      iterationsUsed: result.iterations,
+    });
+  }
+
+  return {
+    dx: vx,
+    dy: vy,
+    confidence,
+    magnitude: Math.hypot(vx, vy),
+    angleDeg: (Math.atan2(vy, vx) * 180 / Math.PI + 360) % 360,
+    perLevel,
+  };
+}
+
+// ── ImageData / channel extraction utilities ─────────────────────────────
+
+export type ChannelMode = 'alpha' | 'luminance' | 'distance-from-white' | 'saturation';
+
+/**
+ * Extract a single intensity channel from canvas ImageData into a
+ * Float32Array suitable for lucasKanadePyramidal.
+ *
+ * Four modes, each suited to different radar palettes:
+ *   - 'alpha':                DWD banded palette — alpha gradients at
+ *                             intensity boundaries carry the signal
+ *   - 'luminance':            ITU-R BT.601 perceptual brightness, neutral
+ *                             baseline that works for any palette
+ *   - 'distance-from-white':  255 - min(R, G, B), gated and weighted by
+ *                             alpha. **Default and recommended** —
+ *                             captures both greyscale and coloured rain
+ *                             on one scale; works for all three radar
+ *                             sources (DWD, RainViewer, NOAA)
+ *   - 'saturation':           max - min of RGB. Fails for greyscale rain
+ *                             (RainViewer/NOAA low-intensity); included
+ *                             only for completeness with the prototype
+ *
+ * radar-player.ts uses 'distance-from-white' unconditionally. The
+ * other modes are kept exported so the prototype harness keeps working
+ * and so future per-source dispatch (if ever needed) has somewhere to
+ * land.
+ */
+export function extractChannel(
+  imgData: { data: Uint8ClampedArray; width: number; height: number },
+  mode: ChannelMode = 'distance-from-white',
+): Float32Array {
+  const out = new Float32Array(imgData.width * imgData.height);
+  const data = imgData.data;
+  for (let i = 0; i < out.length; i++) {
+    const r = data[i * 4];
+    const g = data[i * 4 + 1];
+    const b = data[i * 4 + 2];
+    const a = data[i * 4 + 3];
+    switch (mode) {
+      case 'alpha':
+        out[i] = a;
+        break;
+      case 'luminance':
+        out[i] = a === 0 ? 0 : 0.299 * r + 0.587 * g + 0.114 * b;
+        break;
+      case 'distance-from-white':
+        // Gating on a === 0 (the "no rain" check) AND weighting by
+        // alpha means transparent pixels contribute zero, and
+        // semi-transparent rain contributes proportionally to its
+        // visible intensity.
+        //
+        // Tried squaring this (intensity² / 255) to re-bias LK's
+        // gradient signal toward saturated red/yellow core pixels in
+        // hopes of reducing the visible "core jumps" while outlines
+        // drift smoothly artifact. Empirically no visible improvement
+        // — the residual core motion appears to be storm-evolution
+        // (cell rotation / decay / reorganisation) rather than
+        // translation that LK could chase. Reverted to linear; dense
+        // per-region flow is the real fix and that's a v2 project.
+        // See docs/motion-compensation-feature-design.md.
+        out[i] = a === 0 ? 0 : ((255 - Math.min(r, g, b)) * a) / 255;
+        break;
+      case 'saturation':
+        out[i] = a === 0 ? 0 : Math.max(r, g, b) - Math.min(r, g, b);
+        break;
+      default:
+        out[i] = a;
+    }
+  }
+  return out;
+}

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (schneller)",
       "playback_speed_quad": "4× (schnellste)",
       "viewer_layer_control": "Benutzerbezogene Speicherung (Admin-Opt-in)",
-      "viewer_layer_control_helper": "Wenn aktiviert, wird die Geschwindigkeitswahl pro Benutzer gespeichert und folgt dem Benutzer über Browser und Geräte hinweg über den Home-Assistant-Frontend-Speicher. Wenn deaktiviert, funktioniert die Schaltfläche weiterhin für die aktuelle Sitzung, die Auswahl wird jedoch nicht gespeichert."
+      "viewer_layer_control_helper": "Wenn aktiviert, wird die Geschwindigkeitswahl pro Benutzer gespeichert und folgt dem Benutzer über Browser und Geräte hinweg über den Home-Assistant-Frontend-Speicher. Wenn deaktiviert, funktioniert die Schaltfläche weiterhin für die aktuelle Sitzung, die Auswahl wird jedoch nicht gespeichert.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Höhe",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Height",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Altura",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Hauteur",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Altezza",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Høyde",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Hoogte",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Wysokość",

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Altura",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Výška",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -180,7 +180,9 @@
       "playback_speed_double": "2× (faster)",
       "playback_speed_quad": "4× (fastest)",
       "viewer_layer_control": "Per-user persistence (admin opt-in)",
-      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved."
+      "viewer_layer_control_helper": "When enabled, the toolbar speed button persists per user and follows them across browsers and devices via Home Assistant frontend storage. When off the button still works for the current session but the choice is not saved.",
+      "motion_compensation": "Motion Compensation (drift rain between frames)",
+      "motion_compensation_helper": "Slides each frame in the direction of rain motion during the crossfade so the rain appears to drift smoothly between frames instead of teleporting to its new position. Motion is recovered from the frame pair via pyramidal Lucas-Kanade optical flow — no external wind data, works for all radar sources. Pairs naturally with Smooth Animation. Default off."
     },
     "appearance": {
       "height": "Höjd",

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -7,6 +7,8 @@ import { FetchTileLayer, FetchWmsTileLayer, layerSettled } from './fetch-tile-la
 import { RadarToolbar } from './radar-toolbar';
 import { localize } from './localize/localize';
 import { getEffectiveTimeRange } from './source-caps';
+import { extractChannel } from './lk';
+import { createLkWorker, LkWorkerClient, estimateMotionLk } from './lk-worker';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -30,6 +32,15 @@ export function nearestFrameIndex(frames: { time: number }[], nowSec: number): n
 
 export type FrameStatus = 'empty' | 'loading' | 'loaded' | 'failed';
 export interface RadarFrame { time: number; path: string; host?: string; }
+
+/**
+ * Screen-space motion vector for one frame-to-frame transition.
+ * Produced by the LK motion-compensation pipeline; applied as a CSS
+ * translate in {@link RadarPlayer._showSlot}. Sign convention matches
+ * the LK output: (dx, dy) is the displacement of rain content from
+ * the older frame into the newer frame.
+ */
+interface MotionVector { dx: number; dy: number; confidence: number; }
 
 const NOAA_WMS_URL =
   'https://mapservices.weather.noaa.gov/eventdriven/services/radar/radar_base_reflectivity_time/ImageServer/WMSServer';
@@ -265,6 +276,85 @@ export class RadarPlayer {
   // lower native zoom.
   private _pinnedNativeZoom = 0;
 
+  // ── Motion compensation state ────────────────────────────────────────
+  //
+  // Per-frame snapshots of the visible radar tiles (distance-from-white
+  // intensity grid at SNAPSHOT_GRID resolution), and per-transition
+  // motion vectors derived from adjacent snapshots via pyramidal
+  // Lucas-Kanade optical flow. Both arrays are parallel to
+  // _radarImage[] — index = frame index.
+  //
+  // _frameMotion[fi] is the vector to USE when transitioning INTO
+  // frame fi (so the slide ends in sync with the fade-in of the new
+  // frame). _frameMotion[0] is always null because the oldest frame
+  // has no predecessor.
+  //
+  // null entries mean either:
+  //   - snapshot not captured yet (frame still loading), or
+  //   - LK confidence below CONFIDENCE_FLOOR (image too flat for a
+  //     trustworthy vector — fall back to static crossfade).
+  //
+  // _snapshotGen is bumped on each map move/zoom/resize so async LK
+  // results from the previous viewport don't pollute the new one when
+  // they eventually resolve.
+  private _frameSnapshot: (Float32Array | null)[] = [];
+  // Per-snapshot non-zero pixel count, tracked alongside _frameSnapshot
+  // so we can detect partial captures (tiles still loading when 'load'
+  // fired). Two snapshots with very different nz aren't comparing the
+  // same content and produce spurious LK vectors with deceptively high
+  // confidence — gated against in _computeMotionForFrame.
+  private _frameSnapshotNz: number[] = [];
+  private _frameMotion: (MotionVector | null)[] = [];
+  private _snapshotGen = 0;
+  // Tracks which frame indices we've already logged an "averaging
+  // anomaly" for (direction flip or magnitude overshoot in
+  // _smoothedMotion). The smoothed value is constant for a given
+  // snapshot-generation, so logging once per fi per generation
+  // avoids spamming the console while still surfacing every
+  // anomalous transition for diagnostic.
+
+  // LK worker client; lazy-initialised on first compensation request
+  // so the worker isn't created when motion_compensation is off. Falls
+  // back to synchronous main-thread execution if Worker construction
+  // fails (e.g. corporate CSP blocks blob: workers).
+  private _lkClient: LkWorkerClient | null = null;
+  private _lkWorkerInitTried = false;
+
+  // 96 × 96 snapshot keeps the LK compute under ~3 ms on a fast
+  // desktop, ~10–25 ms on a low-end mobile/tablet — well within a
+  // single animation frame even on slow hardware when run in the
+  // worker. CONFIDENCE_FLOOR matches the prototype's empirical
+  // "borderline" threshold (Shi-Tomasi min eigenvalue normalised by
+  // pixel count). Below it, the gradient field is too flat for LK to
+  // produce a trustworthy vector and we fall back to no compensation
+  // rather than slide by whatever the noise floor returned.
+  private static readonly SNAPSHOT_GRID = 96;
+  private static readonly CONFIDENCE_FLOOR = 5;
+  // Window for cross-tick motion-vector smoothing in _smoothedMotion.
+  // ±2 around the current transition (5-tap median) — same as PR #156's
+  // smoothMotionVectors. Suppresses the per-tick speed jumps that read
+  // visually as "stepping" between frames: raw LK output for a typical
+  // RainViewer loop showed 3× speed variation between adjacent
+  // transitions, which the slide animation faithfully renders as a
+  // step at every tick boundary even when overlap=1 makes the fade
+  // itself continuous.
+  private static readonly MOTION_SMOOTH_RADIUS = 2;
+  // Coverage similarity floor: when the smaller of two snapshots'
+  // non-zero pixel counts is below this fraction of the larger, the
+  // snapshots aren't comparing the same content and we refuse to
+  // compute motion (which would otherwise produce a spurious vector
+  // with deceptively high confidence — LK aggregates whatever
+  // gradient signal it finds, even on incompatible inputs). 0.6
+  // tolerates a meaningful rain-decay difference between consecutive
+  // frames while rejecting the ~3× nz mismatches we see when one
+  // snapshot captures partially-loaded tiles.
+  private static readonly COVERAGE_SIMILARITY_FLOOR = 0.6;
+  // Absolute floor on snapshot coverage. Below this many non-zero
+  // pixels the input is too sparse to produce a meaningful estimate
+  // regardless of comparability — typically means a near-empty
+  // (clear-sky) viewport or a snapshot captured before tiles arrived.
+  private static readonly MIN_SNAPSHOT_NZ = 500;
+
   constructor(opts: RadarPlayerOptions) {
     this._map = opts.map;
     this._shadowRoot = opts.shadowRoot;
@@ -278,6 +368,8 @@ export class RadarPlayer {
       this._sourceMaxNativeZoom(),
     );
     this._map.on('zoomend', this._onZoomEnd);
+    this._map.on('moveend', this._onMoveEnd);
+    this._map.on('resize', this._onResize);
   }
 
   private _sourceMaxNativeZoom(): number {
@@ -288,14 +380,502 @@ export class RadarPlayer {
   private _onZoomEnd = (): void => {
     if (!this._map) return;
     const newPin = Math.min(this._map.getZoom(), this._sourceMaxNativeZoom());
-    if (newPin <= this._pinnedNativeZoom) return;
-    this._pinnedNativeZoom = newPin;
-    // Leaflet reads minNativeZoom each time _clampZoom runs; updating the
-    // option on existing layers is enough, no redraw needed.
-    for (const layer of this._radarImage) {
-      if (layer) (layer.options as any).minNativeZoom = newPin;
+    if (newPin > this._pinnedNativeZoom) {
+      this._pinnedNativeZoom = newPin;
+      // Leaflet reads minNativeZoom each time _clampZoom runs; updating the
+      // option on existing layers is enough, no redraw needed.
+      for (const layer of this._radarImage) {
+        if (layer) (layer.options as any).minNativeZoom = newPin;
+      }
+    }
+    // Zoom changes pixel scale, so cached snapshots and the screen-
+    // pixel motion vectors derived from them are stale. Drop them and
+    // immediately recapture from whatever tiles are in the DOM at the
+    // new zoom level; _onLayerLoaded will run again if new tiles also
+    // arrive, overwriting with a fresher snapshot.
+    this._invalidateSnapshots();
+    void this._resnapshotAll();
+  };
+
+  private _onMoveEnd = (): void => {
+    // Pan changes which tiles are visible, but Leaflet only fires the
+    // layer-level 'load' event when it actually fetches NEW tiles. A
+    // small pan within the already-cached tile set just repositions
+    // existing tiles via CSS transform and never fires 'load' — which
+    // means _onLayerLoaded never runs and motion compensation would
+    // stay off indefinitely after a cached-pan. So we resnapshot here
+    // directly using whatever tiles are in the DOM right now; if a
+    // larger pan also triggers new tile fetches, _onLayerLoaded picks
+    // those up later and overwrites with the fresher snapshot.
+    this._invalidateSnapshots();
+    void this._resnapshotAll();
+  };
+
+  // Map container size changed (window resize, parent reflow, theme
+  // switch, etc.). Leaflet's tile manager will re-fetch tiles for the
+  // new viewport and each layer will fire its own 'load' as its tiles
+  // settle, at which point _onLayerLoaded rebuilds its snapshot. Drop
+  // the cached snapshots and motion vectors now so playback runs
+  // without compensation through the resize rather than animating
+  // with stale viewport data.
+  private _onResize = (): void => {
+    this._invalidateSnapshots();
+    void this._resnapshotAll();
+  };
+
+  // ── Motion compensation: snapshot + LK pipeline ──────────────────────
+
+  // Lazy-initialise the LK worker on first request. We don't create it
+  // in the constructor because motion_compensation is off by default
+  // and we don't want every player to spawn a worker it never uses.
+  private _ensureLkClient(): void {
+    if (this._lkClient || this._lkWorkerInitTried) return;
+    this._lkWorkerInitTried = true;
+    const created = createLkWorker();
+    if (created) {
+      this._lkClient = new LkWorkerClient(created.worker, created.blobUrl);
+    } else {
+      // Worker construction unavailable — silently fall back to
+      // synchronous LK on the main thread. Logged once so a user
+      // troubleshooting performance reports under a strict CSP has a
+      // breadcrumb.
+      console.info(
+        '[weather-radar-card] LK worker unavailable; motion compensation will run on the main thread.',
+      );
+    }
+  }
+
+  // Drop the per-frame snapshots and motion vectors and bump the
+  // generation so any pending async LK results bail out. New
+  // snapshots will be captured the next time tiles settle on each
+  // frame (or immediately via _resnapshotAll for cached-pan cases).
+  private _invalidateSnapshots(): void {
+    this._snapshotGen++;
+    if (this._frameSnapshot.length > 0) {
+      this._frameSnapshot = new Array(this._frameSnapshot.length).fill(null);
+      this._frameSnapshotNz = new Array(this._frameSnapshotNz.length).fill(0);
+      this._frameMotion = new Array(this._frameMotion.length).fill(null);
+    }
+  }
+
+  // Capture the current visible state of a loaded radar frame's tiles
+  // to a downsampled distance-from-white intensity grid. The grid
+  // feeds the LK call that estimates rain motion between consecutive
+  // frames.
+  //
+  // Why render to canvas rather than read tile <img> pixels directly:
+  // FetchTileLayer serves tiles via blob URLs (so the canvas is
+  // same-origin and readable), but reading pixels per <img> would
+  // require one canvas allocation each. Building a single
+  // viewport-sized canvas and drawImage'ing every tile into it is
+  // simpler and only marginally more memory.
+  //
+  // Why distance-from-white (not alpha): alpha works for DWD's banded
+  // palette but is near-binary for RainViewer/NOAA's smooth ramps,
+  // leaving no signal for LK at the rain edges. Distance-from-white
+  // (`255 - min(R, G, B)`, weighted by alpha) reads the colour ramp
+  // as a continuous gradient and works for all three sources.
+  //
+  // ## Async because of the decode race
+  //
+  // FetchTileLayer assigns `tile.src` to a blob URL and calls
+  // Leaflet's `done()` callback synchronously immediately after — see
+  // src/fetch-tile-layer.ts createFetchTile(). That fires the layer's
+  // 'load' event the moment the LAST tile's `done()` runs, but at
+  // that point the browser may not have finished DECODING the new
+  // image data (`tile.src = url` is async). Tiles with the
+  // `.leaflet-tile-loaded` class but `complete=false` aren't drawable
+  // yet — our JS check skips them, producing a partial snapshot whose
+  // motion-vector output looks plausible but is measuring random
+  // gradient overlap rather than real rain motion.
+  //
+  // We await `tile.decode()` on any incomplete tile before drawing.
+  // For already-decoded tiles decode() returns immediately, so the
+  // cost is paid only on the first 'load' fire of a freshly-loaded
+  // layer. Re-snapshot on pan/zoom resolves instantly.
+  //
+  // The async generation check (`genAtStart !== _snapshotGen`)
+  // ensures a viewport change mid-decode discards the result rather
+  // than polluting the new state.
+  //
+  // Skips silently when the layer's container isn't mounted yet, no
+  // tiles have loaded, or canvas isn't available. Callers check the
+  // _frameSnapshot[fi] slot to know whether a snapshot exists.
+  private async _captureFrameSnapshot(fi: number): Promise<void> {
+    const layer = this._radarImage[fi];
+    if (!layer || !this._map) return;
+    const container = (layer as any).getContainer?.() as HTMLElement | undefined;
+    if (!container) return;
+    // Broader selector than `.leaflet-tile-loaded`: pick up any tile
+    // in this layer's grid. The decode-await below filters the actual
+    // "drawable" set, and the JS isImageLoaded check in the draw loop
+    // is the final gate. Using the class would be premature filtering
+    // because Leaflet adds the class before the browser finishes
+    // decoding (see the doc-block above).
+    const tiles = container.querySelectorAll<HTMLImageElement>('img.leaflet-tile');
+    if (tiles.length === 0) return;
+    // Wait for any tile whose browser decode isn't complete yet.
+    // decode() returns a resolved promise for already-decoded images,
+    // so the common steady-state pan/zoom recapture costs nothing.
+    // catch() swallows broken-image rejections — those tiles fail the
+    // isImageLoaded check below and get skipped at draw time.
+    const genAtStart = this._snapshotGen;
+    await Promise.all(Array.from(tiles).map((t) => {
+      if (t.complete && t.naturalWidth > 0) return Promise.resolve();
+      return t.decode().catch(() => { /* broken; skip at draw time */ });
+    }));
+    // View changed during decode (pan/zoom/resize) — the snapshot for
+    // the old viewport is no longer relevant; the new generation will
+    // do its own capture.
+    if (genAtStart !== this._snapshotGen) return;
+    // Verify the layer wasn't replaced underneath us either (e.g. by
+    // _updateRadar's shift, or a teardown).
+    if (this._radarImage[fi] !== layer) return;
+    const mapSize = this._map.getSize();
+    const grid = RadarPlayer.SNAPSHOT_GRID;
+    const canvas = document.createElement('canvas');
+    canvas.width = grid;
+    canvas.height = grid;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const mapRect = this._map.getContainer().getBoundingClientRect();
+    const xScale = grid / mapSize.x;
+    const yScale = grid / mapSize.y;
+    for (const tileImg of Array.from(tiles)) {
+      if (!tileImg.complete || tileImg.naturalWidth === 0) continue;
+      const tr = tileImg.getBoundingClientRect();
+      const sx = (tr.left - mapRect.left) * xScale;
+      const sy = (tr.top - mapRect.top) * yScale;
+      const sw = tr.width * xScale;
+      const sh = tr.height * yScale;
+      try {
+        ctx.drawImage(tileImg, sx, sy, sw, sh);
+      } catch {
+        // Cross-origin taint shouldn't happen with FetchTileLayer's
+        // blob URLs, but if it does we silently skip the tile rather
+        // than throw.
+      }
+    }
+    const imgData = ctx.getImageData(0, 0, grid, grid);
+    const snapshot = extractChannel(imgData, 'distance-from-white');
+    this._frameSnapshot[fi] = snapshot;
+    // Count non-zero pixels so _computeMotionForFrame can detect a
+    // partial-load capture (small nz next to a sibling frame's full
+    // snapshot → LK would lock onto noise with high confidence).
+    let nz = 0;
+    for (let k = 0; k < snapshot.length; k++) if (snapshot[k] > 0) nz++;
+    this._frameSnapshotNz[fi] = nz;
+  }
+
+  // After snapshotting frame fi, async-compute the motion vector that
+  // takes frame fi-1's rain field into frame fi's. Stored as the
+  // vector to animate when transitioning INTO frame fi. Skips if the
+  // previous snapshot doesn't exist yet (fi is the oldest, or its
+  // predecessor hasn't loaded). Discards stale async results via the
+  // generation check so a viewport change mid-computation doesn't
+  // pollute the new state with old-viewport vectors.
+  private _computeMotionForFrame(fi: number): void {
+    const cur = this._frameSnapshot[fi];
+    const prev = this._frameSnapshot[fi - 1];
+    if (!cur || !prev || !this._map) { this._frameMotion[fi] = null; return; }
+    // Comparability check: two snapshots with very different non-zero
+    // coverage aren't capturing the same scene (one was likely taken
+    // while tiles were still loading — Leaflet's 'load' event empirically
+    // fires before all tile <img> elements are decoded into the DOM as
+    // class="leaflet-tile-loaded"). LK on incompatible inputs produces
+    // spurious vectors with deceptively high Shi-Tomasi confidence,
+    // because the algorithm just minimises the residual on whatever
+    // gradient signal exists — not knowing the inputs don't correspond.
+    // Without this gate the user sees occasional "rain teleports half
+    // the screen" frames mixed in with normal slides.
+    const prevNz = this._frameSnapshotNz[fi - 1];
+    const curNz = this._frameSnapshotNz[fi];
+    if (prevNz < RadarPlayer.MIN_SNAPSHOT_NZ || curNz < RadarPlayer.MIN_SNAPSHOT_NZ) {
+      // Too sparse to be reliable. Leave any prior motion[fi] in
+      // place — better an out-of-date vector than a wrong one.
+      return;
+    }
+    const ratio = Math.min(prevNz, curNz) / Math.max(prevNz, curNz);
+    if (ratio < RadarPlayer.COVERAGE_SIMILARITY_FLOOR) {
+      // Snapshots have incompatible coverage. Same reasoning — keep
+      // whatever motion[fi] already holds rather than overwriting.
+      return;
+    }
+    this._ensureLkClient();
+    const grid = RadarPlayer.SNAPSHOT_GRID;
+    const genAtStart = this._snapshotGen;
+    // The worker transfers (and detaches) the ArrayBuffers it
+    // receives. Copy the snapshots first so future
+    // _computeMotionForFrame calls — which read these same snapshots
+    // for adjacent transitions — still find valid data.
+    const i0 = new Float32Array(prev);
+    const i1 = new Float32Array(cur);
+    const mapSize = this._map.getSize();
+    const xScale = mapSize.x / grid;
+    const yScale = mapSize.y / grid;
+    void estimateMotionLk(i0, i1, grid, grid, {}, this._lkClient).then((result) => {
+      // Viewport changed since the call started — result is stale,
+      // _invalidateSnapshots already cleared _frameMotion.
+      if (genAtStart !== this._snapshotGen) return;
+      if (result.confidence < RadarPlayer.CONFIDENCE_FLOOR) {
+        this._frameMotion[fi] = null;
+        return;
+      }
+      this._frameMotion[fi] = {
+        dx: result.dx * xScale,
+        dy: result.dy * yScale,
+        confidence: result.confidence,
+      };
+    }).catch(() => {
+      // Worker error or termination — quietly drop. The next
+      // _onLayerLoaded / _resnapshotAll cycle will retry.
+      if (genAtStart !== this._snapshotGen) return;
+      this._frameMotion[fi] = null;
+    });
+  }
+
+  // Handle a layer's Leaflet 'load' event by snapshotting just that
+  // layer and recomputing the motion vectors for the two pairs it
+  // participates in (the transition INTO it, and the transition OUT
+  // of it to the next-newer frame). Per-layer rather than a debounced
+  // global sweep because Leaflet's 'load' fires the moment THIS
+  // layer's visible tiles are decoded, which is precisely when its
+  // pixel buffer is consistent. A global sweep timer can fire while
+  // a slower layer is still decoding, leaving a partial snapshot
+  // whose vector then drags the smoothed motion for that frame off
+  // course — visible as a jittery patch midway through the loop
+  // after a pan, zoom, or resize.
+  private _onLayerLoaded = async (layer: FetchTileLayer | FetchWmsTileLayer): Promise<void> => {
+    if (!this._cfg.motion_compensation) return;
+    const fi = this._radarImage.indexOf(layer);
+    if (fi < 0) return;
+    // Await capture — the decode race in fetch-tile-layer.ts means
+    // tile pixels may not be drawable when 'load' fires. See the
+    // doc-block on _captureFrameSnapshot.
+    await this._captureFrameSnapshot(fi);
+    // Layer might have been replaced (e.g. by _updateRadar) during
+    // the decode wait. _captureFrameSnapshot returns silently in
+    // that case, leaving snapshot[fi] stale or unchanged — either
+    // way, recomputing motion off it is meaningless.
+    if (this._radarImage[fi] !== layer) return;
+    this._computeMotionForFrame(fi);
+    if (fi + 1 < this._frameSnapshot.length) {
+      this._computeMotionForFrame(fi + 1);
     }
   };
+
+  // Median-of-5 smoothing for the motion vector at frame fi. Reduces
+  // visible "stepping" at tick boundaries when adjacent transitions
+  // produce significantly different LK vectors — without this, the
+  // slide animation honestly renders every per-tick speed change as
+  // a perceptible step. With it, the per-tick vector applied to the
+  // slide is the median of the window centered on fi, robustly
+  // ignoring single-tick outliers (e.g. a brief moment of bad
+  // gradient signal producing a 3× spike).
+  //
+  // Confidence inherits from the centre transition since the median
+  // is structural rather than statistical — averaging confidence
+  // would mask the actual signal quality of THIS transition.
+  //
+  // O(window²) time per call. With window=5 (radius 2) and per-tick
+  // invocation, this is single-digit operations — negligible.
+  private _smoothedMotion(fi: number): MotionVector | null {
+    if (fi < 0 || fi >= this._frameMotion.length) return null;
+    const raw = this._frameMotion[fi];
+    // Bypass smoothing when raw is near-zero. These come from frame
+    // pairs where the source served byte-identical snapshots
+    // (publication-cycle quirks on RainViewer / DWD / NOAA produce
+    // periodic duplicate frames when the requested stride is finer
+    // than the source's true unique-frame interval). LK correctly
+    // reports zero motion for these — but the median smoothing would
+    // replace the zero with the bulk neighbor vector, sliding the
+    // new layer from translate(-d_neighbor) to translate(0) over the
+    // tick. Since the actual frame content is identical to the
+    // previous frame, the rain visually JUMPS BACKWARD by d_neighbor
+    // at the tick start, then slides forward to its starting
+    // position. That's the periodic "step back" artifact.
+    //
+    // Threshold of 0.5 canvas-px = ~2 screen-px on a typical viewport
+    // — well below visual significance, so anything below it is
+    // either noise or a true duplicate-frame zero.
+    if (raw && Math.hypot(raw.dx, raw.dy) < 0.5) return raw;
+    const radius = RadarPlayer.MOTION_SMOOTH_RADIUS;
+    const dxs: number[] = [];
+    const dys: number[] = [];
+    for (let k = -radius; k <= radius; k++) {
+      const j = fi + k;
+      if (j < 0 || j >= this._frameMotion.length) continue;
+      const v = this._frameMotion[j];
+      if (!v) continue;
+      dxs.push(v.dx);
+      dys.push(v.dy);
+    }
+    if (dxs.length === 0) return null;
+    const median = (vs: number[]): number => {
+      const sorted = vs.slice().sort((a, b) => a - b);
+      const mid = sorted.length >> 1;
+      return sorted.length % 2 === 0
+        ? (sorted[mid - 1] + sorted[mid]) / 2
+        : sorted[mid];
+    };
+    return {
+      dx: median(dxs),
+      dy: median(dys),
+      confidence: this._frameMotion[fi]?.confidence ?? 0,
+    };
+  }
+
+  // Detect frames that are byte-identical to their predecessor and
+  // remove them from the playback loop, compacting every per-frame
+  // array. Caused by source-side publication-cycle quirks — NOAA's
+  // eventdriven WMS service snaps any TIME query within a single
+  // ~6-7 min publication window to the same physical frame, so
+  // requests at the source-caps `intervalMin: 5` stride return
+  // duplicates at roughly every 3-4th position. NOAA's metadata
+  // endpoints (queryRasters, query, GetCapabilities) all refuse
+  // browser requests, so the only way to learn the true cadence is
+  // empirically — from the snapshot nz fingerprints LK already has.
+  //
+  // Detection criterion: consecutive snapshots with identical nz
+  // (non-zero pixel count). When two snapshots have the same number
+  // of rain pixels AND we know they were captured from the same
+  // tile set (loaded sequentially in _initRadar), they're byte-
+  // identical with overwhelming probability — coincidental nz
+  // collision on random different frames is theoretically possible
+  // but vanishingly rare for any real radar scene.
+  //
+  // After compaction, _loadedSlots becomes the trivial [0, 1, …,
+  // n-1] (slot index == fi), every per-frame array is sized to the
+  // unique count, _configFrameCount reflects the actual displayed
+  // count, and the progress bar is rebuilt to match. _currentSlot
+  // and _prev1Slot are remapped to keep showing the same frame
+  // content across the compaction.
+  //
+  // Synchronous — atomic update relative to any tick callbacks
+  // (JavaScript single-threaded). Caller is responsible for
+  // bumping _loopGen via _stopLoop first so any in-flight
+  // setTimeout from before the dedup bails out on its gen check
+  // (the cancelled timer's captured n/isLoopBack would be stale
+  // after dedup).
+  private _dedupFrames(): void {
+    if (this._loadedSlots.length <= 1) return;
+    // Walk _loadedSlots in order; mark frames whose nz matches the
+    // PREVIOUSLY-KEPT frame (not the previous in _loadedSlots — a
+    // chain of 3 duplicates should all collapse to one, not zigzag).
+    const isDuplicate: boolean[] = new Array(this._loadedSlots.length).fill(false);
+    let lastKeptFi = this._loadedSlots[0];
+    for (let i = 1; i < this._loadedSlots.length; i++) {
+      const fi = this._loadedSlots[i];
+      const nz = this._frameSnapshotNz[fi];
+      const prevNz = this._frameSnapshotNz[lastKeptFi];
+      if (nz > 0 && nz === prevNz) {
+        isDuplicate[i] = true;
+      } else {
+        lastKeptFi = fi;
+      }
+    }
+    const droppedCount = isDuplicate.filter(Boolean).length;
+    if (droppedCount === 0) return;
+
+    // Capture the fi values for the currently-visible slot and the
+    // most-recent prev1 slot BEFORE we compact, so we can remap
+    // those pointers afterward to keep showing the same content.
+    const currentFi = this._loadedSlots[this._currentSlot];
+    const prev1Fi = this._prev1Slot >= 0
+      ? this._loadedSlots[this._prev1Slot]
+      : -1;
+
+    // Build the kept-fi list in slot order (oldest → newest), then
+    // tear down the dropped layers (return their tiles + DOM to
+    // Leaflet) so duplicates don't linger as invisible attached
+    // layers consuming memory.
+    const keptFi: number[] = [];
+    for (let i = 0; i < this._loadedSlots.length; i++) {
+      if (isDuplicate[i]) {
+        const fi = this._loadedSlots[i];
+        const layer = this._radarImage[fi];
+        if (layer && (layer as { remove?: () => void }).remove) {
+          (layer as { remove: () => void }).remove();
+        }
+        const mask = this._radarMask[fi];
+        if (mask && (mask as { remove?: () => void }).remove) {
+          (mask as { remove: () => void }).remove();
+        }
+      } else {
+        keptFi.push(this._loadedSlots[i]);
+      }
+    }
+
+    // Compact every per-frame array. New index == position in
+    // keptFi, which IS the new fi value since _loadedSlots becomes
+    // trivial [0..n-1] below.
+    this._radarImage = keptFi.map((fi) => this._radarImage[fi]);
+    this._radarTime = keptFi.map((fi) => this._radarTime[fi]);
+    this._radarPaths = keptFi.map((fi) => this._radarPaths[fi]);
+    this._frameSnapshot = keptFi.map((fi) => this._frameSnapshot[fi]);
+    this._frameSnapshotNz = keptFi.map((fi) => this._frameSnapshotNz[fi]);
+    this._frameMotion = keptFi.map((fi) => this._frameMotion[fi]);
+    this._radarMask = keptFi.map((fi) => this._radarMask[fi] ?? null);
+
+    // _loadedSlots becomes the identity mapping; _configFrameCount
+    // reflects what's actually displayed.
+    this._loadedSlots = Array.from({ length: keptFi.length }, (_, i) => i);
+    this._configFrameCount = keptFi.length;
+
+    // Remap _currentSlot / _prev1Slot to the new fi positions so
+    // playback resumes on the same content.
+    const newCurrent = keptFi.indexOf(currentFi);
+    this._currentSlot = newCurrent >= 0 ? newCurrent : (keptFi.length - 1);
+    if (prev1Fi >= 0) {
+      const newPrev1 = keptFi.indexOf(prev1Fi);
+      this._prev1Slot = newPrev1 >= 0 ? newPrev1 : this._currentSlot;
+    }
+
+    // Rebuild the progress bar at the new (correct) length. All
+    // remaining frames are loaded by this point, so seed every
+    // segment to 'loaded' rather than 'empty'.
+    this._buildSegments();
+    for (let i = 0; i < this._loadedSlots.length; i++) {
+      this._setSegment(i, 'loaded');
+    }
+    // Recompute the "now" marker against the new (compacted)
+    // _radarPaths and re-highlight the currently-visible segment.
+    this._computeNowFrameIndex();
+    this._applyNowMarker();
+    this._highlightSegment(this._currentSlot);
+
+    // Diagnostic: what cadence did we infer? Surfacing this once
+    // makes it easy for users to choose `frame_stride_minutes` in
+    // YAML if they want to skip the discovery overhead entirely.
+    const range = getEffectiveTimeRange(this._cfg);
+    const originalCount = keptFi.length + droppedCount;
+    const inferredCadenceMin = (originalCount * range.strideMin) / keptFi.length;
+    const dataSource = this._cfg.data_source ?? 'RainViewer';
+    console.info(
+      `[weather-radar-card] ${dataSource} cadence inferred: ~${inferredCadenceMin.toFixed(1)} min (dropped ${droppedCount} of ${originalCount} frames as duplicates).`,
+    );
+  }
+
+  // Snapshot every currently attached radar layer and compute every
+  // adjacent-pair motion vector. Called after view changes (pan, zoom,
+  // resize) where Leaflet's 'load' event may not fire because the
+  // necessary tiles are already cached and only reposition. Per-layer
+  // 'load' still handles the case where new tiles do load and gives
+  // a fresher snapshot.
+  private async _resnapshotAll(): Promise<void> {
+    if (!this._cfg.motion_compensation) return;
+    // Capture all snapshots in parallel (each awaits its own tiles'
+    // decode internally). Once all snapshots resolve, recompute every
+    // adjacent-pair motion vector with the fresh data.
+    await Promise.all(
+      this._radarImage.map((layer, fi) =>
+        layer ? this._captureFrameSnapshot(fi) : Promise.resolve(),
+      ),
+    );
+    for (let fi = 1; fi < this._frameSnapshot.length; fi++) {
+      this._computeMotionForFrame(fi);
+    }
+  }
 
   // ── Config helpers ───────────────────────────────────────────────────────
 
@@ -382,11 +962,20 @@ export class RadarPlayer {
     this._pathsAbortCtrl?.abort();
     this._pathsAbortCtrl = null;
     this._map?.off('zoomend', this._onZoomEnd);
+    this._map?.off('moveend', this._onMoveEnd);
+    this._map?.off('resize', this._onResize);
     if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
     this._worker?.terminate();
     this._worker = null;
     this._workerCallbacks.clear();
     if (this._workerBlobUrl) { URL.revokeObjectURL(this._workerBlobUrl); this._workerBlobUrl = null; }
+    // Bump generation so any in-flight LK promises bail out on resolve.
+    this._snapshotGen++;
+    this._lkClient?.dispose();
+    this._lkClient = null;
+    this._frameSnapshot = [];
+    this._frameSnapshotNz = [];
+    this._frameMotion = [];
     this._frameStatuses = [];
     this._updateLoadingSpinner();
   }
@@ -523,6 +1112,10 @@ export class RadarPlayer {
       if (!el) continue;
       el.style.transition = 'none';
       el.style.opacity = (s === current) ? '1' : '0';
+      // Reset any mid-transition translate so a paused-then-resumed
+      // playback doesn't show the current frame still offset by the
+      // outgoing slide of the previous tick.
+      el.style.transform = '';
     }
   }
 
@@ -575,7 +1168,13 @@ export class RadarPlayer {
       : this._crossfadeTiming();
     const fade = timing.fadeMs;
     const fadeOutDelay = timing.delayMs;
-    const transition = fade > 0 ? `opacity ${fade}ms ease-in-out` : 'none';
+    // Linear opacity easing (rather than ease-in-out) so the fade
+    // curve matches the slide's linear timing. ease-in-out's slow
+    // start / slow end creates a perceptual "settling" at each fade
+    // boundary that reads as extra stepping when consecutive ticks
+    // are stitched together. Linear keeps the brightness change rate
+    // constant throughout the cycle, eliminating that artifact.
+    const transition = fade > 0 ? `opacity ${fade}ms linear` : 'none';
 
     // Two-slot animation model. Per-layer opacity transitions between 0
     // and 1; radar_opacity is applied at the pane level (see
@@ -613,6 +1212,37 @@ export class RadarPlayer {
     const prev1 = this._prev1Slot;
     const useChain = fade > 0;
 
+    // Motion compensation: slide layers in the rain-drift direction
+    // over the full transition window (frame_delay). The incoming
+    // layer starts at translate(-dx, -dy) — where its rain WOULD
+    // have been at the previous frame's time — and slides to (0, 0).
+    // The outgoing layer starts at (0, 0) and slides to (+dx, +dy) —
+    // where its rain WOULD be at the new frame's time. At any t the
+    // two layers' rain positions overlap, so the composite reads as
+    // one drifting field rather than two crossfading ones.
+    //
+    // Linear easing keeps the perceived drift speed constant.
+    //
+    // _frameMotion[fi] is the vector from frame fi-1 INTO frame fi —
+    // so for THIS tick we want _frameMotion[newFi]. Disabled when:
+    //   - opts.snap (loop-restart): a slide across the loop reads
+    //     wrong because the user just watched time pause
+    //   - useChain is false (animations off): no transition to slide on
+    //   - motion_compensation config is off
+    //   - vector unavailable (snapshot pending, low confidence, etc.)
+    const newFi = this._loadedSlots[slot];
+    // Read the smoothed vector rather than the raw one — see
+    // _smoothedMotion's doc-block. The raw LK output for adjacent
+    // transitions can vary by 3× in magnitude on real radar data,
+    // which the slide animation would honestly render as a visible
+    // speed change at every tick boundary. Median-of-5 across the
+    // window centered on this frame collapses outliers and keeps the
+    // perceived rain speed consistent across the loop.
+    const motion = (!opts?.snap && useChain && this._cfg.motion_compensation && newFi !== undefined)
+      ? this._smoothedMotion(newFi)
+      : null;
+    const motionTransition = motion ? `, transform ${this._timeout}ms linear` : '';
+
     for (let s = 0; s < n; s++) {
       const fi = this._loadedSlots[s];
       const layer = this._radarImage[fi];
@@ -624,12 +1254,18 @@ export class RadarPlayer {
         el.style.zIndex = String(newZ);
         el.style.transition = 'none';
         el.style.opacity = '0';
+        // Stage the starting translate before the reflow so the
+        // transform transition has a "from" position to animate from.
+        // No motion: clear any stale translate left over from this
+        // layer's previous role as prev1 in an earlier tick.
+        el.style.transform = motion ? `translate(${-motion.dx}px, ${-motion.dy}px)` : '';
         // Forced reflow before re-assigning — without this the browser
         // coalesces the two opacity writes and skips the transition.
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         void el.offsetHeight;
-        el.style.transition = transition;
+        el.style.transition = transition + motionTransition;
         el.style.opacity = '1';
+        if (motion) el.style.transform = 'translate(0px, 0px)';
       } else if (useChain && s === prev1) {
         // Just-promoted previous current: delayed fade-out. The
         // `transition-delay` (the second time value) holds the layer
@@ -639,13 +1275,24 @@ export class RadarPlayer {
         // mode delay is 75% of fade duration — the fade-out starts
         // before fade-in finishes, creating a brief overlap window
         // where the brightness composite stays close to constant.
-        el.style.transition = `opacity ${fade}ms ease-in-out ${fadeOutDelay}ms`;
+        // The transform animation runs the full window (no delay) so
+        // the slide ends in sync with the fade-out completing.
+        // Linear opacity easing here too — matches the slot
+        // layer's linear easing set above. Previously ease-in-out,
+        // which created an asymmetric brightness curve during the
+        // crossfade (slot fading in linearly while prev faded out
+        // along an S-curve) that read as a "settling pause" mid-
+        // transition. Symmetric linear keeps the perceived rate of
+        // change constant.
+        el.style.transition = `opacity ${fade}ms linear ${fadeOutDelay}ms${motionTransition}`;
         el.style.opacity = '0';
+        if (motion) el.style.transform = `translate(${motion.dx}px, ${motion.dy}px)`;
       } else if (!useChain) {
         // Snap mode / fade=0: every non-current slot snaps to 0
         // immediately so we never see two layers at opacity 1.
         el.style.transition = 'none';
         el.style.opacity = '0';
+        el.style.transform = '';
       }
       // useChain && older: don't touch. Their delayed fade-out from a
       // previous tick is either still finishing or already at 0.
@@ -810,6 +1457,12 @@ export class RadarPlayer {
     // that no longer exist after a teardown + re-init.
     this._prev1Slot = -1;
     this._zCounter = 0;
+    // Reset motion-compensation state too. _snapshotGen++ invalidates
+    // any LK results still in flight from the previous frame set.
+    this._snapshotGen++;
+    this._frameSnapshot = [];
+    this._frameSnapshotNz = [];
+    this._frameMotion = [];
     this._clearDwdMaskLayers();
   }
 
@@ -929,6 +1582,18 @@ export class RadarPlayer {
       const frames: RadarFrame[] = [];
       // forecast_minutes is irrelevant for NOAA (maxForecastMin: 0) so the
       // anchor is just the latest past frame.
+      //
+      // Note: NOAA's eventdriven WMS server snaps any TIME query within
+      // a single ~6-7 min publication window to the same physical
+      // frame, so requests at the source-caps `intervalMin: 5` stride
+      // produce periodic duplicate frames (every 3-4 stride positions,
+      // empirically). NOAA's metadata endpoints (/queryRasters, /query,
+      // GetCapabilities) all refuse browser requests so we can't
+      // discover the actual frame times in advance. Instead, _initRadar
+      // detects duplicates from the captured snapshot statistics and
+      // prunes them via _dedupFrames, leaving the playback loop with
+      // only unique frames. See the doc-block on _dedupFrames for the
+      // full reasoning.
       for (let i = frameCount - 1; i >= 0; i--) {
         frames.push({ time: (snap - i * strideMs) / 1000, path: '' });
       }
@@ -1010,8 +1675,17 @@ export class RadarPlayer {
     const { size: tileSize, zoomOffset } = this._radarTileSize();
     // Drive the spinner from each layer's load events, so pan/zoom edge
     // fetches on attached layers light it up too (not just frame status).
+    // The same 'load' event drives the spinner AND the motion-comp
+    // snapshot refresh. Leaflet fires it once a layer's visible tiles
+    // are all decoded, which is exactly the right moment to read
+    // pixels for the LK input. Per-layer rather than a debounced
+    // global sweep, because a debounce timer can fire while ONE
+    // late-loading layer is still decoding, leaving a partial
+    // snapshot whose vector then drags the motion for that frame off
+    // course — visible as a jittery patch midway through the loop.
     const wireSpinner = (l: FetchTileLayer | FetchWmsTileLayer): typeof l => {
       l.on('loading load', () => this._updateLoadingSpinner());
+      l.on('load', () => this._onLayerLoaded(l));
       return l;
     };
     if (dataSource === 'NOAA') {
@@ -1132,6 +1806,20 @@ export class RadarPlayer {
     }
     const dwdLayerName = dwdActive ? this._dwdLayerName() : '';
 
+    // Initialise motion-compensation state for the fresh set of
+    // frames. _captureFrameSnapshot writes into these as each frame's
+    // tile-settle completes below.
+    this._frameSnapshot = new Array(frameCount).fill(null);
+    this._frameSnapshotNz = new Array(frameCount).fill(0);
+    this._frameMotion = new Array(frameCount).fill(null);
+
+    // Collected snapshot promises so we can await all captures before
+    // running _dedupFrames at the end of this init. The dedup needs
+    // every snapshot's nz to be populated before it can identify
+    // duplicate frames; without the await it would run while
+    // half the captures are still in their decode-wait.
+    const snapshotPromises: Promise<void>[] = [];
+
     let newestShown = false;
 
     for (let fi = frameCount - 1; fi >= 0; fi--) {
@@ -1164,6 +1852,32 @@ export class RadarPlayer {
       if (status === 'loaded') {
         const prevSlotCount = this._loadedSlots.length;
         this._loadedSlots.unshift(fi);
+
+        // Motion-comp prep: snapshot this frame, then compute the
+        // motion vector(s) we now have enough data for. Frames load
+        // newest first, so after fi snapshots we may be able to
+        // compute motion FROM fi INTO fi+1 (snapshotted last
+        // iteration). motion[fi] itself needs fi-1, which arrives
+        // next iteration.
+        //
+        // Fire and forget: _captureFrameSnapshot awaits each tile's
+        // decode() so we don't want to block this loop on it. The
+        // motion computation chains off the snapshot completion via
+        // .then() so it picks up fresh snapshot data, and a generation
+        // guard in _computeMotionForFrame discards stale results if
+        // _frameGeneration bumps mid-flight.
+        if (this._cfg.motion_compensation) {
+          const myGenInner = myGen;
+          snapshotPromises.push(
+            this._captureFrameSnapshot(fi).then(() => {
+              if (myGenInner !== this._frameGeneration) return;
+              this._computeMotionForFrame(fi);
+              if (fi + 1 < this._frameSnapshot.length) {
+                this._computeMotionForFrame(fi + 1);
+              }
+            }),
+          );
+        }
 
         if (!newestShown) {
           // Show newest frame as a static preview before the loop starts.
@@ -1214,6 +1928,33 @@ export class RadarPlayer {
     }
 
     if (myGen !== this._frameGeneration) return;
+
+    // Wait for snapshot captures to finish, then dedup duplicate
+    // frames out of the playback loop. Done at this point so the
+    // user has been watching the un-deduped loop for a few seconds
+    // already (the loop starts after 2 frames load) — the dedup
+    // tightens the loop without making them wait for it on first
+    // paint. _stopLoop bumps _loopGen so any in-flight tick whose
+    // captured (delay, isLoopBack) state is stale after compaction
+    // bails on its gen check; we restart immediately after dedup
+    // **regardless of whether the dedup actually dropped any frames**
+    // — _stopLoop killed the loop unconditionally, so we have to
+    // restart unconditionally too. (Skipping the restart when no
+    // duplicates were found leaves the loop dead, which manifests
+    // for sources like RainViewer where the configured intervalMin
+    // already matches the native cadence — no duplicates ever exist
+    // to trigger the restart-on-dedup path.)
+    if (this._cfg.motion_compensation && snapshotPromises.length > 0) {
+      await Promise.all(snapshotPromises);
+      if (myGen !== this._frameGeneration) return;
+      const wasRunning = this.run && this._radarReady && this._loadedSlots.length >= 2;
+      if (wasRunning) this._stopLoop();
+      this._dedupFrames();
+      if (wasRunning && this._loadedSlots.length >= 2) {
+        this._startLoop(this._currentSlot);
+      }
+    }
+
     if (this._loadedSlots.length > 0) {
       this._radarReady = true;
       this._scheduleUpdate();
@@ -1279,6 +2020,20 @@ export class RadarPlayer {
     this._radarTime[frameCount - 1] = newTime;
     this._radarPaths[frameCount - 1] = latestFrame;
     this._loadedSlots = this._loadedSlots.map(fi => fi - 1).filter(fi => fi >= 0);
+    // Shift motion-compensation state alongside the radar frames.
+    // The old frame 0 is dropped, so old motion[1] (which described
+    // the 0→1 transition) is also dropped — its predecessor no
+    // longer exists. All later motion vectors stay valid because the
+    // pair they describe (old fi-1, old fi) survives intact as
+    // (new fi-2, new fi-1).
+    for (let i = 0; i < frameCount - 1; i++) {
+      this._frameSnapshot[i] = this._frameSnapshot[i + 1] ?? null;
+      this._frameSnapshotNz[i] = this._frameSnapshotNz[i + 1] ?? 0;
+      this._frameMotion[i] = i === 0 ? null : (this._frameMotion[i + 1] ?? null);
+    }
+    this._frameSnapshot[frameCount - 1] = null;
+    this._frameSnapshotNz[frameCount - 1] = 0;
+    this._frameMotion[frameCount - 1] = null;
     this._computeNowFrameIndex();
     this._applyNowMarker();
 
@@ -1296,7 +2051,23 @@ export class RadarPlayer {
       }
       const newStatus: FrameStatus = newLayer._tileFailed > 0 ? 'failed' : 'loaded';
       this._setSegment(frameCount - 1, newStatus);
-      if (newStatus === 'loaded') this._loadedSlots.push(frameCount - 1);
+      if (newStatus === 'loaded') {
+        this._loadedSlots.push(frameCount - 1);
+        // Snapshot the freshly loaded newest frame so its transition
+        // into view picks up motion compensation from the previous
+        // frame. _onLayerLoaded would handle this too on the next
+        // 'load' fire, but doing it here makes the very first
+        // post-refresh transition compensated rather than waiting
+        // a tile-cycle. Fire-and-forget — see the equivalent
+        // call in _initRadar for the gen-guard rationale.
+        if (this._cfg.motion_compensation) {
+          const myGenInner = myGen;
+          void this._captureFrameSnapshot(frameCount - 1).then(() => {
+            if (myGenInner !== this._frameGeneration) return;
+            this._computeMotionForFrame(frameCount - 1);
+          });
+        }
+      }
       // Restart loop at newest frame so new data shows immediately
       this._currentSlot = this._loadedSlots.length - 1;
       this._startLoop();

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -241,6 +241,15 @@ export class RadarPlayer {
   private _pathsAbortCtrl: AbortController | null = null;
   private _configFrameCount = 5;
   private _doRadarUpdate = false;
+  // Wall-clock ms of the last time we fetched fresh frame paths
+  // (either via _initRadar or _updateRadar). Read by onVisibilityVisible
+  // to decide whether resuming from a hidden state needs a full
+  // re-init: the scheduled _updateRadar handles a single missed
+  // refresh via the _doRadarUpdate flag, but on resume from device
+  // sleep or a long-hidden tab we can be many refresh-cycles stale,
+  // and a single _updateRadar would only freshen the newest slot
+  // while leaving the rest of the loop holding hour-old data.
+  private _lastFrameRefreshAt = 0;
 
   // Frame loop state — _loopGen is incremented to cancel in-flight timers
   private _currentSlot = 0;
@@ -1028,6 +1037,32 @@ export class RadarPlayer {
   onVisibilityVisible(): void {
     if (!this.viewPaused) return;
     this.viewPaused = false;
+    // Stale-frame detection on resume. The scheduled _updateRadar uses
+    // _workerTimeout, which mostly keeps firing while the tab is just
+    // hidden but stops dead when the device sleeps — and even when it
+    // does fire, _doRadarUpdate is a single bit ("a refresh is owed")
+    // that doesn't distinguish "owed one update" from "owed twelve".
+    // A single _updateRadar only freshens the newest frame; older
+    // frames in the loop stay stuck at whatever timestamps they were
+    // initialised with. After a long hidden / sleep window, the entire
+    // loop is many cycles outdated and one update isn't enough.
+    //
+    // Heuristic: if more than 2× the refresh period (= 10 min) has
+    // elapsed since the last successful path-fetch, scrap the loop
+    // entirely and let _initRadar refetch every slot from scratch.
+    // Shorter gaps fall through to the existing _doRadarUpdate-driven
+    // single-frame path (or just a loop resume).
+    const FRAME_PERIOD_MS = 300_000;
+    const STALE_THRESHOLD_MS = 2 * FRAME_PERIOD_MS;
+    const ageMs = this._lastFrameRefreshAt > 0
+      ? Date.now() - this._lastFrameRefreshAt
+      : 0;
+    if (this._radarReady && ageMs > STALE_THRESHOLD_MS) {
+      this._doRadarUpdate = false;
+      this._clearLayers();
+      void this._initRadar();
+      return;
+    }
     if (this._doRadarUpdate && this._radarReady) {
       this._doRadarUpdate = false;
       this._updateRadar();
@@ -1792,6 +1827,7 @@ export class RadarPlayer {
     if (myGen !== this._frameGeneration) return;
     if (pastFrames.length === 0) return; // API returned no frames
     this._radarPaths = pastFrames;
+    this._lastFrameRefreshAt = Date.now();
     const frameCount = pastFrames.length;
     this._configFrameCount = frameCount;
     this._computeNowFrameIndex();
@@ -2019,6 +2055,7 @@ export class RadarPlayer {
     this._radarMask[frameCount - 1] = newMask;
     this._radarTime[frameCount - 1] = newTime;
     this._radarPaths[frameCount - 1] = latestFrame;
+    this._lastFrameRefreshAt = Date.now();
     this._loadedSlots = this._loadedSlots.map(fi => fi - 1).filter(fi => fi >= 0);
     // Shift motion-compensation state alongside the radar frames.
     // The old frame 0 is dropped, so old motion[1] (which described

--- a/src/source-caps.ts
+++ b/src/source-caps.ts
@@ -44,7 +44,25 @@ export const SOURCE_CAPS: Record<string, SourceCaps> = {
     defaultForecastMin: 0,
   },
   NOAA: {
-    intervalMin: 5,
+    // Empirically measured publication cadence on
+    // mapservices.weather.noaa.gov/.../eventdriven is ~5-9 min
+    // (alternating short/long, mean ~7 min) — see
+    // `.dev/noaa-cadence-probe.mjs`. NOAA's metadata endpoints
+    // (queryRasters / query / GetCapabilities) all refuse browser
+    // requests, so we can't discover the actual grid in advance.
+    //
+    // Setting `intervalMin: 10` over-quantises slightly relative to
+    // the mean, but avoids the duplicate-frame churn produced when
+    // the requested stride is finer than the publication interval —
+    // NOAA's WMS server snaps any TIME within a publication window
+    // to the same physical frame, so finer requests just return
+    // byte-identical content for multiple slots.
+    //
+    // Tracking a server-side improvement upstream at
+    // https://github.com/weather-gov/api/ — a metadata endpoint that
+    // exposes actual publication times would let us snap exactly to
+    // the grid and drop this conservative quantisation.
+    intervalMin: 10,
     // mapservices.weather.noaa.gov advertises 4h of history but in
     // practice frames > 2h back fail intermittently — observed empty
     // tiles past that point. Cap at 2h until we understand why.

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,27 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
    * choice is not saved.
    */
   playback_speed?: number;
+  /**
+   * Slide each radar layer in the estimated direction of rain motion
+   * during the crossfade transition, so the rain appears to drift
+   * smoothly between frames instead of appearing in its new position
+   * while the old position fades out underneath.
+   *
+   * The motion vector is recovered by running pyramidal Lucas-Kanade
+   * optical flow on consecutive frame snapshots — no external wind
+   * data, no source dependency. Works for all three radar sources
+   * (DWD, RainViewer, NOAA). Runs in a Web Worker when available so
+   * slow devices don't see UI jank; falls back to synchronous main-
+   * thread execution if Worker construction fails (e.g. corporate CSP).
+   *
+   * Pairs naturally with `smooth_overlap: 0` (sequential timing) so
+   * the composite stays at full opacity through the slide — overlap > 0
+   * still works but lets the alpha dip be slightly visible mid-slide.
+   *
+   * Default off. Frames without enough texture (light rain, clear sky)
+   * fall back to the static crossfade automatically.
+   */
+  motion_compensation?: boolean;
   center_longitude?: CoordinateConfig;
   center_latitude?: CoordinateConfig;
   zoom_level?: number;

--- a/tests/lk.test.ts
+++ b/tests/lk.test.ts
@@ -1,0 +1,329 @@
+// Tests for pyramidal Lucas-Kanade optical flow.
+//
+// Two test surfaces:
+//
+//   1. Algorithm correctness (lk.ts): five synthetic scenarios ported
+//      from the prototype harness (.dev/lk-prototype/). These pin LK's
+//      behaviour on inputs with known ground truth — coherent uniform
+//      motion, differential per-cell motion, stationary scene, large
+//      motion exceeding the per-level convergence radius, and a
+//      noise-free flat field.
+//
+//   2. Drift between the TypeScript implementation (lk.ts) and the
+//      hand-translated JS source embedded in lk-worker.ts. The worker
+//      runs in a different language form because it has to be a string
+//      Blob — but the algorithm must produce identical output for
+//      identical inputs. This test extracts the embedded source,
+//      evaluates it in the test process via `new Function`, and
+//      compares against the TS version on the same fixtures. If
+//      anyone modifies one implementation without the other, this
+//      test fails before review.
+
+import { describe, it, expect } from 'vitest';
+import {
+  lucasKanadePyramidal,
+  buildPyramid,
+  sobel,
+  extractChannel,
+} from '../src/lk';
+import { LK_ALGORITHM_SOURCE } from '../src/lk-worker';
+
+// ── Synthetic fixture builders ───────────────────────────────────────────
+
+const SIZE = 128;
+
+/**
+ * Render a 2D Gaussian "blob" into a Float32 buffer. Used to build
+ * synthetic radar frames with known feature positions — translating
+ * the blob between two frames gives an exact ground-truth motion.
+ */
+function addBlob(buf: Float32Array, w: number, h: number, cx: number, cy: number, sigma: number, amp: number): void {
+  const twoSigmaSq = 2 * sigma * sigma;
+  // Cap the additive contribution at 255 so two blobs near each other
+  // don't push out-of-range; downstream LK treats values as 0..255.
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const v = amp * Math.exp(-(dx * dx + dy * dy) / twoSigmaSq);
+      const i = y * w + x;
+      buf[i] = Math.min(255, buf[i] + v);
+    }
+  }
+}
+
+/** Coherent uniform translation: two blobs all moving by the same vector. */
+function makeCoherent(dx: number, dy: number): { I0: Float32Array; I1: Float32Array } {
+  const I0 = new Float32Array(SIZE * SIZE);
+  const I1 = new Float32Array(SIZE * SIZE);
+  // Two blobs at fixed positions in I0, shifted by (dx, dy) in I1.
+  addBlob(I0, SIZE, SIZE, 40, 50, 8, 200);
+  addBlob(I0, SIZE, SIZE, 80, 70, 10, 220);
+  addBlob(I1, SIZE, SIZE, 40 + dx, 50 + dy, 8, 200);
+  addBlob(I1, SIZE, SIZE, 80 + dx, 70 + dy, 10, 220);
+  return { I0, I1 };
+}
+
+/** Differential motion: each blob moves in a different direction. */
+function makeDifferential(): { I0: Float32Array; I1: Float32Array; bulkDx: number; bulkDy: number } {
+  const I0 = new Float32Array(SIZE * SIZE);
+  const I1 = new Float32Array(SIZE * SIZE);
+  // Two cells, one moving right-down, one moving up-right; bulk vector
+  // is the weighted average of the per-cell motions.
+  addBlob(I0, SIZE, SIZE, 30, 30, 8, 200);
+  addBlob(I0, SIZE, SIZE, 90, 90, 8, 200);
+  addBlob(I1, SIZE, SIZE, 38, 35, 8, 200);   // cell A: (+8, +5)
+  addBlob(I1, SIZE, SIZE, 92, 84, 8, 200);   // cell B: (+2, -6)
+  // Bulk is mean of per-cell vectors (equal weight blobs).
+  return { I0, I1, bulkDx: 5, bulkDy: -0.5 };
+}
+
+/** Stationary scene: identical frames. LK must NOT hallucinate motion. */
+function makeStationary(): { I0: Float32Array; I1: Float32Array } {
+  const I0 = new Float32Array(SIZE * SIZE);
+  addBlob(I0, SIZE, SIZE, 40, 50, 8, 200);
+  addBlob(I0, SIZE, SIZE, 80, 70, 10, 220);
+  return { I0, I1: new Float32Array(I0) };
+}
+
+/** Flat field: zero gradient everywhere. LK must return low confidence. */
+function makeFlat(): { I0: Float32Array; I1: Float32Array } {
+  return { I0: new Float32Array(SIZE * SIZE), I1: new Float32Array(SIZE * SIZE) };
+}
+
+// ── 1. Algorithm correctness (TypeScript implementation) ─────────────────
+
+describe('lucasKanadePyramidal — synthetic correctness', () => {
+  it('recovers a coherent (+5, -3) motion to within 1 px', () => {
+    const { I0, I1 } = makeCoherent(5, -3);
+    const result = lucasKanadePyramidal(I0, I1, SIZE, SIZE);
+    expect(result.dx).toBeCloseTo(5, 0);
+    expect(result.dy).toBeCloseTo(-3, 0);
+    // 5,-3 against two well-separated blobs is a strong gradient signal.
+    expect(result.confidence).toBeGreaterThan(5);
+  });
+
+  it('recovers a coherent (+10, +10) motion', () => {
+    const { I0, I1 } = makeCoherent(10, 10);
+    const result = lucasKanadePyramidal(I0, I1, SIZE, SIZE);
+    expect(result.dx).toBeCloseTo(10, 0);
+    expect(result.dy).toBeCloseTo(10, 0);
+  });
+
+  it('approximates differential motion to within ~2 px of the bulk vector', () => {
+    const { I0, I1, bulkDx, bulkDy } = makeDifferential();
+    const result = lucasKanadePyramidal(I0, I1, SIZE, SIZE);
+    // Single global vector can't perfectly model two cells moving
+    // independently, but should land near the bulk mean. Tolerance
+    // here is intentionally loose — the prototype run on similar
+    // fixtures saw ~0.5 px residual, but we allow 2 px to absorb
+    // sampling jitter and the asymmetry of unequal blob amplitudes.
+    expect(Math.abs(result.dx - bulkDx)).toBeLessThan(2);
+    expect(Math.abs(result.dy - bulkDy)).toBeLessThan(2);
+  });
+
+  it('does not hallucinate motion on a stationary scene', () => {
+    const { I0, I1 } = makeStationary();
+    const result = lucasKanadePyramidal(I0, I1, SIZE, SIZE);
+    expect(Math.abs(result.dx)).toBeLessThan(0.1);
+    expect(Math.abs(result.dy)).toBeLessThan(0.1);
+  });
+
+  it('returns low confidence on a flat-field input', () => {
+    const { I0, I1 } = makeFlat();
+    const result = lucasKanadePyramidal(I0, I1, SIZE, SIZE);
+    // det of the gradient tensor is exactly zero on a flat input;
+    // lkSingleLevel short-circuits and returns confidence 0 plus
+    // unchanged (0, 0). Just confirm we don't crash and confidence
+    // signals "don't trust this".
+    expect(result.confidence).toBeLessThan(5);
+    expect(result.dx).toBe(0);
+    expect(result.dy).toBe(0);
+  });
+
+  it('recovers large (+30, -20) motion via the pyramid', () => {
+    // 30 px is well beyond the single-level convergence radius
+    // (~5 px). The pyramid resolves it because at the coarsest level
+    // (after two halvings) the same motion looks like 7.5 px on a
+    // 32×32 grid — within range. Without the pyramid, single-level
+    // LK would fail. This test exists to lock in the pyramid's
+    // contribution.
+    const { I0, I1 } = makeCoherent(30, -20);
+    const result = lucasKanadePyramidal(I0, I1, SIZE, SIZE, { levels: 3, iterations: 5 });
+    // Allow a bit more slack for large motion (sub-pixel sampling
+    // through the warp chain accumulates small errors).
+    expect(result.dx).toBeCloseTo(30, -0.5);
+    expect(result.dy).toBeCloseTo(-20, -0.5);
+  });
+});
+
+// ── 2. Primitives ────────────────────────────────────────────────────────
+
+describe('buildPyramid', () => {
+  it('halves dimensions per level and 2×2-averages pixels', () => {
+    // 16×16 → 8×8 → 4×4 is three levels of halving that all clear
+    // the "stop below 4" guard in buildPyramid. The next halving
+    // would land at 2×2 which is refused — see the dedicated guard
+    // test below.
+    const w = 16; const h = 16;
+    const img = new Float32Array(w * h).fill(100);
+    const pyramid = buildPyramid(img, w, h, 3);
+    expect(pyramid).toHaveLength(3);
+    expect(pyramid[0].width).toBe(16);
+    expect(pyramid[1].width).toBe(8);
+    expect(pyramid[2].width).toBe(4);
+    // Average of a uniform-100 image is 100 at every level.
+    expect(pyramid[2].data[0]).toBe(100);
+  });
+
+  it('stops adding levels once a halved dimension falls below 4', () => {
+    const w = 8; const h = 8;
+    const img = new Float32Array(w * h).fill(50);
+    // Asking for 5 levels — should stop at 3 (8 → 4 → 2 would be < 4).
+    const pyramid = buildPyramid(img, w, h, 5);
+    expect(pyramid.length).toBeLessThanOrEqual(3);
+    for (const level of pyramid) {
+      expect(level.width).toBeGreaterThanOrEqual(2);
+    }
+  });
+});
+
+describe('sobel', () => {
+  it('returns zero gradients on a flat image', () => {
+    const w = 16; const h = 16;
+    const img = new Float32Array(w * h).fill(50);
+    const { Ix, Iy } = sobel(img, w, h);
+    // Interior pixels should all be zero; borders are zero by construction.
+    for (let i = 0; i < Ix.length; i++) {
+      expect(Ix[i]).toBe(0);
+      expect(Iy[i]).toBe(0);
+    }
+  });
+
+  it('produces non-zero gradient at a vertical edge', () => {
+    const w = 16; const h = 16;
+    const img = new Float32Array(w * h);
+    // Left half = 0, right half = 200 — vertical edge in the middle.
+    for (let y = 0; y < h; y++) {
+      for (let x = w / 2; x < w; x++) img[y * w + x] = 200;
+    }
+    const { Ix, Iy } = sobel(img, w, h);
+    // Interior pixel on the edge should have a large positive Ix and ~zero Iy.
+    const mid = 8 * w + 8;
+    expect(Ix[mid]).toBeGreaterThan(10);
+    expect(Math.abs(Iy[mid])).toBeLessThan(1);
+  });
+});
+
+describe('extractChannel', () => {
+  function fakeImageData(rgba: number[]): { data: Uint8ClampedArray; width: number; height: number } {
+    const data = new Uint8ClampedArray(rgba);
+    return { data, width: rgba.length / 4, height: 1 };
+  }
+
+  it('alpha mode returns the alpha channel', () => {
+    const img = fakeImageData([255, 0, 0, 100, 0, 255, 0, 200]);
+    const out = extractChannel(img, 'alpha');
+    expect(Array.from(out)).toEqual([100, 200]);
+  });
+
+  it('distance-from-white returns 0 for transparent pixels', () => {
+    const img = fakeImageData([100, 100, 100, 0]);
+    const out = extractChannel(img, 'distance-from-white');
+    expect(out[0]).toBe(0);
+  });
+
+  it('distance-from-white is 255 for pure black, gated by alpha', () => {
+    // Fully opaque black: 255 - min(0,0,0) = 255, weighted by alpha/255 = 1.
+    const img = fakeImageData([0, 0, 0, 255]);
+    const out = extractChannel(img, 'distance-from-white');
+    expect(out[0]).toBe(255);
+  });
+
+  it('distance-from-white is 0 for pure white at any alpha', () => {
+    const img = fakeImageData([255, 255, 255, 255]);
+    const out = extractChannel(img, 'distance-from-white');
+    expect(out[0]).toBe(0);
+  });
+
+  it('distance-from-white is linear: 255 - min(R,G,B), weighted by alpha', () => {
+    // Light-blue outline pixel (typical RainViewer low-intensity).
+    // 255 - min(150,200,255) = 105.
+    const lightBlue = fakeImageData([150, 200, 255, 255]);
+    expect(extractChannel(lightBlue, 'distance-from-white')[0]).toBe(105);
+    // Saturated red pixel (typical RainViewer high-intensity core).
+    // 255 - min(255,50,50) = 205.
+    const red = fakeImageData([255, 50, 50, 255]);
+    expect(extractChannel(red, 'distance-from-white')[0]).toBe(205);
+    // Alpha-weighted: half-opaque red is half-intensity.
+    // 205 * 128 / 255 = 26240/255 ≈ 102.9
+    const halfRed = fakeImageData([255, 50, 50, 128]);
+    expect(extractChannel(halfRed, 'distance-from-white')[0]).toBeCloseTo(103, 0);
+  });
+});
+
+// ── 3. Worker source ↔ TypeScript implementation parity ──────────────────
+//
+// Eval the embedded worker source in the test process via `new Function`
+// (we are NOT in a CSP environment here, and the worker source is
+// trusted module code from the same repo). Then run identical inputs
+// through both versions and assert byte-for-byte equality of the
+// numeric results. This is the safety net against the duplication
+// between src/lk.ts and the LK_ALGORITHM_SOURCE constant in
+// src/lk-worker.ts.
+
+describe('lk-worker source ↔ lk.ts parity', () => {
+  // Build a callable lucasKanadePyramidal from the embedded source.
+  // The Function captures the algorithm definitions in its scope and
+  // exposes lucasKanadePyramidal via the returned closure — same
+  // pattern that the actual worker uses when its onmessage handler
+  // calls lucasKanadePyramidal().
+  const workerLk = new Function(
+    'I0', 'I1', 'width', 'height', 'opts',
+    `${LK_ALGORITHM_SOURCE}\nreturn lucasKanadePyramidal(I0, I1, width, height, opts);`,
+  ) as (I0: Float32Array, I1: Float32Array, w: number, h: number, opts?: object) => { dx: number; dy: number; confidence: number };
+
+  function expectParity(I0: Float32Array, I1: Float32Array, w: number, h: number, opts: object = {}): void {
+    const tsResult = lucasKanadePyramidal(I0, I1, w, h, opts);
+    const wkResult = workerLk(I0, I1, w, h, opts);
+    // The two implementations are algorithmically identical, so
+    // results should match to the bit — Float32 floor differences
+    // would only appear if one path used Float64 arithmetic
+    // somewhere. We assert a tiny epsilon to absorb any future
+    // platform-specific FMA rounding without masking real drift.
+    expect(wkResult.dx).toBeCloseTo(tsResult.dx, 6);
+    expect(wkResult.dy).toBeCloseTo(tsResult.dy, 6);
+    expect(wkResult.confidence).toBeCloseTo(tsResult.confidence, 6);
+  }
+
+  it('coherent motion produces identical dx, dy, confidence', () => {
+    const { I0, I1 } = makeCoherent(5, -3);
+    expectParity(I0, I1, SIZE, SIZE);
+  });
+
+  it('differential motion produces identical output', () => {
+    const { I0, I1 } = makeDifferential();
+    expectParity(I0, I1, SIZE, SIZE);
+  });
+
+  it('stationary scene produces identical output', () => {
+    const { I0, I1 } = makeStationary();
+    expectParity(I0, I1, SIZE, SIZE);
+  });
+
+  it('flat-field produces identical output (both should hit the det<eps short-circuit)', () => {
+    const { I0, I1 } = makeFlat();
+    expectParity(I0, I1, SIZE, SIZE);
+  });
+
+  it('large motion produces identical output across pyramid levels', () => {
+    const { I0, I1 } = makeCoherent(30, -20);
+    expectParity(I0, I1, SIZE, SIZE, { levels: 3, iterations: 5 });
+  });
+
+  it('non-default options propagate identically', () => {
+    const { I0, I1 } = makeCoherent(5, -3);
+    expectParity(I0, I1, SIZE, SIZE, { levels: 4, iterations: 10 });
+    expectParity(I0, I1, SIZE, SIZE, { levels: 1, iterations: 5 });
+  });
+});

--- a/tests/migrate-config.test.ts
+++ b/tests/migrate-config.test.ts
@@ -154,11 +154,16 @@ describe('migrateConfig', () => {
       expect(r.past_minutes).toBe(40);
     });
 
-    it('converts legacy frame_count to past_minutes using the source interval (NOAA, 5-min)', () => {
+    it('converts legacy frame_count to past_minutes using the source interval (NOAA, 10-min)', () => {
       const cfg = { ...base, data_source: 'NOAA', frame_count: 12 };
       const r = migrateConfig(cfg);
-      // (12 - 1) × 5 min = 55 min
-      expect(r.past_minutes).toBe(55);
+      // (12 - 1) × 10 min = 110 min. NOAA interval was bumped from 5
+      // to 10 min — see SOURCE_CAPS.NOAA doc-block on the empirical
+      // publication cadence — so legacy frame_count: 12 now migrates
+      // to a longer time span. The user keeps 12 distinct frames in
+      // their loop; with the old 5-min stride those 12 would have
+      // been 6-8 unique + 4-6 duplicates from server-side snapping.
+      expect(r.past_minutes).toBe(110);
     });
 
     it('converts legacy frame_count using RainViewer interval when data_source is undefined', () => {

--- a/tests/source-caps.test.ts
+++ b/tests/source-caps.test.ts
@@ -25,7 +25,11 @@ describe('getSourceCaps', () => {
 
   it('exposes the right per-source intervals', () => {
     expect(SOURCE_CAPS.RainViewer.intervalMin).toBe(10);
-    expect(SOURCE_CAPS.NOAA.intervalMin).toBe(5);
+    // NOAA's empirical publication cadence is 5-9 min (mean ~7);
+    // we quantise to 10 min to avoid the duplicate-frame churn
+    // produced when our stride is finer than NOAA's actual grid.
+    // See SOURCE_CAPS.NOAA doc-block.
+    expect(SOURCE_CAPS.NOAA.intervalMin).toBe(10);
     expect(SOURCE_CAPS.DWD.intervalMin).toBe(5);
   });
 


### PR DESCRIPTION
## Summary

Source-agnostic motion compensation for radar transitions — rain visibly drifts between frames instead of teleporting to its new position while the old fades out.

- Opt-in via `motion_compensation: true` in the card config; toggle exposed in the editor's Animation section.
- Algorithm: pyramidal Lucas-Kanade optical flow on a distance-from-white intensity channel. Works for all three radar sources (DWD, RainViewer, NOAA) instead of being effectively DWD-only.
- Runs in a Web Worker by default (no main-thread block); falls back to synchronous main-thread execution under strict CSPs.

**Built on top of [@genericJE](https://github.com/genericJE)'s [#156](https://github.com/jpettitt/weather-radar-card/pull/156)** — kept the entire snapshot-capture infrastructure and the dual-translate animation in `_showSlot`. The swap is the algorithm (SAD block-matcher → Lucas-Kanade) and the channel extraction (alpha → distance-from-white), which together make motion compensation source-agnostic. Closing #156 as superseded by this PR with thanks for the foundation it provided.

## Related work in this PR

- **NOAA cadence bump** (`intervalMin: 5 → 10`) — empirical publication cycle is ~5-9 min (mean ~7) with the server snapping any TIME query within a publication window to the same physical frame. Quantising to 10 min eliminates duplicate frames at the source; the post-init dedup catches residuals. Legacy `frame_count` configs auto-migrate (count preserved, time span doubles).
- **Stale-frame fix on resume** — after device sleep / hours-tabbed-away, the displayed loop was holding old timestamps. Now does a full re-init when frames are >10 min stale on visibility-visible.
- **Editor toggle + i18n** — motion_compensation switch in the Animation section, English strings + English fallbacks for the 10 other languages (translations welcome).

Full architecture in [`docs/motion-compensation-feature-design.md`](docs/motion-compensation-feature-design.md).

## Test plan

- [x] `npm run lint` clean, `npm test` 535 pass (518 baseline + 17 new for LK algorithm correctness, worker↔TS source parity, primitive coverage), `npm run build` produces bundle.
- [x] Soak-tested on production HA: motion comp visibly drifts rain on RainViewer / NOAA / DWD; dedup catches NOAA duplicates with no visible artifact; stale-frame fix triggers full re-init on >10-min hidden+resume.

## Risk

- Default off. Existing users unchanged unless they explicitly opt in.
- NOAA cadence change affects all NOAA users — half as many frames per `past_minutes` window but every frame is unique. Documented in CHANGELOG.
- Inline Blob URL worker matches the existing setTimeout-shim worker pattern in `radar-player.ts`; no rollup config changes.
- Algorithm duplicated between `src/lk.ts` (TS) and `LK_ALGORITHM_SOURCE` in `src/lk-worker.ts` (JS string). Parity test in `tests/lk.test.ts` catches drift.

## Docs touched

- [x] `README.md`, `CHANGELOG.md`, `docs/configuration.md`
- [x] `docs/motion-compensation-feature-design.md` (new)
- [x] `src/types.ts` doc-block on `motion_compensation`

Closes #156 (with thanks to [@genericJE](https://github.com/genericJE)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)