### PR TITLE
fix: add SELinux :Z labels to docker-compose volume mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,6 @@ services:
     ports:
       - "8123:8123"
     volumes:
-      - ./.dev/ha-config:/config
-      - ./dist:/config/www/community/weather-radar-card:ro
+      - ./.dev/ha-config:/config:Z
+      - ./dist:/config/www/community/weather-radar-card:ro,Z
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
## Summary

- Add `:Z` SELinux labels to the bind-mount volumes in `docker-compose.yml` so the HA container can write to `/config` on Fedora/RHEL with SELinux enforcing and rootless Podman.
- Without the labels, HA crash-loops with `Fatal Error: Unable to create library directory /config/deps: [Errno 13] Permission denied`.

## Test plan

- [x] Verified on Fedora 40 with SELinux enforcing + rootless Podman: `npm run ha:up` starts HA successfully
- [ ] No-op on Docker Desktop (`:Z` is silently ignored when SELinux is not active)

## Risk

None for Docker Desktop users — `:Z` is ignored when SELinux is absent. Podman on SELinux-enforcing systems goes from broken to working.

## Docs touched

- n/a — internal dev tooling change

🤖 Generated with [Claude Code](https://claude.com/claude-code)