### PR TITLE
chore(release): 3.7.3-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.3-beta1] - 2026-07-15
+
+> **Beta pre-release.** New opt-in `start_paused` option, plus a small editor/toolbar fix for single-frame configs. Drop-in upgrade from 3.7.2 — no config changes required.
+
 ### Added
 
-- **`start_paused` option** — start the card paused on the latest radar frame instead of auto-playing the animation loop. The card still refreshes periodically so the displayed frame stays current; tap play to see the full animation. Configurable via YAML or the visual editor's Animation section.
+- **`start_paused` option** — start the card paused on the latest radar frame instead of auto-playing the animation loop. The card still refreshes periodically so the displayed frame stays current; tap play to see the full animation. Configurable via YAML or the visual editor's Animation section. Contributed by [@knobunc](https://github.com/knobunc).
 
 ### Fixed
 
@@ -863,7 +867,8 @@ Multi-marker overhaul. **Breaking:** single-marker config fields (`show_marker`,
 
 For changes in versions prior to 2.0.4, please refer to the git commit history.
 
-[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.2...HEAD
+[Unreleased]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.3-beta1...HEAD
+[3.7.3-beta1]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.2...v3.7.3-beta1
 [3.7.2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.2-beta1...v3.7.2
 [3.7.2-beta2]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.2-beta1...23d64b4
 [3.7.2-beta1]: https://github.com/jpettitt/weather-radar-card/compare/v3.7.1...v3.7.2-beta1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.7.2",
+  "version": "3.7.3-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.7.2",
+      "version": "3.7.3-beta1",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.7.2",
+  "version": "3.7.3-beta1",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (schneller)",
       "playback_speed_quad": "4× (am schnellsten)",
+      "start_paused": "Pausiert starten (Live-Momentaufnahme)",
+      "start_paused_helper": "Zeigt zunächst nur das neueste Radarbild ohne Animation. Das Bild wird automatisch aktualisiert, sobald neue Daten eintreffen. Zum Abspielen der vollständigen Animation auf Wiedergabe tippen.",
       "viewer_layer_control": "Speicherung pro Benutzer (Admin-Opt-in)",
       "viewer_layer_control_helper": "Wenn aktiviert, wird die Wahl der Geschwindigkeitstaste pro Benutzer gespeichert und folgt ihm über den Frontend-Speicher von Home Assistant auf alle Browser und Geräte. Wenn deaktiviert, funktioniert die Taste weiterhin für die aktuelle Sitzung, die Wahl wird aber nicht gespeichert.",
       "motion_compensation": "Bewegungskompensation (Regen zwischen Frames driften lassen)",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (rápido)",
       "playback_speed_quad": "4× (más rápido)",
+      "start_paused": "Iniciar en pausa (instantánea en vivo)",
+      "start_paused_helper": "Muestra solo el último fotograma del radar sin animación. El fotograma se actualiza automáticamente al llegar nuevos datos. Toca reproducir para ver la animación completa.",
       "viewer_layer_control": "Persistencia por usuario (activación por admin)",
       "viewer_layer_control_helper": "Si está activado, la elección del botón de velocidad se guarda por usuario y le sigue en todos los navegadores y dispositivos mediante el almacenamiento del frontend de Home Assistant. Si está desactivado, el botón sigue funcionando durante la sesión actual pero la elección no se guarda.",
       "motion_compensation": "Compensación de movimiento (desplazar la lluvia entre fotogramas)",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normale)",
       "playback_speed_double": "2× (plus rapide)",
       "playback_speed_quad": "4× (le plus rapide)",
+      "start_paused": "Démarrer en pause (instantané en direct)",
+      "start_paused_helper": "Affiche uniquement la dernière image radar sans animation. L'image se met à jour automatiquement à l'arrivée de nouvelles données. Appuyez sur lecture pour voir l'animation complète.",
       "viewer_layer_control": "Persistance par utilisateur (activation par l'admin)",
       "viewer_layer_control_helper": "Si activé, le choix du bouton de vitesse est mémorisé par utilisateur et le suit sur tous les navigateurs et appareils via le stockage du frontend Home Assistant. Si désactivé, le bouton fonctionne toujours pour la session en cours mais le choix n'est pas enregistré.",
       "motion_compensation": "Compensation de mouvement (dérive de la pluie entre les images)",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normale)",
       "playback_speed_double": "2× (veloce)",
       "playback_speed_quad": "4× (più veloce)",
+      "start_paused": "Avvia in pausa (istantanea dal vivo)",
+      "start_paused_helper": "Mostra solo l'ultimo fotogramma radar senza animazione. Il fotogramma si aggiorna automaticamente all'arrivo di nuovi dati. Tocca riproduci per vedere l'animazione completa.",
       "viewer_layer_control": "Persistenza per utente (opt-in amministratore)",
       "viewer_layer_control_helper": "Se attivo, la scelta del pulsante velocità viene salvata per utente e lo segue su browser e dispositivi tramite l’archiviazione del frontend di Home Assistant. Se disattivato il pulsante funziona comunque per la sessione corrente ma la scelta non viene salvata.",
       "motion_compensation": "Compensazione del movimento (deriva della pioggia tra i fotogrammi)",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (raskere)",
       "playback_speed_quad": "4× (raskest)",
+      "start_paused": "Start pauset (direkte øyeblikksbilde)",
+      "start_paused_helper": "Vis kun det nyeste radarbildet uten animasjon. Bildet oppdateres automatisk når nye data kommer inn. Trykk på avspilling for å se hele animasjonssløyfen.",
       "viewer_layer_control": "Lagring per bruker (admin må aktivere)",
       "viewer_layer_control_helper": "Når aktivert lagres hastighetsknappens valg per bruker og følger dem på tvers av nettlesere og enheter via Home Assistants frontend-lagring. Når av fungerer knappen fortsatt for gjeldende økt, men valget lagres ikke.",
       "motion_compensation": "Bevegelseskompensasjon (la regnet drive mellom bilder)",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normaal)",
       "playback_speed_double": "2× (sneller)",
       "playback_speed_quad": "4× (snelst)",
+      "start_paused": "Gepauzeerd starten (live momentopname)",
+      "start_paused_helper": "Toon alleen het nieuwste radarbeeld zonder animatie. Het beeld wordt automatisch bijgewerkt zodra nieuwe gegevens binnenkomen. Tik op afspelen om de volledige animatie te zien.",
       "viewer_layer_control": "Opslag per gebruiker (admin-opt-in)",
       "viewer_layer_control_helper": "Indien ingeschakeld wordt de keuze van de snelheidsknop per gebruiker opgeslagen en volgt deze hen op alle browsers en apparaten via de frontend-opslag van Home Assistant. Indien uitgeschakeld werkt de knop nog steeds voor de huidige sessie, maar wordt de keuze niet bewaard.",
       "motion_compensation": "Bewegingscompensatie (regen laten driften tussen frames)",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normalnie)",
       "playback_speed_double": "2× (szybciej)",
       "playback_speed_quad": "4× (najszybciej)",
+      "start_paused": "Start wstrzymany (zrzut na żywo)",
+      "start_paused_helper": "Pokazuje tylko najnowszą klatkę radaru bez animacji. Klatka aktualizuje się automatycznie po napłynięciu nowych danych. Dotknij odtwarzania, aby zobaczyć pełną animację.",
       "viewer_layer_control": "Zapamiętywanie dla użytkownika (włączane przez administratora)",
       "viewer_layer_control_helper": "Po włączeniu wybór przycisku prędkości jest zapisywany dla każdego użytkownika i podąża za nim między przeglądarkami i urządzeniami poprzez magazyn frontendu Home Assistant. Po wyłączeniu przycisk nadal działa w bieżącej sesji, ale wybór nie jest zapisywany.",
       "motion_compensation": "Kompensacja ruchu (przesuwanie deszczu między klatkami)",

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (rápido)",
       "playback_speed_quad": "4× (mais rápido)",
+      "start_paused": "Iniciar pausado (instantâneo ao vivo)",
+      "start_paused_helper": "Mostra apenas o quadro mais recente do radar sem animação. O quadro é atualizado automaticamente conforme novos dados chegam. Toque em reproduzir para ver a animação completa.",
       "viewer_layer_control": "Persistência por usuário (ativação pelo admin)",
       "viewer_layer_control_helper": "Quando ativado, a escolha do botão de velocidade é salva por usuário e o acompanha em navegadores e dispositivos via armazenamento do frontend do Home Assistant. Quando desativado, o botão ainda funciona na sessão atual, mas a escolha não é salva.",
       "motion_compensation": "Compensação de movimento (deriva da chuva entre quadros)",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normálne)",
       "playback_speed_double": "2× (rýchlejšie)",
       "playback_speed_quad": "4× (najrýchlejšie)",
+      "start_paused": "Spustiť pozastavené (živá snímka)",
+      "start_paused_helper": "Zobrazí iba najnovšiu snímku radaru bez animácie. Snímka sa automaticky aktualizuje pri príchode nových údajov. Ťuknutím na prehrávanie zobrazíte celú animáciu.",
       "viewer_layer_control": "Ukladanie pre používateľa (zapína administrátor)",
       "viewer_layer_control_helper": "Ak je zapnuté, voľba tlačidla rýchlosti sa ukladá pre každého používateľa a nasleduje ho naprieč prehliadačmi a zariadeniami cez frontendové úložisko Home Assistant. Ak je vypnuté, tlačidlo stále funguje v aktuálnej relácii, ale voľba sa neuloží.",
       "motion_compensation": "Kompenzácia pohybu (posúvanie dažďa medzi snímkami)",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -181,6 +181,8 @@
       "playback_speed_normal": "1× (normal)",
       "playback_speed_double": "2× (snabbare)",
       "playback_speed_quad": "4× (snabbast)",
+      "start_paused": "Starta pausad (direktbild)",
+      "start_paused_helper": "Visa endast den senaste radarbilden utan animering. Bilden uppdateras automatiskt när ny data kommer in. Tryck på uppspelning för att se hela animeringsloopen.",
       "viewer_layer_control": "Sparas per användare (admin måste aktivera)",
       "viewer_layer_control_helper": "När aktiverat sparas hastighetsknappens val per användare och följer dem mellan webbläsare och enheter via Home Assistants frontend-lagring. När avstängt fungerar knappen fortfarande under pågående session men valet sparas inte.",
       "motion_compensation": "Rörelsekompensering (låt regnet driva mellan bildrutor)",


### PR DESCRIPTION
Release prep for **v3.7.3-beta1** — feature/fix beta on top of 3.7.2.

- Bump `package.json` 3.7.2 → 3.7.3-beta1 (lockfile synced)
- Promote CHANGELOG `[Unreleased]` → `[3.7.3-beta1]` (dated, compare link)
- Translate `start_paused`/`start_paused_helper` into all 10 non-English locales (previously English-only)

Contents: `start_paused` option (#216, contributed by @knobunc) + `show_playback` single-frame editor/toolbar fix (#221).