### PR TITLE
feat(overlays): canvas rendering for lightning + hazard layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Lightning strikes render on a single canvas instead of per-strike DOM markers.** Each strike previously mounted two DOM markers with inline SVG (fill + outline panes); during an active storm with a long `lightning_max_age_minutes` that's hundreds-to-thousands of nodes, which made pan/zoom heavy even after the 3.7.0-alpha3 time-sliced backlog drain. One canvas now holds every strike: two-pass painting preserves the stacked-outline look (outlines under fills, newest on top), the fresh-bolt pulse is drawn as a short rAF animation (still honours `prefers-reduced-motion`), and popups still work via a click hit-test — **the most recent strike within 10 px wins** (recency beats distance when strikes overlap; the fresh strike is the one you're reacting to). Hover still shows a pointer cursor over strikes. Settled strikes (past the 30 s bolt window) live in an offscreen buffer, so the steady-state repaint is one blit plus the newest strikes — a new strike arriving costs O(1), not a full-set repaint (the first cut repainted everything ~36× per arriving strike's pulse animation, which saturated the main thread under storm load). Soak-validated at 10,000 simultaneous strikes (Blitzortung's max) with the page fully responsive. No config changes.
+- **NWS alert polygons and wildfire perimeters render through Leaflet's canvas renderer — one shared renderer per map.** Alert outbreaks carry hundreds of multi-ring zone shapes and WFIGS perimeters carry thousands of vertices each; per-ring SVG nodes were the heavy part of pan/zoom with overlays on. Leaflet's canvas renderer keeps its own hit-testing, so popups and click behaviour are unchanged; fire icons remain DOM markers (bounded count). The shared-renderer constraint is load-bearing: a canvas renderer receives clicks as DOM events on its own canvas element, and with two renderers stacked the topmost silently swallows the other's clicks (observed live as alert polygons going permanently unclickable the moment the first fire perimeter crossed the icon→polygon zoom threshold and lazily spawned a second renderer on top).
+
 ## [3.7.0-alpha3] - 2026-06-10
 
 > **Alpha pre-release.** Stability wave for the 3.7 line: fixes for every finding from the 2026-06-09 full-project code review plus four issues live-debugged during the alpha2 soak (DWD mask architecture, coverage clipping, rate-limit recovery, lightning-backlog UI freeze). No new features, no config surface changes. **Not recommended for production dashboards** — install to exercise the fixes and report findings.
@@ -779,6 +786,7 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
+[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha3...HEAD
 [3.7.0-alpha3]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha2...v3.7.0-alpha3
 [3.7.0-alpha2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha1...v3.7.0-alpha2
 [3.7.0-alpha1]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.5...v3.7.0-alpha1

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -331,7 +331,9 @@ Design sketch (clickability confirmed feasible for both):
 - **Lightning strikes**: custom `L.Layer` painting strikes into one canvas
   per map (redraw on move/zoom/age-tick; age-based fade becomes a cheap
   global-alpha pass instead of per-marker style writes). Markers lose DOM
-  hit-testing, so add a DIY hit test: map `click` → nearest strike within
-  ~10 px tolerance → open the existing popup content at that latlng.
+  hit-testing, so add a DIY hit test: map `click` → **most recent** strike
+  within 10 px tolerance (recency wins over distance when several strikes
+  overlap — the fresh strike is the one the user is reacting to) → open the
+  existing popup content at that latlng.
   ~200–250 lines incl. tests; the strike data model and `_collectStrikes`
   pipeline stay as-is.

--- a/src/lightning-layer.ts
+++ b/src/lightning-layer.ts
@@ -16,18 +16,37 @@ import {
 } from './lightning-helpers';
 
 // Lightning overlay — renders Blitzortung integration's per-strike
-// geo_location entities as small bolt-shaped markers, fill-coloured by
-// age. See docs/lightning-feature-design.md for the full design.
+// geo_location entities onto a single canvas, fill-coloured by age.
+// See docs/lightning-feature-design.md for the full design.
+//
+// CANVAS, not DOM markers. The original implementation built two DOM
+// markers with inline SVG per strike (fill + outline on separate panes);
+// during an active storm with a long max-age that's hundreds-to-thousands
+// of nodes, which made pan/zoom heavy and froze editor-open for seconds
+// (two simultaneous full builds: re-attached card + preview). One canvas
+// repainted per change is O(strikes) draw calls but O(1) DOM — the
+// structural fix for the per-datapoint DOM ceiling (see docs/todo.md).
+//
+// What canvas gives up vs. DOM markers, and how each is recovered:
+//  - Leaflet marker hit-testing → DIY hit test on map click: the MOST
+//    RECENT strike within HIT_TOLERANCE_PX wins (user decision: when
+//    strikes overlap, the fresh one is the one being reacted to —
+//    recency beats distance).
+//  - The two-pane stacked-outline trick → two-pass painting: all black
+//    + outlines first, then all colour fills, newest last. Same visual
+//    result (stacked outlines merge harmlessly underneath, topmost
+//    colour stays clean) without any pane juggling.
+//  - The CSS one-shot pulse on fresh bolts → a short rAF-driven scale
+//    animation drawn into the same canvas.
 //
 // No external HTTP from this file. The Blitzortung integration owns the
 // data plumbing (WebSocket polling, distance/age filter); we just diff
-// hass.states for new/gone strikes and paint markers on the map.
+// hass.states for new/gone strikes and repaint.
 
 const DEFAULT_ICON_SIZE_PX = 14;
 // Bolts render at 1.3× the + size — the "happening now" indicator
 // reads better when it's visibly larger than the steady-state markers
-// it sits among. Applied at icon creation; if the user sets
-// lightning_icon_size, the bolt stays proportionally larger.
+// it sits among.
 const BOLT_SIZE_RATIO = 1.3;
 // Default card-side max-age cap. The Blitzortung integration commonly
 // keeps strikes for 120 min; rendering them all turns busy storms into
@@ -35,43 +54,34 @@ const BOLT_SIZE_RATIO = 1.3;
 // cell. Configurable via cfg.lightning_max_age_minutes.
 const DEFAULT_MAX_AGE_MIN = 30;
 // 30 s recompute of the age-derived fill — the design doc's chosen
-// cadence. Smoothing the age across 30 s on a multi-thousand-second
-// gradient is visually indistinguishable from continuous fade and
-// avoids per-marker timers.
+// cadence. Each repaint derives colour from current age, so the timer
+// only needs to trigger expiry + a repaint.
 const AGE_REFRESH_MS = 30 * 1000;
+// Click / hover hit-test tolerance. ~10 px ≈ a comfortable touch slop
+// around a 14 px glyph.
+const HIT_TOLERANCE_PX = 10;
+// Matches the old CSS keyframe duration (scale 2 → 1 over 600 ms).
+const PULSE_MS = 600;
+// Canvas margin beyond the viewport on each side, as a fraction of the
+// viewport dimension. Strikes inside the margin are already painted
+// when a pan reveals them; the moveend repaint re-centres the margin.
+const CANVAS_PAD_FRACTION = 0.5;
 
-// Two custom Leaflet panes. Both sit between the default overlayPane
-// (400, where radar tiles + wildfire / alert polygons live) and the
-// default markerPane (600, where home / person / device-tracker
-// markers live). This ordering matches the design doc: lightning is
-// visible over a NWS alert polygon, and the home marker stays on top
-// of any strike at the same point.
-//
-// The OUTLINE pane (z 499) carries the black-stroked path of each +
-// sign on its own. The FILL pane (z 500) carries the coloured-fill
-// path. Splitting them solves the "black blob" problem at low zoom
-// when many strikes pile up at the same screen location: the outlines
-// stack and merge harmlessly underneath, while the topmost coloured
-// fill stays cleanly visible on top instead of being lost under
-// stacked strokes.
-//
-// Bolt-phase markers go on the FILL pane only — they're a single
-// glyph and don't suffer the same stacking issue (bolt phase is
-// short, and the bolts are bigger than the +s).
+// Custom Leaflet pane between the default overlayPane (400, radar tiles
+// + hazard polygons) and the default markerPane (600, home / person /
+// device-tracker markers): lightning is visible over an alert polygon,
+// and the home marker stays on top of any strike at the same point.
 const LIGHTNING_PANE = 'wrc-lightning';
 const LIGHTNING_PANE_Z = 500;
-const LIGHTNING_OUTLINE_PANE = 'wrc-lightning-outline';
-const LIGHTNING_OUTLINE_PANE_Z = 499;
 
 interface Strike {
-  ts: number;        // epoch ms when the strike was first observed
+  ts: number;        // epoch ms when the strike occurred / was first seen
   lat: number;
   lon: number;
-  // Two-phase visual: bolt (with pulse) for the first BOLT_DURATION_SEC,
-  // then plus-sign for the rest of the lifetime. Tracked here so a
-  // strike that crosses the threshold between age refreshes only swaps
-  // its icon DOM once (setIcon rebuilds the marker element).
-  isBolt: boolean;
+  // Epoch ms until which the fresh-bolt pulse animation runs. 0 = no
+  // pulse (strike discovered already past its bolt window, pulses
+  // disabled, or prefers-reduced-motion).
+  pulseUntil: number;
 }
 
 export class LightningLayer {
@@ -79,31 +89,61 @@ export class LightningLayer {
   private _getConfig: () => WeatherRadarCardConfig;
   private _hass: HomeAssistant | undefined;
 
-  // Three parallel maps keyed by entity_id (geo_location.lightning_strike_*).
-  // Splitting strike data from the Leaflet markers keeps _refreshAges()
-  // small — it iterates _strikes and recolours the matching marker, no
-  // need to dig coords or timestamps back out of the marker DOM.
-  //
-  // _markers is the FILL marker — bolt during the first 30 s, then a
-  // coloured + sign on the LIGHTNING_PANE. Popups bind here.
-  // _outlines is the OUTLINE marker — only present in the + phase, on
-  // the LIGHTNING_OUTLINE_PANE one z-step lower. Non-interactive.
-  // Splitting + signs into two markers on different panes is what
-  // prevents stacked outlines obscuring stacked colours at low zoom:
-  // outlines pile up harmlessly underneath, fills stay clean on top.
-  // Strike markers awaiting materialisation (see _refreshFromHass) and
-  // the single-flight flag for the rAF drain loop.
-  private _pendingAdds: Array<[string, Strike]> = [];
-  private _drainScheduled = false;
-
   private _strikes: Map<string, Strike> = new Map();
-  private _markers: Map<string, L.Marker> = new Map();
-  private _outlines: Map<string, L.Marker> = new Map();
+
+  private _canvas: HTMLCanvasElement | null = null;
+  // Container-pixel padding the canvas extends beyond the viewport on
+  // each side. Recomputed from the map size on every reposition.
+  private _padX = 0;
+  private _padY = 0;
+  // The layer point the canvas's top-left is pinned to (what
+  // DomUtil.setPosition was last given). All painting is done relative
+  // to THIS, in layer coordinates — never container coordinates. Layer
+  // points are drag-stable: during a pan Leaflet translates the pane
+  // (carrying the canvas), so a repaint mid-drag (hass tick adding a
+  // strike, pulse animation frame) must NOT also include the drag
+  // delta. Painting at container coordinates did exactly that — the
+  // delta applied twice and strikes moved at 2× drag speed until
+  // moveend repositioned the canvas.
+  private _originLayerPoint = { x: 0, y: 0 };
+  // Single-flight flag for the rAF repaint. Multiple invalidations per
+  // frame (hass tick + moveend + age timer) collapse into one paint.
+  private _redrawQueued = false;
+
+  // Offscreen buffer holding every SETTLED strike (older than the bolt
+  // window at build time), so the common repaint is one drawImage blit
+  // plus a handful of live bolts instead of O(strikes) glyph draws.
+  // This is load-bearing at storm scale: every arriving strike runs a
+  // 600 ms pulse animation = ~36 full repaints, and with thousands of
+  // strikes on the map the un-buffered version repainted the whole set
+  // continuously — observed live as a saturated, unresponsive main
+  // thread under a 5000-strike stress config.
+  //
+  // Partition rule is pure timestamp arithmetic, no bookkeeping set:
+  // the buffer contains strikes with ts <= _bufferMaxTs (computed as
+  // build-time-now − BOLT_DURATION, so everything buffered is already
+  // in its + phase); everything newer is drawn live on top each frame.
+  // A strike that crosses the bolt→plus boundary simply keeps drawing
+  // live (as a +) until the next rebuild folds it in — no visual gap.
+  private _buffer: HTMLCanvasElement | null = null;
+  private _bufferDirty = true;
+  private _bufferMaxTs = 0;
 
   private _ageTimer: ReturnType<typeof setInterval> | null = null;
   // Set in pause(), cleared in resume(). Differs from the wildfire/alerts
   // pattern: there's no fetch to reschedule, just the age-recompute timer.
   private _pausedAt: number | null = null;
+
+  // True while the container cursor is overridden to 'pointer' because
+  // the mouse is over a strike. Tracked so we only touch style on change.
+  private _hoverActive = false;
+  private _hoverQueued = false;
+
+  // Bound handlers kept as fields so clear() can detach exactly what
+  // start() attached.
+  private _onViewChange = (): void => this._repositionAndRedraw();
+  private _onMapClick = (e: L.LeafletMouseEvent): void => this._handleClick(e);
+  private _onMapMouseMove = (e: L.LeafletMouseEvent): void => this._handleMouseMove(e);
 
   constructor(
     map: L.Map,
@@ -116,56 +156,76 @@ export class LightningLayer {
   }
 
   start(): void {
-    this._ensurePanes();
+    this._ensurePane();
+    this._ensureCanvas();
+    // moveend covers pan AND zoom (Leaflet fires it after zoomend); the
+    // explicit zoomend listener repaints one frame earlier so the
+    // glyphs snap to their post-zoom positions as soon as the zoom
+    // animation lands. resize re-pads the canvas for the new viewport.
+    this._map.on('moveend', this._onViewChange);
+    this._map.on('zoomend', this._onViewChange);
+    this._map.on('resize', this._onViewChange);
+    this._map.on('click', this._onMapClick);
+    this._map.on('mousemove', this._onMapMouseMove);
     this._refreshFromHass();
     this._ageTimer = setInterval(() => this._refreshAges(), AGE_REFRESH_MS);
   }
 
-  // Idempotent — Leaflet panes are sticky for the map's lifetime. We just
-  // need both panes to exist before the first L.marker(...{pane}) call.
-  // pointer-events: none on each pane (Leaflet's default for marker
-  // panes) lets clicks fall through dead space; .wrc-lightning-icon
-  // flips it back on for the actual icon hit area on the FILL pane.
-  // Outline-pane markers stay non-interactive (interactive: false on the
-  // L.marker) — clicks hit the fill on top, which carries the popup.
-  private _ensurePanes(): void {
-    for (const [name, z] of [
-      [LIGHTNING_PANE, LIGHTNING_PANE_Z],
-      [LIGHTNING_OUTLINE_PANE, LIGHTNING_OUTLINE_PANE_Z],
-    ] as const) {
-      if (this._map.getPane(name)) continue;
-      const pane = this._map.createPane(name);
-      pane.style.zIndex = String(z);
-      pane.style.pointerEvents = 'none';
-    }
+  // Idempotent — Leaflet panes are sticky for the map's lifetime.
+  // pointer-events stays 'none': all interaction goes through map-level
+  // click/mousemove + the DIY hit test, so the canvas never intercepts
+  // clicks meant for markers or hazard polygons.
+  private _ensurePane(): void {
+    if (this._map.getPane(LIGHTNING_PANE)) return;
+    const pane = this._map.createPane(LIGHTNING_PANE);
+    pane.style.zIndex = String(LIGHTNING_PANE_Z);
+    pane.style.pointerEvents = 'none';
+  }
+
+  private _ensureCanvas(): void {
+    if (this._canvas) return;
+    const pane = this._map.getPane(LIGHTNING_PANE);
+    if (!pane) return;
+    this._canvas = document.createElement('canvas');
+    this._canvas.style.position = 'absolute';
+    pane.appendChild(this._canvas);
+    this._repositionAndRedraw();
   }
 
   clear(): void {
-    // Drop queued-but-unmaterialised strike markers; the in-flight rAF
-    // drain (if any) finds an empty queue and no-ops.
-    this._pendingAdds = [];
     if (this._ageTimer) { clearInterval(this._ageTimer); this._ageTimer = null; }
-    for (const marker of this._markers.values()) this._map.removeLayer(marker);
-    for (const outline of this._outlines.values()) this._map.removeLayer(outline);
-    this._markers.clear();
-    this._outlines.clear();
+    this._map.off('moveend', this._onViewChange);
+    this._map.off('zoomend', this._onViewChange);
+    this._map.off('resize', this._onViewChange);
+    this._map.off('click', this._onMapClick);
+    this._map.off('mousemove', this._onMapMouseMove);
+    if (this._hoverActive) {
+      this._hoverActive = false;
+      this._map.getContainer().style.cursor = '';
+    }
+    this._canvas?.remove();
+    this._canvas = null;
+    this._buffer = null;
+    this._bufferDirty = true;
+    this._bufferMaxTs = 0;
     this._strikes.clear();
   }
 
-  // Stop the age timer while the host card is hidden. Currently-displayed
-  // markers stay on the map (they'll resume refreshing on the next visible
-  // tick). The strike-set diff still runs on hass updates because the
-  // card's IntersectionObserver doesn't gate updateHass calls — but a
-  // hidden card receives few hass-update render passes anyway, so this is
-  // not worth defensive guarding.
+  // Stop the age timer while the host card is hidden. The painted canvas
+  // stays as-is (it'll repaint on the next visible tick). The strike-set
+  // diff still runs on hass updates because the card's
+  // IntersectionObserver doesn't gate updateHass calls — but a hidden
+  // card receives few hass-update render passes anyway, so this is not
+  // worth defensive guarding.
   pause(): void {
     if (this._pausedAt != null) return;
     this._pausedAt = Date.now();
     if (this._ageTimer) { clearInterval(this._ageTimer); this._ageTimer = null; }
   }
 
-  // Resume after a pause. Always recompute ages immediately (the visible
-  // strikes have aged during the hidden interval) and restart the timer.
+  // Resume after a pause. Always run an age pass immediately (the
+  // painted strikes have aged during the hidden interval) and restart
+  // the timer.
   resume(): void {
     if (this._pausedAt == null) return;
     this._pausedAt = null;
@@ -175,11 +235,9 @@ export class LightningLayer {
     }
   }
 
-  // Diff incoming hass against the current strike set, mutating only what
-  // changed. Hass updates fire on every state change in the system —
-  // frequent — so a no-op tick must be cheap. The Blitzortung integration
-  // adds entities one at a time as strikes arrive and removes them after
-  // its max-age window expires; per tick we typically see 0–1 changes.
+  // Diff incoming hass against the current strike set. Hass updates fire
+  // on every state change in the system — frequent — so a no-op tick
+  // must be cheap: when nothing changed we never touch the canvas.
   updateHass(hass: HomeAssistant): void {
     this._hass = hass;
     this._refreshFromHass();
@@ -187,70 +245,32 @@ export class LightningLayer {
 
   private _refreshFromHass(): void {
     const current = this._collectStrikes();
+    let changed = false;
 
-    // Additions: strikes in hass that we don't have a marker for yet.
-    // QUEUED, not materialised inline: each strike costs two DOM
-    // markers with inline SVG (fill + outline panes), and on a fresh
-    // card mount during an active storm the backlog can be hundreds to
-    // thousands of strikes — building them all in one synchronous pass
-    // froze the UI for seconds (observed live: opening the edit pane,
-    // which mounts a preview card AND re-attaches the original, ran
-    // two full builds at once; dropping lightning_max_age_minutes to 2
-    // made it disappear). The drain below materialises newest-first in
-    // ~8 ms slices per animation frame, so the most relevant strikes
-    // appear immediately and the UI never blocks. Steady-state ticks
-    // add 1-2 strikes — those land on the next frame, imperceptible.
     for (const [id, strike] of current) {
-      if (!this._strikes.has(id)) {
-        this._strikes.set(id, strike);
-        this._pendingAdds.push([id, strike]);
-      }
+      if (this._strikes.has(id)) continue;
+      this._strikes.set(id, strike);
+      changed = true;
+      // A fresh strike (ts past the buffer cutoff) draws live — no
+      // buffer rebuild. Only a strike that belongs IN the buffer
+      // (discovered already old, e.g. backlog on card mount) dirties
+      // it. This is what keeps steady-state storm cost flat: arrivals
+      // don't trigger full-set repaints.
+      if (strike.ts <= this._bufferMaxTs) this._bufferDirty = true;
     }
 
     // Removals: strikes we tracked that hass no longer has (integration
-    // dropped them past its max-age cap). _removeMarker tolerates ids
-    // whose markers were still queued and never materialised; the drain
-    // re-checks _strikes membership before building.
+    // dropped them past its max-age cap). Removed strikes may be baked
+    // into the buffer, so removals always rebuild it.
     for (const id of Array.from(this._strikes.keys())) {
       if (!current.has(id)) {
         this._strikes.delete(id);
-        this._removeMarker(id);
+        changed = true;
+        this._bufferDirty = true;
       }
     }
 
-    if (this._pendingAdds.length > 0) this._scheduleDrain();
-  }
-
-  private _scheduleDrain(): void {
-    if (this._drainScheduled) return;
-    this._drainScheduled = true;
-    const raf: (cb: () => void) => void =
-      typeof requestAnimationFrame === 'function'
-        ? (cb) => requestAnimationFrame(cb)
-        : (cb) => void setTimeout(cb, 16);
-    raf(() => {
-      this._drainScheduled = false;
-      this._drainPendingAdds();
-      if (this._pendingAdds.length > 0) this._scheduleDrain();
-    });
-  }
-
-  /**
-   * Materialise queued strike markers, newest-first, until the time
-   * budget is spent. @internal — exposed for tests, which call it
-   * directly instead of waiting on animation frames.
-   */
-  _drainPendingAdds(budgetMs = 8): void {
-    // Newest first: during a large backlog drain the freshest strikes
-    // (the ones the user is watching for) appear in the first slice.
-    this._pendingAdds.sort((a, b) => b[1].ts - a[1].ts);
-    const start = performance.now();
-    while (this._pendingAdds.length > 0) {
-      const [id, strike] = this._pendingAdds.shift()!;
-      if (!this._strikes.has(id)) continue;   // removed while queued
-      this._addMarker(id, strike);
-      if (performance.now() - start >= budgetMs) break;
-    }
+    if (changed) this._scheduleRedraw();
   }
 
   // Walk hass.states once. Only entity_ids matching geo_location.* with
@@ -258,12 +278,13 @@ export class LightningLayer {
   // domain is used for earthquakes, fire perimeters, etc. so the source
   // attribute is the disambiguator. Strikes already past the
   // display-cap are filtered out at this stage so a freshly-mounted
-  // card doesn't paint markers it would immediately drop.
+  // card doesn't track strikes it would immediately drop.
   private _collectStrikes(): Map<string, Strike> {
     const out = new Map<string, Strike>();
     if (!this._hass?.states) return out;
     const maxAgeSec = this._displayMaxAgeSec();
     const now = Date.now();
+    const pulseOk = this._getConfig().lightning_pulse !== false && !prefersReducedMotion();
     // for-in with an early prefix test rather than Object.entries: this
     // runs on EVERY hass tick (any state change in the whole install),
     // and Object.entries allocates a [key, value] pair array for
@@ -282,273 +303,303 @@ export class LightningLayer {
       const ts = parseStrikeTimestamp(st);
       const ageSec = (now - ts) / 1000;
       if (ageSec > maxAgeSec) continue;
-      // Initial-form decision happens here so a strike we discover well
-      // past its 30 s window (e.g. card just mounted with strikes
-      // already present) renders as a plus rather than briefly flashing
-      // as a bolt.
-      const isBolt = ageSec < BOLT_DURATION_SEC;
-      out.set(id, { ts, lat, lon, isBolt });
+      // Pulse only for strikes still fresh at discovery — a strike we
+      // first see well past its bolt window (card just mounted with
+      // strikes already present) renders straight as a + with no flash.
+      const pulseUntil = pulseOk && ageSec < BOLT_DURATION_SEC ? now + PULSE_MS : 0;
+      out.set(id, { ts, lat, lon, pulseUntil });
     }
     return out;
   }
 
-  // Strike paint order: newest-on-top within each pane, matching
-  // Blitzortung's own web map.
-  //
-  // Leaflet's L.Marker computes z-index from screen-Y position
-  // (markers further south render on top) and adds `options.zIndexOffset`
-  // on top. The default ordering is geographic, NOT DOM-insertion order
-  // — without an offset, two strikes close together on screen would
-  // stack with the southern one on top regardless of arrival time.
-  //
-  // We set zIndexOffset = floor(strike.ts / 1000) on every strike
-  // marker (bolt, + fill, + outline). Newer strikes have larger
-  // timestamps → higher offsets → render on top of older strikes in
-  // the same pane, regardless of their relative latitude.
-  //
-  // Seconds-since-epoch is ~1.74e9 in 2026, comfortably under the 2^31
-  // ceiling some browsers apply to CSS z-index. Drops below the ceiling
-  // again if needed by dividing strike.ts by a larger denominator.
-  //
-  // The bolt → + swap uses setIcon (in-place mutation, no DOM
-  // re-insertion), so the original marker's zIndexOffset persists
-  // across the swap. The new OUTLINE marker added during the swap is
-  // given the same strike.ts-derived offset explicitly.
-  private _addMarker(id: string, strike: Strike): void {
+  // ── repaint pipeline ────────────────────────────────────────────────
+
+  private _scheduleRedraw(): void {
+    if (this._redrawQueued) return;
+    this._redrawQueued = true;
+    const raf: (cb: () => void) => void =
+      typeof requestAnimationFrame === 'function'
+        ? (cb) => requestAnimationFrame(cb)
+        : (cb) => void setTimeout(cb, 16);
+    raf(() => {
+      this._redrawQueued = false;
+      this._redraw();
+    });
+  }
+
+  // Re-pad + re-position the canvas for the current viewport, then
+  // repaint. Called on moveend/zoomend/resize; the canvas itself rides
+  // the pane transform during the gesture, so mid-pan strikes stay
+  // visually glued to geography and only the margin needs re-centring
+  // here.
+  private _repositionAndRedraw(): void {
+    const canvas = this._canvas;
+    if (!canvas) return;
+    const size = this._map.getSize();
+    if (size.x === 0 || size.y === 0) return;
+    this._padX = Math.round(size.x * CANVAS_PAD_FRACTION);
+    this._padY = Math.round(size.y * CANVAS_PAD_FRACTION);
+    const w = size.x + 2 * this._padX;
+    const h = size.y + 2 * this._padY;
+    const dpr = (typeof devicePixelRatio === 'number' && devicePixelRatio > 0) ? devicePixelRatio : 1;
+    // Resizing a canvas clears it, so only touch the backing store when
+    // the dimensions actually changed (repaint follows either way).
+    if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+      canvas.width = Math.round(w * dpr);
+      canvas.height = Math.round(h * dpr);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+    }
+    // Pin the canvas's top-left to the layer point that currently sits
+    // at container point (-padX, -padY). DomUtil.setPosition is what
+    // Leaflet's own canvas renderer uses — it survives the pane
+    // transforms applied during pan/zoom animations.
+    const origin = this._map.containerPointToLayerPoint([-this._padX, -this._padY]);
+    this._originLayerPoint = { x: origin.x, y: origin.y };
+    L.DomUtil.setPosition(canvas as unknown as HTMLElement, origin);
+    this._bufferDirty = true;   // projected positions changed
+    this._scheduleRedraw();
+  }
+
+  private _redraw(): void {
+    const canvas = this._canvas;
+    if (!canvas || canvas.width === 0) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = (typeof devicePixelRatio === 'number' && devicePixelRatio > 0) ? devicePixelRatio : 1;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+
+    if (this._strikes.size === 0) return;
+
+    const now = Date.now();
+    const maxAgeSec = this._displayMaxAgeSec();
     const cfg = this._getConfig();
     const plusSize = cfg.lightning_icon_size ?? DEFAULT_ICON_SIZE_PX;
     const boltSize = Math.round(plusSize * BOLT_SIZE_RATIO);
-    // Pulse only fires for strikes still in their bolt phase. A strike
-    // we discover already past 30 s (card-mount-with-existing-strikes
-    // case) renders straight as a + with no flash.
-    const pulseEnabled = cfg.lightning_pulse !== false && strike.isBolt;
+    const wCss = canvas.width / dpr;
+    const hCss = canvas.height / dpr;
 
-    if (strike.isBolt) {
-      // Bolt phase: single marker, no separate outline (the bolt's own
-      // path stroke + halo do that work, and bolts don't suffer the
-      // same stacking-blob problem +s do because they only last 30 s
-      // and are bigger).
-      const marker = L.marker([strike.lat, strike.lon], {
-        icon: L.divIcon({
-          html: this._boltSvg(boltSize, pulseEnabled),
-          iconSize: [boltSize, boltSize],
-          className: 'wrc-lightning-icon',
-        }),
-        pane: LIGHTNING_PANE,
-        zIndexOffset: Math.floor(strike.ts / 1000),
-      });
-      marker.bindPopup(() => this._popupHtml(strike), {
-        autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight(),
-      });
-      marker.addTo(this._map);
-      this._markers.set(id, marker);
-      if (pulseEnabled) this._wirePulseCleanup(marker);
-      return;
+    // Paint order: oldest → newest within each pass, so newer strikes
+    // land on top — same convention the DOM markers achieved with
+    // ts-derived zIndexOffset, matching Blitzortung's own web map.
+    const ordered = this._drawOrder(now, maxAgeSec, wCss, hCss, boltSize);
+
+    const plusPath = getPath2D(LIGHTNING_PLUS_PATH);
+    const boltPath = getPath2D(LIGHTNING_BOLT_PATH);
+    if (!plusPath || !boltPath) return;   // no Path2D (ancient browser) → skip painting
+
+    // Rebuild the settled-strike buffer when invalidated (add-to-
+    // backlog, removal, view change, age pass). Everything at or below
+    // the cutoff is in its + phase by construction, so the buffer only
+    // ever needs the two + passes.
+    if (this._bufferDirty || !this._buffer
+        || this._buffer.width !== canvas.width || this._buffer.height !== canvas.height) {
+      this._buffer ??= document.createElement('canvas');
+      this._buffer.width = canvas.width;     // resizing also clears
+      this._buffer.height = canvas.height;
+      const bctx = this._buffer.getContext('2d');
+      if (bctx) {
+        bctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        this._bufferMaxTs = now - BOLT_DURATION_SEC * 1000;
+        const settled = ordered.filter((d) => d.ts <= this._bufferMaxTs);
+        this._paintPlusPasses(bctx, settled, plusPath, plusSize, maxAgeSec);
+        this._bufferDirty = false;
+      }
     }
 
-    // Plus phase: split into FILL + OUTLINE markers on different panes
-    // so stacked outlines don't obscure stacked colour fills.
-    const fillColor = colorForAge(this._ageSec(strike), this._displayMaxAgeSec());
-    this._addPlusMarkers(id, strike, plusSize, fillColor);
-  }
+    // Blit the settled set, then draw the live tail (strikes newer than
+    // the buffer cutoff) on top. drawImage in CSS units undoes the
+    // buffer's dpr scaling exactly.
+    ctx.drawImage(this._buffer, 0, 0, wCss, hCss);
+    const live = ordered.filter((d) => d.ts > this._bufferMaxTs);
 
-  // Build and attach the FILL + OUTLINE marker pair for a strike in the
-  // + phase. Popup binds to the FILL marker (which sits on the higher
-  // pane and intercepts clicks); the outline is non-interactive.
-  private _addPlusMarkers(id: string, strike: Strike, size: number, fillColor: string): void {
-    const z = Math.floor(strike.ts / 1000);
-    const fillMarker = L.marker([strike.lat, strike.lon], {
-      icon: L.divIcon({
-        html: this._plusFillSvg(size, fillColor),
-        iconSize: [size, size],
-        className: 'wrc-lightning-icon',
-      }),
-      pane: LIGHTNING_PANE,
-      zIndexOffset: z,
-    });
-    fillMarker.bindPopup(() => this._popupHtml(strike), {
-      autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight(),
-    });
-    fillMarker.addTo(this._map);
-    this._markers.set(id, fillMarker);
+    // Live + glyphs first (strikes that crossed bolt→plus since the
+    // last rebuild), then bolts: a fresh strike always tops the stack.
+    this._paintPlusPasses(ctx, live.filter((d) => !d.isBolt), plusPath, plusSize, maxAgeSec);
 
-    const outlineMarker = L.marker([strike.lat, strike.lon], {
-      icon: L.divIcon({
-        html: this._plusOutlineSvg(size),
-        iconSize: [size, size],
-        className: 'wrc-lightning-icon',
-      }),
-      pane: LIGHTNING_OUTLINE_PANE,
-      interactive: false,
-      zIndexOffset: z,
-    });
-    outlineMarker.addTo(this._map);
-    this._outlines.set(id, outlineMarker);
-  }
-
-  // SVG builders — one per phase. Both share the readability halo
-  // (CSS drop-shadow) which gives every marker a 2 px black outline
-  // against any basemap or radar overlay colour, regardless of stroke
-  // colour. Cheaper and more reliable than nesting concentric SVG
-  // shapes for a manual halo.
-  //
-  // The pulse animation class lives on the SVG, NOT the divIcon's
-  // outer container — Leaflet owns the container's `transform` to
-  // position the marker, and only one CSS transform value applies per
-  // element (latest wins). If the pulse class went on the container,
-  // our `transform: scale(2)` would clobber Leaflet's
-  // `transform: translate3d(...)` for the duration of the keyframe,
-  // visually snapping every flashing strike to the lightning pane's
-  // origin (≈ map centre). Animating the inner SVG keeps Leaflet's
-  // positioning intact.
-  private static readonly HALO = 'filter:drop-shadow(0 0 1px #000) drop-shadow(0 0 1px #000);';
-
-  // Bolt phase (0–30 s): white fill, thin red outline. The red echoes
-  // the "danger / immediate" colour language without dominating the
-  // shape; the halo gives it darker contrast against light basemaps.
-  // We don't use the age gradient here (would be near-white anyway
-  // across the 30 s window). Bolt renders at 1.3× the + size so the
-  // "fresh!" indicator stands out against the older + markers
-  // around it.
-  private _boltSvg(size: number, pulse: boolean): string {
-    const cls = pulse ? 'wrc-lightning-pulse' : '';
-    return `<svg class="${cls}" viewBox="0 0 24 24" width="${size}" height="${size}" style="display:block;overflow:visible;${LightningLayer.HALO}">`
-      + `<path fill="#fff" stroke="#ff0000" stroke-width="1" stroke-linejoin="round" d="${LIGHTNING_BOLT_PATH}"/>`
-      + `</svg>`;
-  }
-
-  // Plus phase (30 s+) FILL marker: just the coloured + with no
-  // stroke or halo — the outline marker on the lower pane provides
-  // both. Stacked colours read clean (no per-marker stroke noise).
-  private _plusFillSvg(size: number, fillColor: string): string {
-    return `<svg viewBox="0 0 24 24" width="${size}" height="${size}" style="display:block;overflow:visible">`
-      + `<path fill="${fillColor}" stroke="none" d="${LIGHTNING_PLUS_PATH}"/>`
-      + `</svg>`;
-  }
-
-  // Plus phase (30 s+) OUTLINE marker: black-stroked + with no fill,
-  // plus the drop-shadow halo for background contrast. Sits one z-step
-  // below the fill marker, so when many strikes pile up at the same
-  // location the outlines stack harmlessly underneath while the
-  // topmost colour stays clean and visible. Stroke 1.5 in viewBox
-  // units ≈ 1 px at the default 14 px icon size.
-  private _plusOutlineSvg(size: number): string {
-    return `<svg viewBox="0 0 24 24" width="${size}" height="${size}" style="display:block;overflow:visible;${LightningLayer.HALO}">`
-      + `<path fill="none" stroke="#000" stroke-width="1.5" stroke-linejoin="miter" d="${LIGHTNING_PLUS_PATH}"/>`
-      + `</svg>`;
-  }
-
-  // Remove the pulse class from the SVG once the animation finishes,
-  // so a future re-render of this marker doesn't re-fire it. Listen on
-  // the outer divIcon container — animationend bubbles up — but mutate
-  // the SVG (which is the element actually carrying the class).
-  private _wirePulseCleanup(marker: L.Marker): void {
-    const el = marker.getElement();
-    if (!el) return;
-    const handler = (): void => {
-      const svg = el.querySelector('svg');
-      if (svg) svg.classList.remove('wrc-lightning-pulse');
-      el.removeEventListener('animationend', handler);
-    };
-    el.addEventListener('animationend', handler);
-  }
-
-  private _removeMarker(id: string): void {
-    const marker = this._markers.get(id);
-    if (marker) {
-      this._map.removeLayer(marker);
-      this._markers.delete(id);
+    // Bolts (first 30 s): white fill + red stroke, with a shadow halo
+    // for contrast — affordable here because bolts are few (≤30 s old).
+    // The pulse scales the glyph 2× → 1× over PULSE_MS, ease-out.
+    let pulseActive = false;
+    ctx.strokeStyle = '#ff0000';
+    ctx.lineWidth = 1;
+    ctx.lineJoin = 'round';
+    ctx.shadowColor = '#000';
+    ctx.shadowBlur = 2;
+    ctx.fillStyle = '#fff';
+    for (const d of live) {
+      if (!d.isBolt) continue;
+      let scale = 1;
+      if (d.pulseUntil > now) {
+        pulseActive = true;
+        const t = 1 - (d.pulseUntil - now) / PULSE_MS;   // 0 → 1 over the pulse
+        scale = 1 + (1 - t) * (1 - t);                   // 2 → 1, ease-out
+      }
+      this._drawGlyph(ctx, boltPath, d.x, d.y, boltSize, scale, 'both');
     }
-    const outline = this._outlines.get(id);
-    if (outline) {
-      this._map.removeLayer(outline);
-      this._outlines.delete(id);
+    ctx.shadowBlur = 0;
+
+    // A live pulse needs continuous frames until it lands; the
+    // single-flight flag makes this a plain rAF animation loop that
+    // stops itself when the last pulse expires. Each of those frames is
+    // now a blit + the live tail, NOT a full-set repaint.
+    if (pulseActive) this._scheduleRedraw();
+  }
+
+  // The two-pass + painter: all black outlines first, then all colour
+  // fills, so that when many strikes pile up at one screen location the
+  // outlines stack and merge harmlessly UNDER every colour fill — the
+  // canvas equivalent of the old two-pane DOM split. No shadow halo:
+  // with thousands of strikes per buffer build, canvas shadow blur is
+  // the single most expensive state, and the solid black stroke already
+  // separates the fills from any basemap.
+  private _paintPlusPasses(
+    ctx: CanvasRenderingContext2D,
+    items: ReadonlyArray<{ x: number; y: number; ageSec: number }>,
+    plusPath: Path2D,
+    plusSize: number,
+    maxAgeSec: number,
+  ): void {
+    ctx.strokeStyle = '#000';
+    ctx.lineWidth = 1.5;   // viewBox units — context is scaled per-glyph below
+    ctx.lineJoin = 'miter';
+    for (const d of items) {
+      this._drawGlyph(ctx, plusPath, d.x, d.y, plusSize, 1, 'stroke');
+    }
+    for (const d of items) {
+      ctx.fillStyle = colorForAge(d.ageSec, maxAgeSec);
+      this._drawGlyph(ctx, plusPath, d.x, d.y, plusSize, 1, 'fill');
     }
   }
 
-  // Re-paint each + sign's fill, swap bolt → plus once a strike
-  // crosses BOLT_DURATION_SEC, and remove strikes that have aged past
-  // the display cap. The swap mutates the existing fill marker in
-  // place (setIcon swaps the icon HTML but keeps the marker and its
-  // popup binding) AND attaches the OUTLINE marker on the lower pane.
-  // The colour-only refresh just mutates the fill marker's <path>
-  // fill attribute. Bolt-phase markers are skipped — their colour
-  // (white fill / red stroke) doesn't depend on age.
+  // Project every live strike to canvas pixels, drop the off-canvas
+  // ones, and return them sorted oldest-first (painters algorithm:
+  // newest ends up on top). Projection goes through LAYER points
+  // relative to the canvas's pinned origin — see _originLayerPoint for
+  // why container points are wrong here. @internal — exposed for
+  // tests, which feed a stubbed map projection.
+  _drawOrder(now: number, maxAgeSec: number, wCss: number, hCss: number, cullMarginPx: number):
+    Array<{ x: number; y: number; ts: number; ageSec: number; isBolt: boolean; pulseUntil: number }> {
+    const out: Array<{ x: number; y: number; ts: number; ageSec: number; isBolt: boolean; pulseUntil: number }> = [];
+    for (const s of this._strikes.values()) {
+      const ageSec = Math.max(0, (now - s.ts) / 1000);
+      if (ageSec > maxAgeSec) continue;
+      const lp = this._map.latLngToLayerPoint([s.lat, s.lon]);
+      const x = lp.x - this._originLayerPoint.x;
+      const y = lp.y - this._originLayerPoint.y;
+      if (x < -cullMarginPx || y < -cullMarginPx || x > wCss + cullMarginPx || y > hCss + cullMarginPx) continue;
+      out.push({ x, y, ts: s.ts, ageSec, isBolt: ageSec < BOLT_DURATION_SEC, pulseUntil: s.pulseUntil });
+    }
+    out.sort((a, b) => a.ts - b.ts);
+    return out;
+  }
+
+  // Draw one 24×24-viewBox glyph centred at (x, y) at `size` CSS px,
+  // optionally pulse-scaled. The context scale maps viewBox units to
+  // pixels, so stroke widths set in viewBox units render identically
+  // to the old SVG markers at any icon size.
+  private _drawGlyph(
+    ctx: CanvasRenderingContext2D,
+    path: Path2D,
+    x: number, y: number,
+    sizePx: number, pulseScale: number,
+    mode: 'fill' | 'stroke' | 'both',
+  ): void {
+    const s = (sizePx * pulseScale) / 24;
+    ctx.save();
+    ctx.translate(x - (sizePx * pulseScale) / 2, y - (sizePx * pulseScale) / 2);
+    ctx.scale(s, s);
+    if (mode !== 'stroke') ctx.fill(path);
+    if (mode !== 'fill') ctx.stroke(path);
+    ctx.restore();
+  }
+
+  // ── interaction ─────────────────────────────────────────────────────
+
+  /**
+   * Hit-test a container point against the live strikes: the MOST
+   * RECENT strike within tolerance wins, not the nearest. User decision
+   * — when several strikes overlap at storm density, the fresh strike
+   * is the one the user is reacting to. @internal — exposed for tests.
+   */
+  _hitTest(pt: { x: number; y: number }, tolerancePx: number = HIT_TOLERANCE_PX): string | null {
+    const tol2 = tolerancePx * tolerancePx;
+    let bestId: string | null = null;
+    let bestTs = -Infinity;
+    for (const [id, s] of this._strikes) {
+      const p = this._map.latLngToContainerPoint([s.lat, s.lon]);
+      const dx = p.x - pt.x;
+      const dy = p.y - pt.y;
+      if (dx * dx + dy * dy > tol2) continue;
+      if (s.ts > bestTs) { bestTs = s.ts; bestId = id; }
+    }
+    return bestId;
+  }
+
+  private _handleClick(e: L.LeafletMouseEvent): void {
+    const id = this._hitTest(e.containerPoint);
+    if (!id) return;
+    const strike = this._strikes.get(id);
+    if (!strike) return;
+    // Anchored at the strike, not the click point, so the popup tail
+    // points at the glyph the user hit. openOn closes any other open
+    // popup (Leaflet's one-popup convention), matching marker behaviour.
+    L.popup({ autoPan: true, autoPanPadding: L.point(12, 12), maxHeight: this._popupMaxHeight() } as any)
+      .setLatLng([strike.lat, strike.lon])
+      .setContent(this._popupHtml(strike))
+      .openOn(this._map);
+  }
+
+  // Pointer-cursor affordance over strikes — what the DOM markers got
+  // for free from CSS. rAF-throttled: mousemove can fire faster than
+  // frames, and each test projects every strike.
+  private _handleMouseMove(e: L.LeafletMouseEvent): void {
+    if (this._hoverQueued) return;
+    this._hoverQueued = true;
+    const pt = e.containerPoint;
+    const raf: (cb: () => void) => void =
+      typeof requestAnimationFrame === 'function'
+        ? (cb) => requestAnimationFrame(cb)
+        : (cb) => void setTimeout(cb, 16);
+    raf(() => {
+      this._hoverQueued = false;
+      if (!this._canvas) return;   // cleared while queued
+      const over = this._hitTest(pt) != null;
+      if (over === this._hoverActive) return;
+      this._hoverActive = over;
+      // Inline style wins over Leaflet's grab-cursor classes and is
+      // cleared (not set to a value) when leaving, so dragging cursors
+      // behave normally everywhere off-strike.
+      this._map.getContainer().style.cursor = over ? 'pointer' : '';
+    });
+  }
+
+  // Expire strikes past the display cap and repaint (the repaint itself
+  // recomputes every fill colour from current age). The Blitzortung
+  // integration may still hold the underlying entities — its own
+  // max-age is the upper bound; we just stop rendering.
   private _refreshAges(): void {
     const max = this._displayMaxAgeSec();
-    const cfg = this._getConfig();
-    const plusSize = cfg.lightning_icon_size ?? DEFAULT_ICON_SIZE_PX;
-    const toRemove: string[] = [];
+    const now = Date.now();
     for (const [id, strike] of this._strikes) {
-      const marker = this._markers.get(id);
-      if (!marker) continue;
-      const ageSec = this._ageSec(strike);
-
-      // Past the display cap → drop the strike from the card. The
-      // Blitzortung integration may still hold the underlying entity
-      // (its own max-age is the upper bound); we just stop rendering.
-      if (ageSec > max) {
-        toRemove.push(id);
-        continue;
-      }
-
-      // Form transition (one-way: bolt → plus). Swap the existing
-      // marker's icon to the FILL SVG, then attach a new OUTLINE
-      // marker on the lower pane. The popup binding survives setIcon
-      // so users keep the click target. We don't re-fire the pulse —
-      // it's a "just appeared!" cue, not recurring.
-      if (strike.isBolt && ageSec >= BOLT_DURATION_SEC) {
-        strike.isBolt = false;
-        const fill = colorForAge(ageSec, max);
-        marker.setIcon(L.divIcon({
-          html: this._plusFillSvg(plusSize, fill),
-          iconSize: [plusSize, plusSize],
-          className: 'wrc-lightning-icon',
-        }));
-        const outlineMarker = L.marker([strike.lat, strike.lon], {
-          icon: L.divIcon({
-            html: this._plusOutlineSvg(plusSize),
-            iconSize: [plusSize, plusSize],
-            className: 'wrc-lightning-icon',
-          }),
-          pane: LIGHTNING_OUTLINE_PANE,
-          interactive: false,
-          zIndexOffset: Math.floor(strike.ts / 1000),
-        });
-        outlineMarker.addTo(this._map);
-        this._outlines.set(id, outlineMarker);
-        continue;
-      }
-
-      // Bolt phase has fixed colours — nothing to refresh.
-      if (strike.isBolt) continue;
-
-      // Plus phase: cheap fill-only refresh on the FILL marker. The
-      // OUTLINE marker is age-independent (always black) — leave it.
-      const el = marker.getElement();
-      if (!el) continue;
-      const pathEl = el.querySelector('svg path') as SVGPathElement | null;
-      if (!pathEl) continue;
-      pathEl.setAttribute('fill', colorForAge(ageSec, max));
+      if ((now - strike.ts) / 1000 > max) this._strikes.delete(id);
     }
-    // Drop expired strikes outside the iteration so we don't mutate
-    // the Map we're walking. The strike stays in hass.states (the
-    // integration's max-age governs that); we just stop tracking it.
-    for (const id of toRemove) {
-      this._strikes.delete(id);
-      this._removeMarker(id);
-    }
+    // Always rebuild: buffered fill colours age (30 s gradient steps)
+    // and strikes that crossed bolt→plus since the last build get
+    // folded into the buffer here.
+    this._bufferDirty = true;
+    this._scheduleRedraw();
   }
 
   // Build the popup HTML. Inline-styled because Leaflet's popup container
   // lives outside the card's shadow root, so the card's CSS doesn't apply.
-  // Re-rendered each open via the bindPopup factory so distance + relative
-  // time are fresh.
+  // Built fresh per click so distance + relative time are current.
   private _popupHtml(strike: Strike): string {
     const center = this._map.getCenter();
     const distKm = haversineKm(center.lat, center.lng, strike.lat, strike.lon);
     const bearing = bearingCardinal(center.lat, center.lng, strike.lat, strike.lon);
-    const ageSec = this._ageSec(strike);
+    const ageSec = Math.max(0, (Date.now() - strike.ts) / 1000);
     const rel = relativeTime(ageSec);
 
     const distLabel = `${formatDistance(distKm, this._hass?.config?.unit_system?.length)} ${localize(`ui.lightning.bearing.${bearing}`)}`;
@@ -571,10 +622,6 @@ export class LightningLayer {
 
   private _popupMaxHeight(): number {
     return Math.max(160, Math.floor(this._map.getSize().y * 0.8));
-  }
-
-  private _ageSec(strike: Strike): number {
-    return Math.max(0, (Date.now() - strike.ts) / 1000);
   }
 
   // The effective max-age the card uses for both filtering (don't
@@ -609,6 +656,32 @@ export class LightningLayer {
     }
     return DEFAULT_BLITZORTUNG_MAX_AGE_SEC;
   }
+}
+
+// Path2D objects compiled once from the same SVG path strings the DOM
+// markers used (Path2D accepts SVG path data directly). Cached at module
+// level; null where Path2D is unavailable (no modern browser lacks it,
+// but jsdom-ish test environments might).
+const path2dCache = new Map<string, Path2D | null>();
+function getPath2D(svgPath: string): Path2D | null {
+  let p = path2dCache.get(svgPath);
+  if (p === undefined) {
+    p = typeof Path2D === 'function' ? new Path2D(svgPath) : null;
+    path2dCache.set(svgPath, p);
+  }
+  return p;
+}
+
+// Cache the MediaQueryList — matchMedia allocates per call and this is
+// consulted on every hass tick that carries a new strike.
+let reducedMotionMql: MediaQueryList | null | undefined;
+function prefersReducedMotion(): boolean {
+  if (reducedMotionMql === undefined) {
+    reducedMotionMql = typeof matchMedia === 'function'
+      ? matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+  }
+  return reducedMotionMql?.matches ?? false;
 }
 
 // Pull the strike's first-seen timestamp out of the entity state. The

--- a/src/nws-alerts-layer.ts
+++ b/src/nws-alerts-layer.ts
@@ -8,6 +8,7 @@ import {
   ALL_ALERT_CATEGORIES, categoryForEvent, getActiveAlertCategories,
 } from './nws-alert-categories';
 import { centroidLngLat, haversineKm } from './geo-utils';
+import { sharedCanvasRenderer } from './shared-canvas-renderer';
 import { escapeHtml, truncate } from './string-utils';
 
 // NWS public API — see docs/nws-alerts-feature-design.md.
@@ -125,6 +126,9 @@ export class NwsAlertsLayer {
     this._zoneAbortCtrl = null;
     if (this._timer) { clearTimeout(this._timer); this._timer = null; }
     if (this._polygonLayer) { this._map.removeLayer(this._polygonLayer); this._polygonLayer = null; }
+    // The shared canvas renderer is deliberately NOT removed — the
+    // wildfire layer may still be drawing through it (map-lifetime,
+    // see shared-canvas-renderer.ts).
     this._features = [];
     this._renderDecisions.clear();
     this._zoneCache.clear();
@@ -459,7 +463,18 @@ export class NwsAlertsLayer {
 
     if (renderable.length === 0) return;
 
+    // Canvas instead of one SVG node per polygon ring — alert outbreaks
+    // routinely carry hundreds of multi-ring zone shapes, and the
+    // per-node DOM cost is what makes pan/zoom heavy. MUST be the
+    // map-shared renderer, never a private L.canvas() — see
+    // shared-canvas-renderer.ts for why stacked canvas renderers
+    // swallow each other's clicks. Popup wiring is unchanged: the
+    // canvas renderer does its own hit-testing.
+    // The cast: `renderer` is a real option here — GeoJSON forwards its
+    // whole options bag to every child Path via geometryToLayer — but
+    // @types/leaflet's GeoJSONOptions doesn't declare it.
     this._polygonLayer = L.geoJSON(renderable, {
+      renderer: sharedCanvasRenderer(this._map),
       style: (feature) => {
         const event = (feature?.properties as AlertProps | null)?.event;
         const colour = colorForEvent(event);
@@ -477,7 +492,7 @@ export class NwsAlertsLayer {
           { autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight() },
         );
       },
-    });
+    } as L.GeoJSONOptions);
     this._polygonLayer.addTo(this._map);
   }
 

--- a/src/shared-canvas-renderer.ts
+++ b/src/shared-canvas-renderer.ts
@@ -1,0 +1,37 @@
+import * as L from 'leaflet';
+
+// ONE canvas renderer per map, shared by every vector overlay (NWS
+// alerts, wildfire perimeters). This is load-bearing, not a memory
+// optimisation: an L.Canvas receives clicks as DOM events on its own
+// canvas element, which covers the whole viewport+padding. With two
+// renderers stacked in the overlay pane, the topmost canvas swallows
+// every click — it hit-tests only ITS OWN paths, and DOM events bubble
+// up to ancestors, never down to the sibling canvas underneath. Live
+// symptom: alert polygons stopped being clickable the moment the first
+// fire perimeter crossed the icon→polygon zoom threshold (which lazily
+// created the second renderer on top), and stayed dead after zooming
+// back out (the empty renderer stays attached). SVG renderers never
+// collide like this because pointer events sit on the individual path
+// elements, not the renderer root — canvas interactivity only works
+// with a single shared renderer, which hit-tests all layers in one
+// draw list (topmost path wins, matching SVG behaviour).
+//
+// padding 0.5 = render half a viewport beyond each edge so short pans
+// don't reveal blank vectors before the post-move redraw.
+//
+// Keyed weakly by map: a card rebuild creates a fresh map and gets a
+// fresh renderer; the old one is garbage with its map. Layers must NOT
+// remove the renderer from the map in their clear() — another layer
+// may still be drawing through it. An empty renderer left attached is
+// harmless: markers live in higher panes, and map-level click handlers
+// (e.g. the lightning hit-test) still fire via bubbling.
+const renderers = new WeakMap<L.Map, L.Canvas>();
+
+export function sharedCanvasRenderer(map: L.Map): L.Canvas {
+  let r = renderers.get(map);
+  if (!r) {
+    r = L.canvas({ padding: 0.5 });
+    renderers.set(map, r);
+  }
+  return r;
+}

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -1513,28 +1513,6 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       @media (prefers-reduced-motion: reduce) {
         .loading-spinner-arc { animation: none; }
       }
-      /* Lightning overlay (Blitzortung). The divIcon outer container
-         carries the animation; the inner SVG paints the bolt. overflow:
-         visible on the SVG lets the brief scale(2) flash spill outside
-         the divIcon box without being clipped. */
-      .wrc-lightning-icon {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-      .wrc-lightning-icon svg {
-        overflow: visible;
-      }
-      @keyframes wrc-lightning-pulse {
-        0%   { transform: scale(2);   filter: brightness(2); opacity: 1; }
-        60%  { transform: scale(1.3); filter: brightness(1.4); opacity: 1; }
-        100% { transform: scale(1);   filter: brightness(1);   opacity: 1; }
-      }
-      .wrc-lightning-pulse {
-        animation: wrc-lightning-pulse 600ms ease-out;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .wrc-lightning-pulse { animation: none; }
-      }
     `,
   ];
 }

--- a/src/wildfire-layer.ts
+++ b/src/wildfire-layer.ts
@@ -5,6 +5,7 @@ import { WeatherRadarCardConfig } from './types';
 import { FIRE_PATH } from './marker-icon';
 import { localize } from './localize/localize';
 import { centroidLngLat, geometryLngLatBounds, haversineKm } from './geo-utils';
+import { sharedCanvasRenderer } from './shared-canvas-renderer';
 import { escapeHtml, slugify } from './string-utils';
 
 // NIFC WFIGS Current Interagency Fire Perimeters — see docs/wildfire-feature-design.md.
@@ -126,6 +127,9 @@ export class WildfireLayer {
       this._zoomHandler = null;
     }
     if (this._polygonLayer) { this._map.removeLayer(this._polygonLayer); this._polygonLayer = null; }
+    // The shared canvas renderer is deliberately NOT removed — the
+    // alerts layer may still be drawing through it (map-lifetime,
+    // see shared-canvas-renderer.ts).
     if (this._iconLayer) { this._map.removeLayer(this._iconLayer); this._iconLayer = null; }
     this._features = [];
     this._renderDecisions.clear();
@@ -346,7 +350,19 @@ export class WildfireLayer {
     if (this._features.length === 0) return;
 
     if (polygons.length > 0) {
+      // Canvas instead of per-ring SVG nodes — WFIGS perimeter rings
+      // carry thousands of vertices each. MUST be the map-shared
+      // renderer, never a private L.canvas() — this layer creates its
+      // polygon layer lazily (only when a fire crosses the icon→polygon
+      // zoom threshold), and a second renderer created at that moment
+      // stacks over the alerts canvas and swallows its clicks from then
+      // on (see shared-canvas-renderer.ts). Fire icons stay DOM markers
+      // (bounded count, need the divIcon SVG glyph).
+      // The cast: `renderer` is a real option here — GeoJSON forwards its
+      // whole options bag to every child Path via geometryToLayer — but
+      // @types/leaflet's GeoJSONOptions doesn't declare it.
       this._polygonLayer = L.geoJSON(polygons, {
+        renderer: sharedCanvasRenderer(this._map),
         style: (feature) => {
           const contained = isContained(feature?.properties as WildfireProps | null);
           const color = contained ? containedColor : activeColor;
@@ -366,7 +382,7 @@ export class WildfireLayer {
             { autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight() },
           );
         },
-      });
+      } as L.GeoJSONOptions);
       this._polygonLayer.addTo(this._map);
     }
 

--- a/tests/overlay-pause-resilience.test.ts
+++ b/tests/overlay-pause-resilience.test.ts
@@ -295,50 +295,162 @@ describe('failure backoff ladders', () => {
   });
 });
 
-// ── Lightning strike-backlog drain (live-debugged: editor-open lockup) ──
+// ── Lightning canvas layer: hit-test + draw order ────────────────────────
 //
-// Each strike materialises as two DOM markers with inline SVG; a fresh
-// mount during an active storm used to build the whole backlog (often
-// hundreds of strikes, and editor-open runs TWO card instances) in one
-// synchronous pass — multi-second UI freeze. Additions now queue and
-// drain newest-first in time-budgeted slices per animation frame.
+// The DOM-marker implementation (and its time-sliced backlog drain) was
+// replaced by a single canvas — strikes are painted, not mounted, so the
+// per-strike DOM cost that froze editor-open is structurally gone. What
+// needs regression coverage now is the DIY interaction layer the canvas
+// brought with it: the click hit-test (MOST RECENT strike within
+// tolerance wins, per user decision — recency beats distance when
+// strikes overlap) and the painters-algorithm draw order.
 
-describe('LightningLayer pending-add drain', () => {
+describe('LightningLayer canvas hit-test', () => {
   async function bareLightning(): Promise<any> {
     const { LightningLayer } = await import('../src/lightning-layer');
     const l = Object.create(LightningLayer.prototype);
     l._strikes = new Map();
-    l._pendingAdds = [];
-    l._drainScheduled = false;
-    l._addMarker = vi.fn();
-    l._removeMarker = vi.fn();
+    // Identity projection: strikes store container px directly in lat/lon.
+    l._map = { latLngToContainerPoint: ([lat, lon]: [number, number]) => ({ x: lon, y: lat }) };
+    l._padX = 0;
+    l._padY = 0;
     return l;
   }
 
-  it('drains newest-first and stops at the time budget', async () => {
+  it('picks the most recent strike within tolerance, not the nearest', async () => {
     const l = await bareLightning();
-    for (let i = 0; i < 5; i++) {
-      const id = `geo_location.s${i}`;
-      const strike = { ts: 1000 + i, lat: 0, lon: 0, isBolt: false };
-      l._strikes.set(id, strike);
-      l._pendingAdds.push([id, strike]);
-    }
-    // Make each _addMarker "cost" enough that a 0ms budget stops after one.
-    l._drainPendingAdds(0);
-    expect(l._addMarker).toHaveBeenCalledTimes(1);
-    // Newest strike (largest ts) materialised first.
-    expect(l._addMarker.mock.calls[0][1].ts).toBe(1004);
-    // Generous budget drains the rest.
-    l._drainPendingAdds(1000);
-    expect(l._addMarker).toHaveBeenCalledTimes(5);
-    expect(l._pendingAdds).toHaveLength(0);
+    // Older strike 1px from the click; newer strike 8px away. Both are
+    // inside the 10px tolerance — recency must win.
+    l._strikes.set('geo_location.older_closer', { ts: 1000, lat: 100, lon: 101, pulseUntil: 0 });
+    l._strikes.set('geo_location.newer_farther', { ts: 2000, lat: 100, lon: 108, pulseUntil: 0 });
+    expect(l._hitTest({ x: 100, y: 100 })).toBe('geo_location.newer_farther');
   });
 
-  it('skips strikes removed while queued', async () => {
+  it('falls back to the nearer strike when the newer one is out of tolerance', async () => {
     const l = await bareLightning();
-    const strike = { ts: 1000, lat: 0, lon: 0, isBolt: false };
-    l._pendingAdds.push(['geo_location.gone', strike]);   // NOT in _strikes
-    l._drainPendingAdds(1000);
-    expect(l._addMarker).not.toHaveBeenCalled();
+    l._strikes.set('geo_location.older_closer', { ts: 1000, lat: 100, lon: 101, pulseUntil: 0 });
+    l._strikes.set('geo_location.newer_farther', { ts: 2000, lat: 100, lon: 120, pulseUntil: 0 });
+    expect(l._hitTest({ x: 100, y: 100 })).toBe('geo_location.older_closer');
+  });
+
+  it('returns null when nothing is within tolerance', async () => {
+    const l = await bareLightning();
+    l._strikes.set('geo_location.far', { ts: 1000, lat: 500, lon: 500, pulseUntil: 0 });
+    expect(l._hitTest({ x: 100, y: 100 })).toBeNull();
+  });
+
+  it('tolerance is a radius: 10px away hits, 11px misses', async () => {
+    const l = await bareLightning();
+    l._strikes.set('geo_location.edge', { ts: 1000, lat: 100, lon: 110, pulseUntil: 0 });
+    expect(l._hitTest({ x: 100, y: 100 })).toBe('geo_location.edge');
+    expect(l._hitTest({ x: 89, y: 100 })).toBeNull();
+  });
+});
+
+describe('LightningLayer canvas draw order', () => {
+  // _drawOrder projects through LAYER points minus the canvas's pinned
+  // layer-point origin — NOT container points. Container points include
+  // the live drag delta, and a repaint mid-drag (hass tick, pulse frame)
+  // at container coordinates applied that delta on top of the pane's own
+  // transform: strikes visibly moved at 2× drag speed until moveend
+  // (live-debugged on the testbed). Layer points are drag-stable.
+  async function bareLightning(): Promise<any> {
+    const { LightningLayer } = await import('../src/lightning-layer');
+    const l = Object.create(LightningLayer.prototype);
+    l._strikes = new Map();
+    l._map = { latLngToLayerPoint: ([lat, lon]: [number, number]) => ({ x: lon, y: lat }) };
+    l._originLayerPoint = { x: 0, y: 0 };
+    return l;
+  }
+
+  it('sorts oldest-first so newer strikes paint on top, and derives bolt phase from age', async () => {
+    const l = await bareLightning();
+    const now = 100_000_000;
+    l._strikes.set('a', { ts: now - 60_000, lat: 10, lon: 10, pulseUntil: 0 });  // 60s old → plus
+    l._strikes.set('b', { ts: now - 5_000, lat: 20, lon: 20, pulseUntil: 0 });   // 5s old → bolt
+    l._strikes.set('c', { ts: now - 120_000, lat: 30, lon: 30, pulseUntil: 0 }); // 120s old → plus
+    const order = l._drawOrder(now, 1800, 200, 200, 20);
+    expect(order.map((d: any) => d.ts)).toEqual([now - 120_000, now - 60_000, now - 5_000]);
+    expect(order.map((d: any) => d.isBolt)).toEqual([false, false, true]);
+  });
+
+  it('culls strikes outside the canvas plus margin and past max age', async () => {
+    const l = await bareLightning();
+    const now = 100_000_000;
+    l._strikes.set('visible', { ts: now - 1_000, lat: 50, lon: 50, pulseUntil: 0 });
+    l._strikes.set('offcanvas', { ts: now - 1_000, lat: 50, lon: 500, pulseUntil: 0 });
+    l._strikes.set('expired', { ts: now - 2_000_000, lat: 60, lon: 60, pulseUntil: 0 });
+    const order = l._drawOrder(now, 1800, 200, 200, 20);
+    expect(order).toHaveLength(1);
+    expect(order[0].x).toBe(50);
+  });
+
+  it('paints relative to the pinned canvas origin (drag-stable layer coords)', async () => {
+    const l = await bareLightning();
+    const now = 100_000_000;
+    l._originLayerPoint = { x: -30, y: -40 };
+    l._strikes.set('s', { ts: now - 1_000, lat: 10, lon: 20, pulseUntil: 0 });
+    const order = l._drawOrder(now, 1800, 200, 200, 20);
+    expect(order[0].x).toBe(50);   // 20 - (-30)
+    expect(order[0].y).toBe(50);   // 10 - (-40)
+  });
+});
+
+// ── Settled-strike buffer invalidation ──────────────────────────────────
+//
+// The offscreen buffer holds every strike older than the bolt window;
+// each pulse frame is a blit + the live tail instead of an O(strikes)
+// full repaint. Live-debugged: a 5000-strike stress config saturated
+// the main thread because every arriving strike's 600 ms pulse ran ~36
+// full-set repaints. The win depends on ARRIVALS NOT INVALIDATING THE
+// BUFFER — these tests pin the invalidation rules.
+
+describe('LightningLayer buffer invalidation', () => {
+  async function bareLightning(): Promise<any> {
+    const { LightningLayer } = await import('../src/lightning-layer');
+    const l = Object.create(LightningLayer.prototype);
+    l._strikes = new Map();
+    l._bufferDirty = false;
+    l._bufferMaxTs = 50_000;
+    l._scheduleRedraw = vi.fn();
+    return l;
+  }
+
+  it('a fresh strike arrival does NOT dirty the buffer (draws live)', async () => {
+    const l = await bareLightning();
+    l._collectStrikes = () => new Map([
+      ['geo_location.fresh', { ts: 60_000, lat: 0, lon: 0, pulseUntil: 0 }],
+    ]);
+    l._refreshFromHass();
+    expect(l._bufferDirty).toBe(false);
+    expect(l._scheduleRedraw).toHaveBeenCalled();
+  });
+
+  it('a backlog strike older than the buffer cutoff dirties it', async () => {
+    const l = await bareLightning();
+    l._collectStrikes = () => new Map([
+      ['geo_location.old', { ts: 40_000, lat: 0, lon: 0, pulseUntil: 0 }],
+    ]);
+    l._refreshFromHass();
+    expect(l._bufferDirty).toBe(true);
+  });
+
+  it('a removal dirties the buffer (strike may be baked in)', async () => {
+    const l = await bareLightning();
+    l._strikes.set('geo_location.gone', { ts: 40_000, lat: 0, lon: 0, pulseUntil: 0 });
+    l._collectStrikes = () => new Map();
+    l._refreshFromHass();
+    expect(l._bufferDirty).toBe(true);
+    expect(l._strikes.size).toBe(0);
+  });
+
+  it('a no-op tick neither dirties nor schedules', async () => {
+    const l = await bareLightning();
+    const strike = { ts: 60_000, lat: 0, lon: 0, pulseUntil: 0 };
+    l._strikes.set('geo_location.same', strike);
+    l._collectStrikes = () => new Map([['geo_location.same', strike]]);
+    l._refreshFromHass();
+    expect(l._bufferDirty).toBe(false);
+    expect(l._scheduleRedraw).not.toHaveBeenCalled();
   });
 });

--- a/tests/shared-canvas-renderer.test.ts
+++ b/tests/shared-canvas-renderer.test.ts
@@ -1,0 +1,43 @@
+// Regression coverage for the one-canvas-renderer-per-map rule.
+//
+// Live-debugged: NWS alert polygons stopped being clickable the moment
+// the wildfire layer lazily created its OWN canvas renderer (first fire
+// crossing the icon→polygon zoom threshold) — the second canvas stacked
+// over the first and swallowed its clicks, and stayed dead after
+// zooming back out. The fix is a single shared renderer per map; these
+// tests pin the sharing contract.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('leaflet', () => {
+  const canvas = vi.fn((opts?: unknown) => ({ kind: 'canvas-renderer', opts }));
+  return { canvas, default: { canvas } };
+});
+
+import * as L from 'leaflet';
+import { sharedCanvasRenderer } from '../src/shared-canvas-renderer';
+
+beforeEach(() => {
+  (L.canvas as unknown as ReturnType<typeof vi.fn>).mockClear();
+});
+
+describe('sharedCanvasRenderer', () => {
+  it('returns the same renderer instance for the same map', () => {
+    const map = {} as L.Map;
+    const a = sharedCanvasRenderer(map);
+    const b = sharedCanvasRenderer(map);
+    expect(a).toBe(b);
+    expect(L.canvas).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns distinct renderers for distinct maps (card rebuild gets a fresh one)', () => {
+    const mapA = {} as L.Map;
+    const mapB = {} as L.Map;
+    expect(sharedCanvasRenderer(mapA)).not.toBe(sharedCanvasRenderer(mapB));
+  });
+
+  it('creates the renderer with pan padding', () => {
+    sharedCanvasRenderer({} as L.Map);
+    expect(L.canvas).toHaveBeenCalledWith({ padding: 0.5 });
+  });
+});


### PR DESCRIPTION
## Summary

The canvas-rendering follow-up planned in docs/todo.md after the alpha3 lightning-freeze fix — the structural fix for the per-datapoint DOM ceiling.

**Lightning** (`src/lightning-layer.ts`, full rewrite): one canvas replaces two DOM markers per strike.
- Two-pass painting preserves the stacked-outline look (black outlines under colour fills, newest on top — painters algorithm replaces the old two-pane zIndexOffset scheme)
- Fresh-bolt pulse is a 600 ms rAF scale animation matching the old CSS keyframes; honours `prefers-reduced-motion`
- Clicks via DIY hit-test: **the most recent strike within 10 px wins** (user decision — when strikes overlap at storm density, recency beats distance). Hover keeps the pointer-cursor affordance.
- **Offscreen settled-strike buffer**: strikes past the 30 s bolt window render from a buffer; the steady-state repaint is one blit + the live tail. The invariant that matters: *a new strike arriving does not invalidate the buffer* — without it, each arrival's pulse ran ~36 full-set repaints and saturated the main thread under storm load (observed live).
- Glyphs come from the same SVG path constants via `Path2D` — identical appearance at any `lightning_icon_size`.

**Hazard polygons** (alerts + wildfire): draw through **one shared `L.canvas({padding: 0.5})` per map** (new `src/shared-canvas-renderer.ts`, WeakMap-keyed). Leaflet's canvas renderer keeps built-in hit-testing so all popup wiring is unchanged; fire icons stay DOM markers (bounded count).

## Bugs found and fixed during the testbed soak

1. **Strikes moved at 2× drag speed**: mid-drag repaints projected through container points, which include the live drag delta — applied on top of the pane transform. Now projects through layer points relative to the canvas's pinned origin (drag-stable by construction).
2. **Alert polygons went permanently unclickable after zooming**: two stacked canvas renderers — the topmost swallows the other's clicks (canvas interactivity is DOM events on the canvas element; events bubble up, never down to the sibling beneath). Triggered when the wildfire layer lazily spawned its renderer on the first icon→polygon threshold crossing; irreversible because the empty renderer stayed attached. Hence the shared-renderer rule, documented as load-bearing at every call site.
3. **Main-thread saturation at storm scale**: the per-pulse full-set repaint, fixed by the buffer above.

## Soak results (production HA, live storms)

- **10,000 simultaneous strikes** (Blitzortung's max) at a sustained **~3.7 strikes/sec** arrival rate, 4000 km radius — page fully responsive
- DOM node count flat over the session (previously ~2 nodes per strike)
- Strike clicks, hazard popups, pulse animation, hover cursor all verified by hand

## Test plan

- [x] `npm run lint` clean, `npm test` 603 passed (12 new: hit-test recency rules, draw order + culling, drag-stable projection, buffer invalidation rules, shared-renderer contract), `npm run build` clean
- [x] Multi-hour live-storm soak as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)