### PR TITLE
Add pan X and Y to center map in case the size is less than the minumum accepted by the card

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: weather-radar-card
-          path: weather-radar-card.js
+          path: dist/weather-radar-card.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,19 +14,17 @@ jobs:
   build:
     name: Test build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
         run: npm install --legacy-peer-deps
       - name: Build
-        run: npm run rollup
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: weather-radar-card
-          path: dist/weather-radar-card.js
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
 name: "Build"
-
 on:
   push:
     branches:
@@ -8,34 +7,26 @@ on:
     branches:
       - main
   workflow_dispatch:
-
-# Cancel an older run of the same workflow on the same ref when a new push
-# arrives. Saves CI minutes on rapid force-pushes / quick fixups.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   build:
     name: Test build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v5
-
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: 'npm'
-
       - name: Install dependencies
         run: npm install --legacy-peer-deps
-
-      - name: Test
-        run: npm test
-
       - name: Build
-        run: npm run build
+        run: npm run rollup
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weather-radar-card
+          path: weather-radar-card.js

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,10 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
   center_longitude?: CoordinateConfig;
   center_latitude?: CoordinateConfig;
   zoom_level?: number;
+  /** Pan the map horizontally (pixels) after initialization. Positive = right, negative = left. */
+  pan_offset_x?: number;
+  /** Pan the map vertically (pixels) after initialization. Positive = down, negative = up. */
+  pan_offset_y?: number;
   markers?: Marker[];
   cluster_markers?: boolean;
   // Legacy single-marker fields — read-only; used only by _migrateConfig()

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -716,6 +716,11 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       wheelPxPerZoomLevel: 120, attributionControl: false,
       minZoom: 3, maxZoom: 16,
     }).setView([center.lat, center.lon], cfg.zoom_level ?? 7);
+    
+    // Pan the map if configured
+    if (cfg.pan_offset_x || cfg.pan_offset_y) {
+      this._map.panBy([cfg.pan_offset_x ?? 0, cfg.pan_offset_y ?? 0]);
+    }
 
     if (cfg.disable_scroll === true && !isStatic) {
       this._map.dragging.disable();


### PR DESCRIPTION
<!--
PR template — see AGENTS.md for the full contribution guide.

Do not remove sections. Mark sections "n/a" with a one-line reason
when they truly don't apply (e.g. "n/a — docs-only"). Reviewers use
this template to track what was tested and what's at risk; removing
parts of it makes review harder.
-->

## Summary

<!--
1–3 bullets on what changed and why. Focus on the *why*; the diff
shows the *what*. Link to an issue or design doc if one motivated
the change.
-->

-

## Test plan

<!--
What you ran locally before requesting review. For code changes,
all three boxes must be checked. For docs-only PRs, write "n/a —
docs only" below the checklist and leave the boxes unticked.
-->

- [x] `npm run lint` — zero eslint errors
- [x] `npm test` — all vitest suites pass
- [x] `npm run build` — clean rebuild, no rollup errors

**Manual / UI verification:**

<!--
For UI or playback changes: how you exercised the change in HA.
Which radar source? Which overlays enabled? Which map zoom level?
Mobile or desktop? If you used the Docker testbed
(`npm run ha:up`), say so. If you couldn't test a surface (e.g. a
DWD-only change without German rain to look at), say so explicitly
so a reviewer can pick it up.
-->

## Risk

<!--
Anything a reviewer should think hardest about. Schema changes,
config migrations, fetch lifecycle (AbortController, generation
counters), the crossfade pipeline, marker resolution, anything that
could regress an existing install on upgrade. "Low — internal
refactor with full test coverage" is a valid answer when true.
-->

## Docs touched

<!--
Tick the docs you updated in this PR, or write "n/a — internal
change" if no user-visible behaviour or future plans changed.
-->

- [ ] `README.md`
- [ ] `CHANGELOG.md`
- [ ] `docs/todo.md`
- [ ] `docs/configuration.md`
- [ ] `docs/data-sources.md`
- [ ] `docs/overlays.md`
- [ ] `docs/markers.md`
- [ ] `docs/examples.md`
- [ ] `docs/animation.md` or other `docs/*-feature-design.md`
- [ ] n/a — internal change
