### PR TITLE
chore(release): 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.7.1-beta1] - 2026-06-29
+## [3.7.1] - 2026-06-29
 
-> **Beta pre-release.** A targeted bug fix for the NWS watches-and-warnings overlay. Drop-in upgrade from 3.7.0 — no config or behaviour changes.
+> **Stable release.** Graduates the 3.7.1-beta1 bug fix to stable — unchanged since the beta. Drop-in upgrade from 3.7.0; no config or behaviour changes.
 
 ### Fixed
 
 - **NWS alert zone-shape cache moved to IndexedDB — fixes a shared-`localStorage`-exhaustion bug that degraded the whole dashboard.** The persistent zone cache used `localStorage`, whose ~5 MB quota is *shared* across all of Home Assistant's frontend and every custom card. The full NWS zone set is ~8,400 zones / ~170 MB of raw GeoJSON (a single marine zone can be ~120 KB), so a heavy watches-and-warnings user filled the quota. **Crucially the impact wasn't limited to this card:** once the shared quota was full, `localStorage` writes from *other* cards and Home Assistant's own frontend also began throwing `QuotaExceededError`, and any card that didn't handle that gracefully showed visible UI breakage — so one overfull radar card could degrade the entire dashboard. The cache now lives in IndexedDB (quota is a share of free disk, hundreds of MB+), which HA itself uses for bulk like its icon cache. Geometry is quantised to 4 dp (~11 m, imperceptible at the card's zoom range) and gzip-compressed (~4× smaller, stored as binary — no base64), bounded by the existing 30-day TTL plus an entry-count cap. On first run the card purges the old `wrc-zone-v1:` `localStorage` entries, immediately reclaiming the shared space they occupied. No config or visible behaviour change; zones persist reliably again — and the card is no longer a bad neighbour to the rest of the dashboard.
+
+## [3.7.1-beta1] - 2026-06-29
+
+> **Beta pre-release.** First cut of the NWS zone-cache fix released as [3.7.1](#371---2026-06-29). See that entry for details.
 
 ## [3.7.0] - 2026-06-15
 
@@ -823,7 +827,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.1-beta1...HEAD
+[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.1...HEAD
+[3.7.1]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.1-beta1...v3.7.1
 [3.7.1-beta1]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0...v3.7.1-beta1
 [3.7.0]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-beta2...v3.7.0
 [3.7.0-beta2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.0-beta1...v3.7.0-beta2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.6.2",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.6.2",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.7.1-beta1",
+  "version": "3.7.1",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [


### PR DESCRIPTION
Release prep for **v3.7.1** (stable) — graduates the NWS zone-cache fix from 3.7.1-beta1, unchanged.

- Bump `package.json` 3.7.1-beta1 → 3.7.1
- Sync `package-lock.json` (was left at 3.7.0 by the beta release commit)
- CHANGELOG: add `[3.7.1]` (full detail), demote the beta entry to a pointer

The fix itself merged in #202; the beta shipped as #203. This stamps the stable version so the `v3.7.1` tag can be cut.