### PR TITLE
fix(radar): pre-3.7.0 review fixes

### DIFF
--- a/src/lightning-layer.ts
+++ b/src/lightning-layer.ts
@@ -488,6 +488,11 @@ export class LightningLayer {
       const lp = this._map.latLngToLayerPoint([s.lat, s.lon]);
       const x = lp.x - this._originLayerPoint.x;
       const y = lp.y - this._originLayerPoint.y;
+      // Guard against a non-finite projection (bad integration lat/lon
+      // near ±90, or a redraw before the map CRS is ready): NaN passes
+      // every cull comparison below (all NaN comparisons are false) and
+      // would reach ctx.translate(NaN, …), so drop the point here.
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
       if (x < -cullMarginPx || y < -cullMarginPx || x > wCss + cullMarginPx || y > hCss + cullMarginPx) continue;
       out.push({ x, y, ts: s.ts, ageSec, isBolt: ageSec < BOLT_DURATION_SEC, pulseUntil: s.pulseUntil });
     }

--- a/src/marker-utils.ts
+++ b/src/marker-utils.ts
@@ -6,10 +6,12 @@ import { getSourceCaps } from './source-caps';
  * Convert legacy time-related fields to the source-agnostic
  * past_minutes / forecast_minutes model introduced in 3.5.
  *
- *   - frame_count → past_minutes = (frame_count - 1) × intervalMin,
- *     using the configured source's native interval. Existing configs
- *     get a time-range that closely matches what their frame_count
- *     was producing on the prior version.
+ *   - frame_count → past_minutes = (frame_count - 1) × defaultStride,
+ *     using the source's default frame interval (defaultStrideMin where
+ *     defined, else the native interval). Existing configs get a
+ *     time-range that closely matches what their frame_count produced
+ *     on the prior version. Only applied when frame_count stands alone;
+ *     see frameCountIsOverridden for the ignored-alongside-time-fields case.
  *   - dwd_forecast_hours → forecast_minutes = hours × 60.
  *
  * Only fills missing fields; user-set past_minutes / forecast_minutes

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -1228,13 +1228,15 @@ export class RadarPlayer {
     // initialised with. After a long hidden / sleep window, the entire
     // loop is many cycles outdated and one update isn't enough.
     //
-    // Heuristic: if more than 2× the refresh period (= 10 min) has
-    // elapsed since the last successful path-fetch, scrap the loop
-    // entirely and let _initRadar refetch every slot from scratch.
-    // Shorter gaps fall through to the existing _doRadarUpdate-driven
-    // single-frame path (or just a loop resume).
-    const FRAME_PERIOD_MS = 300_000;
-    const STALE_THRESHOLD_MS = 2 * FRAME_PERIOD_MS;
+    // Heuristic: if more than 2× the refresh period has elapsed since
+    // the last successful path-fetch (10 min for most sources, 4 min for
+    // a 2-min NOAA loop), scrap the loop entirely and let _initRadar
+    // refetch every slot from scratch. Shorter gaps fall through to the
+    // existing _doRadarUpdate-driven single-frame path (or a loop resume).
+    // Threshold tracks the source's actual refresh cadence (NOAA's 2-min
+    // stride → 4-min threshold; others → 10 min) so a fast source isn't
+    // judged "fresh" for the full 10 min after a long hide.
+    const STALE_THRESHOLD_MS = 2 * this._refreshPeriodMs();
     const ageMs = this._lastFrameRefreshAt > 0
       ? Date.now() - this._lastFrameRefreshAt
       : 0;
@@ -1948,16 +1950,24 @@ export class RadarPlayer {
         }
       } catch (e) {
         if ((e as Error)?.name === 'AbortError') throw e;
-        // fall through to the legacy grid below
+        // Keep the actual error visible: this catch is deliberately
+        // broad (any failure falls through to the legacy grid so radar
+        // keeps working), but logging the cause means a real defect —
+        // e.g. a TypeError from a future parse/snap refactor — surfaces
+        // instead of masquerading silently as "listing unavailable".
+        // eslint-disable-next-line no-console
+        console.warn('[weather-radar-card] NOAA frame listing fetch/parse failed; falling back to legacy eventdriven grid:', e);
+        // _noaaLegacyMode is set unconditionally below — both this caught
+        // path and the empty-listing fall-through land there.
       }
       // Fallback: legacy eventdriven server with a blind 10-min grid
       // behind its measured 15-min availability lag. Stale but correct;
       // recovers automatically — the next refresh cycle retries the
       // listing. The fixed legacy stride deliberately ignores the
       // user's stride choice: the legacy server snaps finer requests
-      // to duplicates of the same physical frame.
-      // eslint-disable-next-line no-console
-      console.warn('[weather-radar-card] NOAA frame listing unavailable; falling back to legacy eventdriven grid');
+      // to duplicates of the same physical frame. (Also reached when the
+      // listing was fetched but empty — times.length === 0 — hence the
+      // _noaaLegacyMode set here too, not only in the catch.)
       this._noaaLegacyMode = true;
       const legacyStrideMs = NOAA_LEGACY_STRIDE_MIN * 60_000;
       const snap = Math.trunc((Date.now() - NOAA_LEGACY_LAG_MS) / legacyStrideMs) * legacyStrideMs;
@@ -2350,6 +2360,23 @@ export class RadarPlayer {
 
   // ── Periodic update ──────────────────────────────────────────────────────
 
+  // Periodic-refresh cadence (ms). _updateRadar shifts in at most ONE
+  // new frame per cycle, so the period must not exceed the source's
+  // frame spacing or the loop silently degrades to refresh-period
+  // spacing. Only NOAA's selectable 2-min stride goes below the 5-min
+  // default (its opengeo listing publishes ~every 2 min); floor at 2 min
+  // to stay polite to the capabilities endpoint, cap at 5 min so coarser
+  // strides still refresh on the standard cadence. Shared by the
+  // scheduler and the visibility-resume staleness check so both track
+  // the same cadence (a 2-min NOAA loop must not be judged "fresh" for a
+  // full 10 min after a tab-hide).
+  private _refreshPeriodMs(): number {
+    const isNoaa = (this._cfg.data_source ?? 'RainViewer') === 'NOAA';
+    if (!isNoaa) return 300_000;
+    const strideMs = getEffectiveTimeRange(this._cfg).strideMin * 60_000;
+    return Math.max(120_000, Math.min(300_000, strideMs));
+  }
+
   private _scheduleUpdate(): void {
     // Single-chain invariant: exactly one armed update timer at any
     // time. Several paths can arm a fresh chain while an old timer is
@@ -2362,13 +2389,9 @@ export class RadarPlayer {
     this._cancelScheduledUpdate?.();
     // _updateRadar shifts in at most ONE new frame per cycle, so the
     // refresh period must not exceed the frame spacing or the loop
-    // silently degrades to refresh-period spacing. Only NOAA's 2-min
-    // stride goes below the 5-min default (its opengeo listing
-    // publishes ~every 2 min); floor at 2 min to stay polite to the
-    // capabilities endpoint.
+    // silently degrades to refresh-period spacing.
     const isNoaa = (this._cfg.data_source ?? 'RainViewer') === 'NOAA';
-    const strideMs = getEffectiveTimeRange(this._cfg).strideMin * 60_000;
-    const framePeriod = isNoaa ? Math.max(120_000, Math.min(300_000, strideMs)) : 300_000;
+    const framePeriod = this._refreshPeriodMs();
     // RainViewer publishes ~1 min after the timestamp; DWD ~1–3 min;
     // NOAA's newest listed frame is itself the publication signal.
     const lag = isNoaa ? 0 : 60_000;


### PR DESCRIPTION
Fixes from the pre-3.7.0 code review of the 3.7 line (full findings + dispositions in `.dev/code-review-2026-06-15.md`). These touch already-merged 3.7 code; the #195 PR carries the frame_count-warning fix separately.

## Fixed
- **NOAA visibility-resume staleness threshold** was hardcoded at 10 min — too loose for NOAA's 2-min stride (loop could sit ~10 min stale after a tab-hide). Extracted `_refreshPeriodMs()`, now shared by the periodic scheduler and the staleness check, so the threshold tracks the source's real cadence (NOAA 2-min → 4-min; others → 10 min).
- **NOAA opengeo fallback masked real errors** — the broad catch logged a generic "listing unavailable", hiding genuine defects (e.g. a future parse/snap `TypeError`) as a network outage. Now logs the actual error; the fall-through to the legacy grid stays so radar keeps working.
- **Lightning `_drawOrder` NaN guard** — a non-finite projection (bad integration lat/lon near ±90, or a redraw before the map CRS is ready) passed every cull comparison and would reach `ctx.translate(NaN, …)`. Added a `Number.isFinite` guard.
- **Stale docstring** — `migrateTimeRange` said "× intervalMin native interval"; the code uses the default stride. Corrected.

## Deferred (noted in the review doc, not blockers)
Legacy-fallback frame-count pinning (transient, self-heals on re-init), dpr-change-without-repaint (rare monitor swap), `parseTimeDimension` regex hardening (verified against prod, fails safe), and several cosmetic/latent items.

## Test plan
- [x] lint clean, 616 tests pass, build clean
- [x] No behaviour change for non-NOAA sources (threshold stays 10 min); NOAA error path still falls back, now with a visible cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)