### PR TITLE
fix(build): stop CARD_VERSION drifting from package.json

### DIFF
--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import babel from '@rollup/plugin-babel';
@@ -5,12 +6,19 @@ import serve from 'rollup-plugin-serve';
 import terser from '@rollup/plugin-terser';
 import json from '@rollup/plugin-json';
 
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
+// Keep this in sync with rollup.config.js's buildStampPlugin — same two
+// tokens, same substitution, just duplicated because this is a separate
+// rollup entrypoint for `npm start` (watch mode).
 const buildStampPlugin = () => {
   const stamp = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
   return {
     name: 'build-stamp',
     renderChunk(code) {
-      return code.replace(/__BUILD_TIMESTAMP__/g, stamp);
+      return code
+        .replace(/__BUILD_TIMESTAMP__/g, stamp)
+        .replace(/__CARD_VERSION__/g, pkg.version);
     },
   };
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,18 +12,24 @@ import json from '@rollup/plugin-json';
 import { string } from 'rollup-plugin-string';
 
 const dev = process.env.ROLLUP_WATCH;
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 
-// Substitute __BUILD_TIMESTAMP__ in the bundled output with the actual build
-// time. Surfaced in the card's console signon so users can confirm a hard
-// refresh actually loaded the new bundle vs a cached older one. Runs at the
-// renderChunk stage so the substitution happens after TS / babel and before
-// terser, regardless of mangling.
+// Substitute __BUILD_TIMESTAMP__ / __CARD_VERSION__ in the bundled output —
+// the build time and package.json's version, respectively. Both surfaced in
+// the card's console signon: the timestamp so users can confirm a hard
+// refresh actually loaded the new bundle vs a cached older one, the version
+// so it can't drift from package.json (a hardcoded literal here stayed
+// stuck at 3.7.0 through four later releases). Runs at the renderChunk
+// stage so substitution happens after TS / babel and before terser,
+// regardless of mangling.
 const buildStampPlugin = () => {
   const stamp = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
   return {
     name: 'build-stamp',
     renderChunk(code) {
-      return code.replace(/__BUILD_TIMESTAMP__/g, stamp);
+      return code
+        .replace(/__BUILD_TIMESTAMP__/g, stamp)
+        .replace(/__CARD_VERSION__/g, pkg.version);
     },
   };
 };

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,9 @@
-export const CARD_VERSION = '3.7.0';
+// Replaced at build time by rollup with package.json's version — a plain
+// literal here drifted stale for four releases (stuck at 3.7.0 through
+// 3.7.0-beta2/3.7.1-beta1/3.7.1/3.7.2-beta1) because nothing forced it to
+// track package.json. Sourcing it from the one place bump-version already
+// updates makes that drift structurally impossible.
+export const CARD_VERSION = '__CARD_VERSION__';
 // Replaced at build time by rollup with the ISO build timestamp. Lets the
 // card's console signon show *which build* loaded — useful for confirming
 // a fresh bundle has replaced a cached one in the browser.


### PR DESCRIPTION
## Summary
- `src/const.ts` hardcoded `CARD_VERSION = '3.7.0'` as a plain literal — nothing forced it to track `package.json`, so the console signon banner stayed stuck at 3.7.0 through four later releases (3.7.0-beta2, 3.7.1-beta1, 3.7.1, 3.7.2-beta1), silently misreporting which version users had loaded.
- Fixed the same way `BUILD_TIMESTAMP` already works: a `__CARD_VERSION__` placeholder substituted at rollup's `renderChunk` stage with `package.json`'s version, in both `rollup.config.js` (prod build) and `rollup.config.dev.js` (`npm start` watch mode, which had its own duplicate `buildStampPlugin` needing the same fix).
- Confirmed fixed live in the HA docker testbed — banner now reads the correct version.

## Test plan
- [x] `tsc --noEmit`
- [x] `npm test` (643/643)
- [x] `npm run build`, confirmed `dist/weather-radar-card.js`'s banner reads `3.7.2-beta1`
- [x] Verified in the running HA docker testbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)