### PR TITLE
chore(release): 3.7.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.0-beta1] - 2026-06-10
+
+> **Beta pre-release — 3.7 is feature complete.** The 3.7 line (per-user state → motion compensation → stability wave → canvas rendering) now enters the beta phase: no further features before 3.7.0, fixes only. Suitable for adventurous daily-driver dashboards; please report anything odd, especially around lightning at storm scale and hazard-polygon clicks.
 
 ### Changed
 
@@ -786,7 +788,7 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha3...HEAD
+[3.7.0-beta1]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha3...v3.7.0-beta1
 [3.7.0-alpha3]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha2...v3.7.0-alpha3
 [3.7.0-alpha2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha1...v3.7.0-alpha2
 [3.7.0-alpha1]: https://github.com/jpettitt/weather-radar-card/compare/v3.6.5...v3.7.0-alpha1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.7.0-alpha3",
+  "version": "3.7.0-beta1",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.7.0-alpha3';
+export const CARD_VERSION = '3.7.0-beta1';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
Release prep for **v3.7.0-beta1** — 3.7 is feature complete and moves to beta (fixes only until 3.7.0).

- `src/const.ts` `CARD_VERSION` + `package.json` → `3.7.0-beta1`
- CHANGELOG: canvas-rendering `Unreleased` section → `## [3.7.0-beta1] - 2026-06-10` with feature-freeze blurb; compare link added

No code changes. After merge: `gh release create v3.7.0-beta1 --prerelease` (release.yml attaches dist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)