### PR TITLE
fix(dev): load card as Lovelace resource for HA 2024.8+ compat

### DIFF
--- a/.dev/configuration.yaml.example
+++ b/.dev/configuration.yaml.example
@@ -5,11 +5,10 @@
 
 default_config:
 
-# Auto-load the card from the bind-mounted dist/ — no need to add it as a
-# Lovelace resource through the UI on each fresh start.
-frontend:
-  extra_module_url:
-    - /local/community/weather-radar-card/weather-radar-card.js
+# The card is auto-loaded as a Lovelace resource via the pre-seeded
+# .storage/lovelace_resources file (copied by `npm run ha:init`).
+# This matches how HACS loads cards and works with HA's scoped
+# custom element registry (2024.8+).
 
 # Set country to enable the US-only overlays (wildfires, NWS alerts) for
 # end-to-end testing. Set to your own country code for region-warning checks.

--- a/.dev/lovelace_resources.json
+++ b/.dev/lovelace_resources.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "lovelace_resources",
+  "data": {
+    "items": [
+      {
+        "id": "weather_radar_card",
+        "type": "module",
+        "url": "/local/community/weather-radar-card/weather-radar-card.js"
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "ha:init": "mkdir -p .dev/ha-config && cp -n .dev/configuration.yaml.example .dev/ha-config/configuration.yaml || true",
+    "ha:init": "mkdir -p .dev/ha-config/.storage && cp -n .dev/configuration.yaml.example .dev/ha-config/configuration.yaml || true && cp -n .dev/lovelace_resources.json .dev/ha-config/.storage/lovelace_resources || true",
     "ha:up": "npm run ha:init && docker compose up -d && echo 'HA starting at http://localhost:8123 (first boot may take a minute)'",
     "ha:down": "docker compose down",
     "ha:logs": "docker compose logs -f ha",


### PR DESCRIPTION
## Summary

- Switch the dev testbed from `frontend: extra_module_url` to a pre-seeded
  Lovelace resource file (`.dev/lovelace_resources.json`), matching how HACS
  loads cards.
- HA 2024.8+ introduced a scoped custom element registry. Cards loaded via
  `extra_module_url` run before the scoped registry is ready, so
  `customElements.define` registers globally but is invisible to Lovelace
  shadow roots — the card never renders.
- The `ha:init` script now copies the resource file into
  `.storage/lovelace_resources` alongside the existing config copy.
- Existing dev environments need `npm run ha:reset` followed by `npm run ha:up`.

## Test plan

- [x] `npm run ha:reset && npm run ha:up` — fresh HA starts, card loads
- [x] Add weather-radar-card to a dashboard — renders without
      "Custom element doesn't exist" error
- [x] Verify version banner prints in browser console
- [x] Confirm `npm run build && npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)