### PR TITLE
chore(release): 3.7.0-alpha3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.0-alpha3] - 2026-06-10
+
+> **Alpha pre-release.** Stability wave for the 3.7 line: fixes for every finding from the 2026-06-09 full-project code review plus four issues live-debugged during the alpha2 soak (DWD mask architecture, coverage clipping, rate-limit recovery, lightning-backlog UI freeze). No new features, no config surface changes. **Not recommended for production dashboards** — install to exercise the fixes and report findings.
 
 ### Fixed
 
@@ -777,7 +779,9 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.5...HEAD
+[3.7.0-alpha3]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha2...v3.7.0-alpha3
+[3.7.0-alpha2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha1...v3.7.0-alpha2
+[3.7.0-alpha1]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.5...v3.7.0-alpha1
 [3.6.5]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.4...v3.6.5
 [3.6.4]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.3...v3.6.4
 [3.6.3]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.2...v3.6.3

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -312,3 +312,26 @@ preserving pinch-to-zoom, so mobile users can scroll past the card.
 - NOAA `intervalMin` bump 5 → 10 — matches empirical publication cadence on the eventdriven WMS service, eliminates duplicate frames at the source ✅ — 3.7.0-alpha2
 - Stale-frame full re-init on resume from long-hidden / device-sleep windows ✅ — 3.7.0-alpha2
 - Local Docker HA testbed (`npm run ha:up`) replacing the abandoned `.devcontainer/` ✅ — post-3.4.0
+
+## Canvas rendering for lightning + hazard layers
+
+Motivation (observed live on alpha2, 2026-06-09): with `lightning_max_age_minutes: 20`
+during an active storm, every strike is two DOM markers with inline SVG —
+hundreds of nodes that make pan/zoom and editor-open heavy. The time-sliced
+backlog drain (3.7.0-alpha3) fixed the open-freeze; canvas rendering is the
+structural fix for steady-state DOM weight.
+
+Design sketch (clickability confirmed feasible for both):
+
+- **Hazard polygons (NWS alerts, wildfire perimeters)**: near-free — pass a
+  shared `L.canvas()` renderer to the existing `L.polygon`/`L.geoJSON` layers.
+  Leaflet's canvas renderer keeps its own hit-testing, so popups and click
+  handlers keep working unchanged. Mostly a constructor-options change plus
+  regression-testing popup behaviour.
+- **Lightning strikes**: custom `L.Layer` painting strikes into one canvas
+  per map (redraw on move/zoom/age-tick; age-based fade becomes a cheap
+  global-alpha pass instead of per-marker style writes). Markers lose DOM
+  hit-testing, so add a DIY hit test: map `click` → nearest strike within
+  ~10 px tolerance → open the existing popup content at that latlng.
+  ~200–250 lines incl. tests; the strike data model and `_collectStrikes`
+  pipeline stay as-is.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.7.0-alpha2",
+  "version": "3.7.0-alpha3",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.7.0-alpha2';
+export const CARD_VERSION = '3.7.0-alpha3';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
Release prep for **v3.7.0-alpha3** — the stability wave: all 2026-06-09 code-review findings plus the four live-debugged soak issues (#187, #186, and the earlier tier-1 commits).

- `src/const.ts` `CARD_VERSION` + `package.json` → `3.7.0-alpha3`
- CHANGELOG: `Unreleased` → `## [3.7.0-alpha3] - 2026-06-10` with alpha blurb; compare-link definitions added for the 3.7 alpha line
- `docs/todo.md`: backlog entry for the canvas-rendering follow-up (lightning canvas layer + `L.canvas()` hazard polygons) with the design sketch

No code changes. After merge: `gh release create v3.7.0-alpha3 --prerelease` (release.yml attaches dist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)