### PR TITLE
chore(release): 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.0] - 2026-06-15
+
+> **Stable release.** Graduates the 3.7 line (per-user state → adjustable playback speed → motion compensation → canvas rendering → opengeo NOAA) to stable. Drop-in upgrade from 3.6.x and any 3.7 pre-release — no breaking changes, no config changes required. The headline features are opt-in **smooth motion** (`motion_compensation`) and **adjustable playback speed**; see the release notes for the full line summary. The entries below are what changed since `3.7.0-beta2`.
 
 ### Changed
 
-- **Over-determined time-range configs now warn instead of silently ignoring `frame_count`** ([#191](https://github.com/jpettitt/weather-radar-card/issues/191)). `frame_count` has been deprecated since 3.5 and is only consumed when no time-based field is present; a config carrying both (e.g. `frame_count: 12` + `past_minutes: 60` + `frame_stride_minutes: 2`) runs purely on the time fields, which looked self-contradictory with no signal that `frame_count` was doing nothing. The card now logs a console warning on load when `frame_count` appears alongside `past_minutes` or `frame_stride_minutes`, and the deprecated-field documentation spells out the precedence. (`frame_count` will be removed entirely in the next major.)
+- **Over-determined time-range configs now warn instead of silently ignoring `frame_count`** ([#191](https://github.com/jpettitt/weather-radar-card/issues/191)). `frame_count` has been deprecated since 3.5 and is only consumed when no time-based field is present; a config carrying both (e.g. `frame_count: 12` + `past_minutes: 60` + `frame_stride_minutes: 2`) runs purely on the time fields, which looked self-contradictory with no signal that `frame_count` was doing nothing. The card now logs a single console warning when `frame_count` appears alongside `past_minutes` or `frame_stride_minutes`, and the deprecated-field documentation spells out the precedence. (`frame_count` will be removed entirely in the next major.)
+
+### Fixed
+
+- **NOAA stayed stale longer than necessary after a tab-hide.** The visibility-resume "is the loop stale?" threshold was hardcoded at 10 minutes — fine for the old cadence, too loose for NOAA's new 2-minute stride. The threshold now scales with the source's actual refresh period (NOAA at a 2-minute interval re-initialises after ~4 minutes hidden instead of 10), so a resumed NOAA loop catches up promptly.
+- **A NOAA frame-listing failure no longer hides its cause.** The opengeo→legacy fallback logged a generic "listing unavailable"; it now logs the actual error, so a genuine defect surfaces instead of masquerading as a network outage (the fallback to the legacy server is unchanged).
+- **Lightning canvas guards against a non-finite projection** (bad integration coordinates near the poles, or a repaint before the map is ready) that could otherwise corrupt the canvas transform.
 
 ## [3.7.0-beta2] - 2026-06-12
 
@@ -805,7 +813,7 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-beta2...HEAD
+[3.7.0]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-beta2...v3.7.0
 [3.7.0-beta2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-beta1...v3.7.0-beta2
 [3.7.0-beta1]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha3...v3.7.0-beta1
 [3.7.0-alpha3]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-alpha2...v3.7.0-alpha3

--- a/README.md
+++ b/README.md
@@ -19,18 +19,7 @@ Full-screen capture with every feature enabled — radar with motion compensatio
 
 [![Watch the demo on YouTube](https://img.youtube.com/vi/xfbZRElOi0o/maxresdefault.jpg)](https://youtu.be/xfbZRElOi0o)
 
-## What's new in 3.6 (current stable line)
-
-- **Real-time lightning strikes** when the [Blitzortung integration](https://github.com/mrk-its/homeassistant-blitzortung) is installed — bolt + pulse for first 30 s, then a coloured + sign on a two-pane outline-vs-fill split (dense storm clusters read clean instead of black-blob). Card-side max-age cap defaults to 30 min. ([3.6.0](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.0))
-- **Wind overlay** — barbs, arrows, animated streamlines from DWD's ICON-D2 model. Bulk WCS fetch with 60 s coalescing cache, zoom-aware streamlines. See [Hazard & Layer Overlays](https://github.com/jpettitt/weather-radar-card/blob/main/docs/overlays.md#wind). ([3.6.0](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.0))
-- **Wind source registry** — choose `dwd_icon`, `dwd_aicon` (DWD's AI-augmented variant), or `ndfd_wind` (NWS NDFD 2.5 km CONUS / AK / HI / PR). Fresh US installs default to `ndfd_wind` automatically. ([3.6.1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.1))
-- **AbortController** on tile + data fetches — superseded fetches no longer complete on the wire after a pan / zoom / teardown. ([3.6.2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.2))
-- **Tablet-friendly progress-bar touch target** via `progress_bar_touch_height` YAML option, contributed by [@cgjolberg](https://github.com/cgjolberg). ([3.6.4](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.4))
-- **Per-user state framework** (dormant) — `ViewerState` wraps HA's frontend-storage WebSocket API. First user-visible consumer (adjustable playback speed) ships in 3.7. ([3.6.5](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.5))
-
-## What's new in 3.7 (beta — feature complete)
-
-3.7 is in beta: the feature set is frozen, fixes only until 3.7.0 stable. Toggle **Show beta versions** in HACS to try it.
+## What's new in 3.7 (current stable)
 
 **Headline features:**
 
@@ -46,6 +35,15 @@ Full-screen capture with every feature enabled — radar with motion compensatio
 - **Translations completed** for all 3.7 editor strings across the card's 11 languages.
 
 For the full release history see [CHANGELOG](https://github.com/jpettitt/weather-radar-card/blob/main/CHANGELOG.md).
+
+## What's new in 3.6
+
+- **Real-time lightning strikes** when the [Blitzortung integration](https://github.com/mrk-its/homeassistant-blitzortung) is installed — bolt + pulse for first 30 s, then a coloured + sign on a two-pane outline-vs-fill split (dense storm clusters read clean instead of black-blob). Card-side max-age cap defaults to 30 min. ([3.6.0](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.0))
+- **Wind overlay** — barbs, arrows, animated streamlines from DWD's ICON-D2 model. Bulk WCS fetch with 60 s coalescing cache, zoom-aware streamlines. See [Hazard & Layer Overlays](https://github.com/jpettitt/weather-radar-card/blob/main/docs/overlays.md#wind). ([3.6.0](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.0))
+- **Wind source registry** — choose `dwd_icon`, `dwd_aicon` (DWD's AI-augmented variant), or `ndfd_wind` (NWS NDFD 2.5 km CONUS / AK / HI / PR). Fresh US installs default to `ndfd_wind` automatically. ([3.6.1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.1))
+- **AbortController** on tile + data fetches — superseded fetches no longer complete on the wire after a pan / zoom / teardown. ([3.6.2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.2))
+- **Tablet-friendly progress-bar touch target** via `progress_bar_touch_height` YAML option, contributed by [@cgjolberg](https://github.com/cgjolberg). ([3.6.4](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.4))
+- **Per-user state framework** (dormant) — `ViewerState` wraps HA's frontend-storage WebSocket API. First user-visible consumer (adjustable playback speed) ships in 3.7. ([3.6.5](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.5))
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ A Home Assistant rain radar card using tiled radar imagery from RainViewer, NOAA
 
 ## Description
 
-This card displays animated weather radar loops within Home Assistant. It supports multiple radar data sources and map styles, and can be zoomed and panned seamlessly. Markers, hazard overlays (US wildfires + NWS watches & warnings), a forecast nowcast (DWD), opt-in [motion-compensated playback](https://github.com/jpettitt/weather-radar-card/blob/main/docs/configuration.md#motion-compensation) (rain drifts between frames instead of teleporting), full sections-grid resize support, and 11 languages.
+This card displays animated weather radar loops within Home Assistant. It supports multiple radar data sources and map styles, and can be zoomed and panned seamlessly. Markers, hazard overlays (US wildfires + NWS watches & warnings), real-time lightning, a forecast nowcast (DWD), opt-in [motion-compensated playback](https://github.com/jpettitt/weather-radar-card/blob/main/docs/configuration.md#motion-compensation) (rain drifts between frames instead of teleporting), adjustable playback speed with optional per-user persistence, full sections-grid resize support, and 11 languages.
 
 ![Weather Radar card](weather-radar-card.gif)
+
+### Video demo
+
+Full-screen capture with every feature enabled — radar with motion compensation, lightning, wind streamlines, hazard overlays, playback controls:
+
+[![Watch the demo on YouTube](https://img.youtube.com/vi/xfbZRElOi0o/maxresdefault.jpg)](https://youtu.be/xfbZRElOi0o)
 
 ## What's new in 3.6 (current stable line)
 
@@ -22,16 +28,28 @@ This card displays animated weather radar loops within Home Assistant. It suppor
 - **Tablet-friendly progress-bar touch target** via `progress_bar_touch_height` YAML option, contributed by [@cgjolberg](https://github.com/cgjolberg). ([3.6.4](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.4))
 - **Per-user state framework** (dormant) — `ViewerState` wraps HA's frontend-storage WebSocket API. First user-visible consumer (adjustable playback speed) ships in 3.7. ([3.6.5](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.5))
 
-## 3.7 in flight (alpha pre-release)
+## What's new in 3.7 (beta — feature complete)
 
-- **Adjustable playback speed** — toolbar button cycles ¼× / ½× / 1× / 2× / 4×; editor dropdown sets the YAML default. Optional per-user persistence via `viewer_layer_control` admin opt-in. Contributed by [@genericJE](https://github.com/genericJE). ([3.7.0-alpha1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha1))
-- **Motion compensation for radar transitions** — opt-in `motion_compensation: true`. Rain visibly drifts between frames instead of teleporting. Pyramidal Lucas-Kanade optical flow on a distance-from-white intensity channel; source-agnostic across DWD / RainViewer / NOAA. Built on top of [@genericJE](https://github.com/genericJE)'s [#156](https://github.com/jpettitt/weather-radar-card/pull/156). ([3.7.0-alpha2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha2))
+3.7 is in beta: the feature set is frozen, fixes only until 3.7.0 stable. Toggle **Show beta versions** in HACS to try it.
+
+**Headline features:**
+
+- **Smooth motion** — opt-in `motion_compensation: true`. During each frame transition, rain slides along its actual direction of travel instead of crossfading in place, so the loop reads as one continuously drifting rain field. Pyramidal Lucas-Kanade optical flow, runs in a Web Worker, source-agnostic across DWD / RainViewer / NOAA. Built on top of [@genericJE](https://github.com/genericJE)'s [#156](https://github.com/jpettitt/weather-radar-card/pull/156). Pairs naturally with `smooth_animation`. ([3.7.0-alpha2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha2))
+- **Adjustable playback speed** — toolbar button cycles ¼× / ½× / 1× / 2× / 4×; editor dropdown sets the YAML default. Optional per-user persistence via the `viewer_layer_control` admin opt-in: each viewer's chosen speed follows them across browsers and devices. Contributed by [@genericJE](https://github.com/genericJE). ([3.7.0-alpha1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha1))
+
+**Also in 3.7 — stability and performance:**
+
+- **Canvas rendering for lightning and hazard overlays** — strikes, NWS alert polygons, and wildfire perimeters paint to canvas instead of one DOM node per item. Identical visuals and clickability (strike clicks select the most recent within 10 px); soak-validated during live storms at 10,000 simultaneous strikes with the page fully responsive. ([3.7.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta1))
+- **Stability wave** — full-project code-review remediation: refresh/state races fixed (long-running dashboards no longer accumulate duplicate frames), DWD coverage clipping + single shared boundary mask, exponential backoff on alert/wildfire fetch failures, bounded caches, antimeridian fixes for Alaska. ([3.7.0-alpha3](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha3))
+- **NOAA radar rebuilt on NCEP's opengeo GeoServer** (the backend radar.weather.gov itself runs on) — the newest frame is now **~2 minutes behind real time instead of 15–25**, every frame is a distinct radar scan, and a new **Frame interval** dropdown picks 2 / 5 / 10-minute loop density. ([3.7.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta2))
+- **"Latest" replaces "Now"** on the newest-frame label — radar frames lag real time by source (NOAA ~2 min, DWD ~5 min, RainViewer ~1–2 min), so the label no longer overstates freshness. ([3.7.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta2))
+- **Translations completed** for all 3.7 editor strings across the card's 11 languages.
 
 For the full release history see [CHANGELOG](https://github.com/jpettitt/weather-radar-card/blob/main/CHANGELOG.md).
 
 ## Roadmap
 
-Active threads, no specific version commitment — alpha line for 3.7 is intentionally iterative until a real shape emerges. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for full backlog with status per item.
+Active threads, no specific version commitment — 3.7 is feature-frozen in beta, so these target 3.8 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
 
 - **Real-time per-user layer visibility control panel** — UI for toggling individual overlays in real time. Persistence framework already shipped (3.6.5); first consumer shipped (playback speed in 3.7.0-alpha1); the on-map panel itself is the remaining piece. Full design in [docs/layer-control-design.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/layer-control-design.md).
 - **Additional wind sources** — Open-Meteo for global coverage, ICON pressure levels for upper-air wind, regional finer-than-ICON-D2 sources (AROME, MEPS, HRRR). Tiers and trade-offs documented in [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For the full release history see [CHANGELOG](https://github.com/jpettitt/weather
 
 ## Roadmap
 
-Active threads, no specific version commitment — 3.7 is feature-frozen in beta, so these target 3.8 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
+Active threads, no specific version commitment — with 3.7 shipped, these target 3.8 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
 
 - **Real-time per-user layer visibility control panel** — UI for toggling individual overlays in real time. Persistence framework already shipped (3.6.5); first consumer shipped (playback speed in 3.7.0-alpha1); the on-map panel itself is the remaining piece. Full design in [docs/layer-control-design.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/layer-control-design.md).
 - **Additional wind sources** — Open-Meteo for global coverage, ICON pressure levels for upper-air wind, regional finer-than-ICON-D2 sources (AROME, MEPS, HRRR). Tiers and trade-offs documented in [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.7.0-beta2",
+  "version": "3.7.0",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '3.7.0-beta2';
+export const CARD_VERSION = '3.7.0';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
Release prep for **v3.7.0** — the 3.7 beta→stable graduation.

- `src/const.ts` `CARD_VERSION` + `package.json` → `3.7.0`
- CHANGELOG: `Unreleased` → `## [3.7.0] - 2026-06-15` (since-beta2 changes: frame_count over-determined warning + the pre-release review fixes from #196); compare link added
- README: 3.7 section retitled "(current stable)" and moved above 3.6; beta "fixes-only / Show beta versions" caveat dropped; 3.6 heading de-flagged as no-longer-current

No code changes (version + docs only). Both pre-release fix PRs (#195, #196) already merged. After this merges: publish **v3.7.0** stable (no `--prerelease`) with the consolidated release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)