### PR TITLE
feat(popups): restore map view after closing a hazard-layer popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Map view now restores after closing a hazard-layer popup (lightning/wildfire/NWS alerts).** Popups near the map edge still auto-pan the view to stay fully visible — Leaflet has no way to reposition a popup within the viewport instead — but the view now returns to where it was once you close the popup, instead of leaving the map shifted. Switching directly between popups only restores once, at the end.
+
 ## [3.7.2-beta2] - 2026-07-01
 
 > **Beta pre-release.** Fixes the console signon banner showing a stale version number. Drop-in upgrade from 3.7.2-beta1 — no config changes.

--- a/src/popup-pan-restore.ts
+++ b/src/popup-pan-restore.ts
@@ -1,0 +1,49 @@
+/**
+ * Decides when to put the map's view back after a popup's autoPan moved it.
+ *
+ * Leaflet's popups have no "reposition instead of panning the map" mode, so
+ * an off-edge hazard-layer popup (lightning/wildfire/NWS-alerts) still pans
+ * the view to stay fully visible. This tracks the center from *before* that
+ * happened so the caller can restore it once the user is done with the
+ * popup — browsing hazard popups near the map edge shouldn't leave the view
+ * shifted afterward.
+ *
+ * Pure decision logic only — no Leaflet, no timers. The caller (see
+ * weather-radar-card.ts's _setupPopupPanRestore) owns the actual
+ * map.on('popupopen'/'popupclose') wiring and the setTimeout that defers
+ * the restore by a tick, needed because switching directly between two
+ * popups fires popupclose then popupopen synchronously in the same tick
+ * (Leaflet's one-popup-at-a-time autoClose behaviour) — onCloseSettled lets
+ * that same-tick reopen cancel the pending restore instead of snapping back
+ * only to immediately pan away again, so a chain of popup switches only
+ * restores once, to the center from before the first one opened.
+ */
+export class PopupPanRestore<Center> {
+  private savedCenter: Center | null = null;
+  private token = 0;
+
+  /** Call when a popup opens. Captures the pre-chain center on the first open of a chain. */
+  onOpen(getCenter: () => Center): void {
+    this.token++;
+    if (this.savedCenter === null) {
+      this.savedCenter = getCenter();
+    }
+  }
+
+  /** Call when a popup closes. Returns a token to pass to onCloseSettled after a deferred tick. */
+  onClose(): number {
+    return ++this.token;
+  }
+
+  /**
+   * Call after deferring a tick past onClose(). Returns the center to
+   * restore to, or null if a popup reopened in the meantime (token no
+   * longer matches) or there was nothing pending.
+   */
+  onCloseSettled(tokenAtClose: number): Center | null {
+    if (tokenAtClose !== this.token) return null;
+    const saved = this.savedCenter;
+    this.savedCenter = null;
+    return saved;
+  }
+}

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -103,6 +103,7 @@ import { LightningLayer } from './lightning-layer';
 import { isBlitzortungLoaded } from './lightning-helpers';
 import { getRegionWarnings } from './region-warning';
 import { resolveCardLayout, isValidCssSize } from './card-layout';
+import { PopupPanRestore } from './popup-pan-restore';
 import { isOnlyKeysChanged } from './config-diff';
 import {
   PROGRESS_BAR_TRACK_HEIGHT,
@@ -200,6 +201,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
   private _wildfireLayer: WildfireLayer | null = null;
   private _alertsLayer: NwsAlertsLayer | null = null;
   private _lightningLayer: LightningLayer | null = null;
+  private _popupPanRestore = new PopupPanRestore<L.LatLng>();
 
   // True while the user is actively editing this card via HA's edit dialog.
   // Detected via window-level events from the editor element's lifecycle —
@@ -708,6 +710,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     this._viewerState?.ensureIdentity();
     this._setupToolbar();
     this._setupNavListeners();
+    this._setupPopupPanRestore();
     this._setupDoubleTapAction();
     void this._hydrateViewerState();
     this._setupVisibilityObserver();
@@ -1284,6 +1287,29 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
         this._pushCenterToEditor();
       }
       this._userMoveInProgress = false;
+    });
+  }
+
+  // Hazard-layer popups (lightning/wildfire/NWS-alerts) still use Leaflet's
+  // autoPan to keep an off-edge popup fully visible — the popup itself has
+  // no "reposition instead of panning" mode, and the alternative (shifting
+  // the popup's own on-screen position) decouples its pointer tip from the
+  // feature it's anchored to. Instead: let autoPan move the view as before,
+  // then put the view back once the user is done with the popup, so
+  // browsing hazard popups near the map edge doesn't leave it shifted.
+  // Decision logic (when to restore vs. defer to a popup switch) lives in
+  // PopupPanRestore — see popup-pan-restore.ts for the full rationale.
+  private _setupPopupPanRestore(): void {
+    const map = this._map;
+    if (!map) return;
+    map.on('popupopen', () => this._popupPanRestore.onOpen(() => map.getCenter()));
+    map.on('popupclose', () => {
+      const token = this._popupPanRestore.onClose();
+      setTimeout(() => {
+        const saved = this._popupPanRestore.onCloseSettled(token);
+        if (!saved || this._map !== map) return;   // superseded, or torn down / reinitialised
+        map.panTo(saved);
+      }, 0);
     });
   }
 

--- a/tests/popup-pan-restore.test.ts
+++ b/tests/popup-pan-restore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { PopupPanRestore } from '../src/popup-pan-restore';
+
+describe('PopupPanRestore', () => {
+  it('restores the center captured before the popup opened', () => {
+    const r = new PopupPanRestore<string>();
+    r.onOpen(() => 'A');
+    const token = r.onClose();
+    expect(r.onCloseSettled(token)).toBe('A');
+  });
+
+  it('returns null when settled with no pending close', () => {
+    const r = new PopupPanRestore<string>();
+    expect(r.onCloseSettled(0)).toBeNull();
+  });
+
+  it('a reopen before the settle tick cancels the pending restore (switching popups)', () => {
+    const r = new PopupPanRestore<string>();
+    r.onOpen(() => 'A');
+    const token = r.onClose();
+    r.onOpen(() => 'B');   // switched directly to another popup — same tick, Leaflet's autoClose order
+    expect(r.onCloseSettled(token)).toBeNull();
+  });
+
+  it('a chain of switches restores once, to the pre-chain center', () => {
+    const r = new PopupPanRestore<string>();
+    r.onOpen(() => 'A');
+    const t1 = r.onClose();
+    r.onOpen(() => 'B');           // A -> B, cancels t1
+    expect(r.onCloseSettled(t1)).toBeNull();
+    const t2 = r.onClose();
+    r.onOpen(() => 'C');           // B -> C, cancels t2; still doesn't overwrite saved 'A'
+    expect(r.onCloseSettled(t2)).toBeNull();
+    const t3 = r.onClose();        // C closes for good
+    expect(r.onCloseSettled(t3)).toBe('A');
+  });
+
+  it('a fresh open/close cycle after a completed restore captures a new center', () => {
+    const r = new PopupPanRestore<string>();
+    r.onOpen(() => 'A');
+    expect(r.onCloseSettled(r.onClose())).toBe('A');
+
+    r.onOpen(() => 'B');
+    expect(r.onCloseSettled(r.onClose())).toBe('B');
+  });
+
+  it('getCenter is only invoked on the first open of a chain', () => {
+    const r = new PopupPanRestore<string>();
+    let calls = 0;
+    const getCenter = () => { calls++; return 'A'; };
+    r.onOpen(getCenter);
+    r.onOpen(getCenter);
+    r.onOpen(getCenter);
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Hazard-layer popups (lightning/wildfire/NWS-alerts) near the map edge still use Leaflet's autoPan to stay fully visible — no built-in way to reposition a popup within the viewport instead, and shifting the popup's own position would decouple its pointer tip from the feature it's anchored to.
- Instead: let autoPan move the view as before, then restore it once the user closes the popup, so browsing hazard popups near the edge doesn't leave the map shifted.
- The restore/cancel decision logic is extracted into `PopupPanRestore` — a pure, Leaflet-free class (unit tested) that handles the case where switching directly between two popups should cancel the pending restore rather than snap back and immediately pan away again.

## Test plan
- [x] `tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (649/649)
- [x] `npm run build`
- [x] Manual smoke test in the HA docker testbed: pan-then-restore and popup-switching both verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)