### PR TITLE
fix(radar): distinguish 5xx server errors from rate-limiting, fix banner lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A source's own server errors (502/503/504) no longer show as "Rate limited."** A tile fetch that failed with a generic non-OK status wasn't tagged with its HTTP status code, so it fell into the same handling as a rate-limit response — wrong banner, wrong retry pacing for a server that's up but struggling rather than one we're self-throttling against. 5xx responses now get their own "Radar server error — retrying" banner and a longer, capped exponential backoff (up to ~30s between attempts) better suited to a transient outage. ([#223](https://github.com/jpettitt/weather-radar-card/issues/223))
+- **Both the rate-limit and (new) server-error banners now clear themselves as soon as a tile loads successfully again**, instead of the rate-limit banner sitting there indefinitely (it previously had no hide path at all) or waiting on a fixed 10-second timer. Recovering also cancels the rate-limit path's fallback full-reinit, so a freshly-recovered loop isn't torn down and rebuilt for no reason. If both conditions are detected at once, each still shows its own banner, but only one (whichever is more informative) drives the disruptive fallback reinit — a confirmed server error suppresses it, since the per-tile backoff is already handling recovery and a forced reinit would only add load to a struggling server.
+
 ## [3.7.3-beta1] - 2026-07-15
 
 > **Beta pre-release.** New opt-in `start_paused` option, plus a small editor/toolbar fix for single-frame configs. Drop-in upgrade from 3.7.2 — no config changes required.

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -54,6 +54,8 @@ The colour-bar uses DWD's `Niederschlagsradar` palette sampled from DWD's offici
 
 > **Forecast leading edge:** when `forecast_minutes > 0`, the newest frames in the timeline are timestamped in the future. DWD's WMS only returns tiles for frames its nowcast has actually computed; if a future timestamp is past the nowcast horizon (or hasn't been published yet), those tiles come back transparent and you'll see a brief blank section at the leading edge of the loop. This resolves itself as DWD publishes new forecast frames.
 
+`maps.dwd.de` occasionally answers tile requests with a 502/503/504 during periods of high load — this is on DWD's server, not the card. The card detects this (distinct from its own rate-limit pacing) and retries automatically with a backoff of up to ~30 seconds per tile; a "Radar server error — retrying" banner shows while this is happening and clears once tiles load normally again.
+
 ## Why source-agnostic time fields
 
 Earlier versions used a single `frame_count` config: 6 frames meant "the last hour" on RainViewer (6 × 10 min) but "30 minutes" on NOAA / DWD (6 × 5 min). Switching `data_source` silently changed how much history showed.

--- a/src/fetch-tile-layer.ts
+++ b/src/fetch-tile-layer.ts
@@ -9,7 +9,24 @@ export interface FetchTileOptions extends L.TileLayerOptions {
   rateLimiter?: RateLimiter;
   maxRetries?: number;
   retryDelay?: number;
+  /** Cap on retries for a 5xx (server error) response — see on5xx. */
+  maxServerErrorRetries?: number;
   on429?: () => void;
+  /**
+   * Called when a tile fetch resolves with a 5xx status (502/503/504…).
+   * Distinct from on429: the server IS responding, just can't serve
+   * right now, so this gets its own longer, capped-exponential-backoff
+   * retry instead of either the rate-limit pacing or the short generic
+   * maxRetries window.
+   */
+  on5xx?: () => void;
+  /**
+   * Called on any successful tile load — the signal that a prior on429 /
+   * on5xx condition has cleared. Fires unconditionally (harmless if
+   * neither was ever triggered); the caller decides what "recovered"
+   * means for its own banner/timer state.
+   */
+  onTileRecovered?: () => void;
   /** When true, Leaflet's _updateOpacity is suppressed so CSS animations own opacity. */
   animationOwnsOpacity?: boolean;
   /**
@@ -90,8 +107,11 @@ export function createFetchTile(
   const opts = layer.options as FetchTileOptions;
   const maxRetries = opts.maxRetries ?? 3;
   const retryDelay = opts.retryDelay ?? 500;
+  const maxServerErrorRetries = opts.maxServerErrorRetries ?? 6;
   const limiter = opts.rateLimiter;
-        const on429 = opts.on429;
+  const on429 = opts.on429;
+  const on5xx = opts.on5xx;
+  const onTileRecovered = opts.onTileRecovered;
   let attempt = 0;
 
   layer._tilePending++;
@@ -124,7 +144,7 @@ export function createFetchTile(
       .then((r) => {
         if (r.status === 404) { const e: any = new Error('404'); e.status = 404; throw e; }
         if (r.status === 429) { const e: any = new Error('429'); e.status = 429; throw e; }
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        if (!r.ok) { const e: any = new Error(`HTTP ${r.status}`); e.status = r.status; throw e; }
         // Soft-error tiles: NOAA's WMS sometimes answers 200 OK with a
         // small text/xml error document instead of a PNG (observed
         // ~240 bytes; likely a rate-limit the server doesn't surface
@@ -157,6 +177,7 @@ export function createFetchTile(
         tile.onerror = () => URL.revokeObjectURL(objUrl);
         tile.src = objUrl;
         limiter?.recordSuccess(url);
+        onTileRecovered?.();
         layer._tilePending--;
         layer._tileLoaded++;
         tile.__wrcAbort = null;
@@ -181,6 +202,18 @@ export function createFetchTile(
           on429?.();
           const wait = limiter ? Math.max(limiter.msUntilSlot(), 1000) : 5000;
           setTimeout(tryFetch, wait);
+        } else if (err.status && err.status >= 500 && err.status < 600) {
+          // Genuine server error (502/503/504…) — the server IS responding,
+          // just can't serve right now. Distinct from on429 (self-imposed
+          // rate-limiting) and the generic path below (a handful of quick
+          // retries): capped exponential backoff, more patient since an
+          // outage like this is often transient but can outlast maxRetries.
+          on5xx?.();
+          if (++attempt < maxServerErrorRetries) {
+            setTimeout(tryFetch, Math.min(1000 * 2 ** (attempt - 1), 30_000));
+          } else {
+            fail();
+          }
         } else if (++attempt < maxRetries) {
           setTimeout(tryFetch, retryDelay * attempt);
         } else {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -4,6 +4,7 @@
   },
   "ui": {
     "rate_limited": "Rate limited — waiting for quota to reset",
+    "server_error": "Radar server error — retrying",
     "loading_radar_tiles": "Loading radar tiles",
     "now": "(latest)",
     "now_tooltip": "Latest",

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -417,6 +417,8 @@ export class RadarPlayer {
   // Rate-limit state
   private _rateLimitTimer: ReturnType<typeof setTimeout> | null = null;
   private _isRateLimited = false;
+  // Server-error (5xx) state — see the "Server error banner" section below.
+  private _isServerError = false;
 
   // Toolbar reference (set externally after toolbar is created)
   toolbar: RadarToolbar | null = null;
@@ -1657,6 +1659,11 @@ export class RadarPlayer {
   }
 
   // ── Rate limit banner ────────────────────────────────────────────────────
+  // The 10s-later full reinit is a fallback for the case where nothing
+  // ever recovers on its own; _onTileRecovered (below) normally clears
+  // the banner and cancels this timer well before it fires, the instant
+  // any tile succeeds again, so the reinit doesn't fire redundantly on
+  // top of an already-healthy loop.
 
   private _showRateLimitBanner(show: boolean): void {
     const banner = this._shadowRoot.getElementById('rate-limit-banner');
@@ -1667,6 +1674,12 @@ export class RadarPlayer {
     if (this._isRateLimited) return;
     this._isRateLimited = true;
     this._showRateLimitBanner(true);
+    // A confirmed server error (below) already explains what's going on
+    // and is already patiently backing off per-tile — don't ALSO arm the
+    // aggressive full-reinit fallback on top of it, which would tear
+    // down a loop mid-outage and add load to a server that's struggling.
+    // The banner above still shows (this condition is real either way).
+    if (this._isServerError) return;
     if (this._rateLimitTimer) clearTimeout(this._rateLimitTimer);
     this._rateLimitTimer = setTimeout(() => this._retryAfterRateLimit(), 10_000);
   }
@@ -1674,8 +1687,52 @@ export class RadarPlayer {
   private _retryAfterRateLimit(): void {
     this._isRateLimited = false;
     this._rateLimitTimer = null;
+    this._showRateLimitBanner(false);
     this._clearLayers();
     this._initRadar();
+  }
+
+  // ── Server error banner ──────────────────────────────────────────────────
+  // Distinct from the rate-limit banner above: a 5xx means the source's
+  // server is up but struggling, not that we've hit our own pacing limit.
+  // Tile-level retries (fetch-tile-layer.ts) handle recovery on their own
+  // with a capped backoff; this just reflects that state in the UI.
+
+  private _showServerErrorBanner(show: boolean): void {
+    const banner = this._shadowRoot.getElementById('server-error-banner');
+    if (banner) banner.style.display = show ? 'block' : 'none';
+  }
+
+  private _onServerError(): void {
+    if (!this._isServerError) {
+      this._isServerError = true;
+      this._showServerErrorBanner(true);
+    }
+    // A confirmed 5xx is better information than "presumed rate limit
+    // from a statusless failure" — cancel any pending forced reinit
+    // (armed by an earlier _onRateLimited) so we don't tear down a loop
+    // that's already correctly backing off per-tile. Runs on every call,
+    // not just the first: _onRateLimited can re-arm the timer from a
+    // different tile after this fires once.
+    if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
+  }
+
+  // ── Tile recovery ────────────────────────────────────────────────────────
+  // Fired on every successful tile load (see fetch-tile-layer.ts's
+  // onTileRecovered). Clears whichever error banner(s) are currently up
+  // and, for rate-limiting, cancels the pending fallback reinit — a tile
+  // succeeding is direct evidence we're no longer limited, so there's
+  // nothing left for that timer to fix.
+  private _onTileRecovered(): void {
+    if (this._isServerError) {
+      this._isServerError = false;
+      this._showServerErrorBanner(false);
+    }
+    if (this._isRateLimited) {
+      this._isRateLimited = false;
+      this._showRateLimitBanner(false);
+      if (this._rateLimitTimer) { clearTimeout(this._rateLimitTimer); this._rateLimitTimer = null; }
+    }
   }
 
   // ── Layer helpers ────────────────────────────────────────────────────────
@@ -1785,6 +1842,8 @@ export class RadarPlayer {
       maxNativeZoom: 8 + Math.max(0, -zoomOffset),
       rateLimiter: this._dwdLimiter,
       on429: () => this._onRateLimited(),
+      on5xx: () => this._onServerError(),
+      onTileRecovered: () => this._onTileRecovered(),
       animationOwnsOpacity: true,
       pane: 'dwd-coverage-mask',
       pixelFilter: makeDwdMaskOnlyFilter(layerName, dim, outline),
@@ -2090,6 +2149,8 @@ export class RadarPlayer {
         maxNativeZoom: 7 + Math.max(0, -zoomOffset),
         rateLimiter: this._noaaLimiter,
         on429: () => this._onRateLimited(),
+        on5xx: () => this._onServerError(),
+        onTileRecovered: () => this._onTileRecovered(),
         animationOwnsOpacity: true,
         pane: RADAR_PANE_NAME,
       } as any));
@@ -2112,6 +2173,8 @@ export class RadarPlayer {
         maxNativeZoom: 8 + Math.max(0, -zoomOffset),
         rateLimiter: this._dwdLimiter,
         on429: () => this._onRateLimited(),
+        on5xx: () => this._onServerError(),
+        onTileRecovered: () => this._onTileRecovered(),
         animationOwnsOpacity: true,
         pixelFilter: makeDwdMaskFilter(layerName),
         pane: RADAR_PANE_NAME,
@@ -2131,6 +2194,8 @@ export class RadarPlayer {
       maxNativeZoom: 7 + Math.max(0, -zoomOffset),
       rateLimiter: this._rainviewerLimiter,
       on429: () => this._onRateLimited(),
+      on5xx: () => this._onServerError(),
+      onTileRecovered: () => this._onTileRecovered(),
       animationOwnsOpacity: true,
       pane: RADAR_PANE_NAME,
     } as any));

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -630,6 +630,9 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
           <div id="rate-limit-banner" class="status-banner" style="display:none">
             ${localize('ui.rate_limited')}
           </div>
+          <div id="server-error-banner" class="status-banner" style="display:none">
+            ${localize('ui.server_error')}
+          </div>
         </div>
         <div id="mapid"></div>
         <div id="div-progress-bar" style="height:${PROGRESS_BAR_TRACK_HEIGHT}px;display:${this._config.show_progress_bar === false ? 'none' : 'block'}">

--- a/tests/error-banners.test.ts
+++ b/tests/error-banners.test.ts
@@ -1,0 +1,242 @@
+// Tests for the rate-limit / server-error banner lifecycle on RadarPlayer.
+//
+// Regression coverage for two things fixed together (issue #223):
+//   1. A 5xx (server error) used to be indistinguishable from a 429
+//      (rate limit) once the fetch error lost its status code — see
+//      tests/fetch-abort.test.ts for the fetch-layer half of this.
+//   2. The rate-limit banner never explicitly hid itself once shown —
+//      it just sat there until the next full teardown/rebuild. Both
+//      banners now clear the instant any tile succeeds again, via the
+//      same onTileRecovered signal, and that recovery also cancels the
+//      rate-limit path's fallback reinit timer so a freshly-recovered
+//      loop doesn't get torn down 10s later for no reason.
+//
+// Follows the "stub Leaflet, test the helpers" convention. Private
+// methods are reached via `as any` (TS-private is compile-time only).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('leaflet', () => {
+  class Layer {}
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as unknown as { WMS: typeof WMS }).WMS = WMS;
+  class Control {
+    constructor(_opts?: unknown) { void _opts; }
+  }
+  const DomUtil = { create: vi.fn(() => ({ style: {}, classList: { add: vi.fn() } })) };
+  const DomEvent = { disableClickPropagation: vi.fn(), on: vi.fn() };
+  return {
+    Layer, TileLayer, Control, DomUtil, DomEvent,
+    default: { Layer, TileLayer, Control, DomUtil, DomEvent },
+  };
+});
+
+import { RadarPlayer } from '../src/radar-player';
+import type { WeatherRadarCardConfig } from '../src/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// A minimal DOM stand-in: getElementById returns a stable per-id element
+// (style object survives across calls, like a real shadow root) rather
+// than a fresh object each time.
+function makeShadowRoot(): { getElementById: (id: string) => any; host: unknown } {
+  const elements = new Map<string, { style: Record<string, string> }>();
+  return {
+    getElementById: (id: string) => {
+      if (!elements.has(id)) elements.set(id, { style: {} });
+      return elements.get(id);
+    },
+    host: {},
+  };
+}
+
+function makePlayer(shadowRoot: ReturnType<typeof makeShadowRoot>): RadarPlayer {
+  const map = {
+    on: vi.fn(),
+    off: vi.fn(),
+    getZoom: () => 7,
+    getSize: () => ({ x: 600, y: 400 }),
+    getPane: vi.fn(),
+    createPane: vi.fn(() => ({ style: {} })),
+    getContainer: () => ({ getBoundingClientRect: () => ({ left: 0, top: 0 }) }),
+  } as any;
+  return new RadarPlayer({
+    map,
+    shadowRoot: shadowRoot as any,
+    getConfig: () => ({ type: 'custom:weather-radar-card' } as WeatherRadarCardConfig),
+    rainviewerLimiter: {} as any,
+    noaaLimiter: {} as any,
+    dwdLimiter: {} as any,
+  });
+}
+
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+describe('rate-limit banner', () => {
+  it('shows on _onRateLimited and hides on _onTileRecovered', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+
+    p._onRateLimited();
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('block');
+
+    p._onTileRecovered();
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('none');
+    expect(p._isRateLimited).toBe(false);
+  });
+
+  it('cancels the fallback reinit timer on recovery — no redundant teardown of a healthy loop', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onRateLimited();
+    p._onTileRecovered();
+
+    // The 10s fallback would otherwise fire here.
+    vi.advanceTimersByTime(10_000);
+    expect(p._clearLayers).not.toHaveBeenCalled();
+    expect(p._initRadar).not.toHaveBeenCalled();
+  });
+
+  it('without recovery, the 10s fallback still tears down and reinitialises', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onRateLimited();
+    vi.advanceTimersByTime(10_000);
+
+    expect(p._clearLayers).toHaveBeenCalledOnce();
+    expect(p._initRadar).toHaveBeenCalledOnce();
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('none');
+    expect(p._isRateLimited).toBe(false);
+  });
+
+  it('a second _onRateLimited while already showing does not reset the fallback timer', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onRateLimited();
+    vi.advanceTimersByTime(6_000);
+    p._onRateLimited(); // still rate-limited — guarded no-op, timer untouched
+    vi.advanceTimersByTime(4_000); // total 10s from the FIRST call
+
+    expect(p._clearLayers).toHaveBeenCalledOnce();
+  });
+});
+
+describe('server-error banner', () => {
+  it('shows on _onServerError and hides on _onTileRecovered', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+
+    p._onServerError();
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBe('block');
+
+    p._onTileRecovered();
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBe('none');
+    expect(p._isServerError).toBe(false);
+  });
+
+  it('has no forced reinit — recovery is purely the banner clearing', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onServerError();
+    p._onTileRecovered();
+    vi.advanceTimersByTime(60_000);
+
+    expect(p._clearLayers).not.toHaveBeenCalled();
+    expect(p._initRadar).not.toHaveBeenCalled();
+  });
+});
+
+describe('cross-transitions between the two banners', () => {
+  it('a 5xx arriving while rate-limited cancels the pending fallback reinit', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onRateLimited(); // arms the 10s fallback reinit
+    vi.advanceTimersByTime(5_000); // partway through the wait
+    p._onServerError(); // a different tile comes back with a genuine 502
+
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('block');
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBe('block');
+
+    // The fallback would have fired at the 10s mark; it must not now.
+    vi.advanceTimersByTime(10_000);
+    expect(p._clearLayers).not.toHaveBeenCalled();
+    expect(p._initRadar).not.toHaveBeenCalled();
+  });
+
+  it('a 429 arriving while a server error is active shows its banner but arms no reinit', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onServerError(); // known server-side outage, no timer scheduled
+    p._onRateLimited(); // a different tile also comes back statusless/429
+
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBe('block');
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('block');
+
+    vi.advanceTimersByTime(30_000);
+    expect(p._clearLayers).not.toHaveBeenCalled();
+    expect(p._initRadar).not.toHaveBeenCalled();
+  });
+
+  it('recovering after a 5xx-then-429 sequence clears both banners with no stray timer', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+    p._clearLayers = vi.fn();
+    p._initRadar = vi.fn();
+
+    p._onRateLimited();
+    p._onServerError();
+    p._onTileRecovered();
+
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('none');
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBe('none');
+
+    vi.advanceTimersByTime(30_000);
+    expect(p._clearLayers).not.toHaveBeenCalled();
+    expect(p._initRadar).not.toHaveBeenCalled();
+  });
+});
+
+describe('_onTileRecovered with nothing to recover from', () => {
+  it('is a harmless no-op when neither banner is showing', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+
+    expect(() => p._onTileRecovered()).not.toThrow();
+    // Neither banner was ever shown, so _onTileRecovered's guards mean
+    // .display was never touched at all — not even set to 'none'.
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBeUndefined();
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBeUndefined();
+  });
+
+  it('clears both banners independently when both are active', () => {
+    const shadowRoot = makeShadowRoot();
+    const p = makePlayer(shadowRoot) as any;
+
+    p._onRateLimited();
+    p._onServerError();
+    p._onTileRecovered();
+
+    expect(shadowRoot.getElementById('rate-limit-banner').style.display).toBe('none');
+    expect(shadowRoot.getElementById('server-error-banner').style.display).toBe('none');
+  });
+});

--- a/tests/fetch-abort.test.ts
+++ b/tests/fetch-abort.test.ts
@@ -14,6 +14,7 @@ vi.mock('leaflet', () => {
 });
 
 import { wireAbortLifecycle, createFetchTile, type TileWithAbort } from '../src/fetch-tile-layer';
+import { RateLimiter } from '../src/rate-limiter';
 
 // Regression guards for the AbortController pattern the fetcher code
 // relies on. The actual layer integration (FetchTileLayer, WildfireLayer,
@@ -439,5 +440,135 @@ describe('createFetchTile (fetch-tile-layer)', () => {
     await new Promise((r) => setTimeout(r, 5));
     expect(layer._tileLoaded).toBe(1);
     expect(layer._tileFailed).toBe(0);
+  });
+
+  // ── 5xx server errors vs 429 rate-limiting (issue #223) ─────────────
+  //
+  // A generic `!r.ok` throw didn't tag `.status`, so 502/503/504
+  // responses fell into the same "statusless -> treat as rate-limited"
+  // branch as CORS-opaque 429s: wrong banner, wrong retry pacing for
+  // what's actually a struggling-but-responding server. These lock in
+  // the fix: 5xx gets its own callback and its own capped-backoff retry,
+  // and genuine 429 / CORS-opaque statusless errors are unaffected.
+
+  describe('5xx server errors are distinct from 429 rate-limiting', () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('a 502 calls on5xx (not on429) and retries with backoff', async () => {
+      const layer = makeFetchLayerStub();
+      const on429 = vi.fn();
+      const on5xx = vi.fn();
+      layer.options = { maxRetries: 1, retryDelay: 0, maxServerErrorRetries: 3, on429, on5xx };
+      const done = vi.fn();
+      createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+
+      fetchCalls[0].resolve(new Blob(['bad gateway']), { status: 502 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(on5xx).toHaveBeenCalledOnce();
+      expect(on429).not.toHaveBeenCalled();
+      expect(fetchCalls.length).toBe(1); // retry scheduled (1s backoff), not yet fired
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(fetchCalls.length).toBe(2);
+
+      fetchCalls[1].resolve(
+        new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' }),
+        { status: 200, headers: { 'content-type': 'image/png' } },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(layer._tileLoaded).toBe(1);
+      expect(layer._tileFailed).toBe(0);
+    });
+
+    it('onTileRecovered fires once the tile succeeds after a 5xx', async () => {
+      const layer = makeFetchLayerStub();
+      const onTileRecovered = vi.fn();
+      layer.options = { maxRetries: 1, retryDelay: 0, maxServerErrorRetries: 3, onTileRecovered };
+      const done = vi.fn();
+      createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+
+      fetchCalls[0].resolve(new Blob(['service unavailable']), { status: 503 });
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(fetchCalls.length).toBe(2);
+
+      fetchCalls[1].resolve(
+        new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' }),
+        { status: 200, headers: { 'content-type': 'image/png' } },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onTileRecovered).toHaveBeenCalledOnce();
+    });
+
+    it('onTileRecovered fires on every successful tile load, not just after an error', async () => {
+      const layer = makeFetchLayerStub();
+      const onTileRecovered = vi.fn();
+      layer.options = { maxRetries: 1, retryDelay: 0, onTileRecovered };
+      const done = vi.fn();
+      createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+
+      fetchCalls[0].resolve(
+        new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' }),
+        { status: 200, headers: { 'content-type': 'image/png' } },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onTileRecovered).toHaveBeenCalledOnce();
+    });
+
+    it('exhausts retries and fails after maxServerErrorRetries consecutive 5xx responses', async () => {
+      const layer = makeFetchLayerStub();
+      const on5xx = vi.fn();
+      layer.options = { maxRetries: 1, retryDelay: 0, maxServerErrorRetries: 2, on5xx };
+      const done = vi.fn();
+      createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+
+      fetchCalls[0].resolve(new Blob(['gateway timeout']), { status: 504 });
+      await vi.advanceTimersByTimeAsync(1000); // first retry fires
+      expect(fetchCalls.length).toBe(2);
+
+      fetchCalls[1].resolve(new Blob(['gateway timeout']), { status: 504 });
+      await vi.advanceTimersByTimeAsync(0); // maxServerErrorRetries: 2 -> gives up, no more scheduling
+
+      expect(on5xx).toHaveBeenCalledTimes(2);
+      expect(layer._tileFailed).toBe(1);
+      expect(layer._tileLoaded).toBe(0);
+      expect(done).toHaveBeenCalled();
+    });
+
+    it('a genuine 429 still calls on429, not on5xx', async () => {
+      const layer = makeFetchLayerStub();
+      const on429 = vi.fn();
+      const on5xx = vi.fn();
+      layer.options = { maxRetries: 1, retryDelay: 0, on429, on5xx };
+      const done = vi.fn();
+      createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+
+      fetchCalls[0].resolve(new Blob(['too many requests']), { status: 429 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(on429).toHaveBeenCalledOnce();
+      expect(on5xx).not.toHaveBeenCalled();
+    });
+
+    it('a CORS-opaque statusless error with a rate limiter still calls on429, not on5xx', async () => {
+      const layer = makeFetchLayerStub();
+      const on429 = vi.fn();
+      const on5xx = vi.fn();
+      layer.options = {
+        maxRetries: 1, retryDelay: 0,
+        rateLimiter: new RateLimiter(500),
+        on429, on5xx,
+      };
+      const done = vi.fn();
+      createFetchTile.call(layer as never, { x: 0, y: 0, z: 0 } as never, done);
+
+      // No status set — mirrors a CORS-opaque response the browser blocked.
+      fetchCalls[0].reject(new Error('Failed to fetch'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(on429).toHaveBeenCalledOnce();
+      expect(on5xx).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Fixes #223 (DWD "Rate limited" banner on genuine 502/503/504 server errors).

## The bug

`fetch-tile-layer.ts`'s generic `!r.ok` throw never tagged its HTTP status. Since every radar source carries a rate limiter, a statusless error automatically satisfied `limiter && !err.status` — so a real 502/503/504 from `maps.dwd.de` was indistinguishable from our own rate-limiting, showing the wrong banner and using the wrong retry pacing.

## The fix

- 5xx now gets its own `on5xx` callback, a distinct **"Radar server error — retrying"** banner, and a capped exponential backoff (1s → 2s → 4s → 8s → 16s → 30s, ~31s total) — more patient than the generic 3-attempt retry path, since a server that's still responding (just with an error) is more likely to recover than one that's silently dropping connections.
- Both the rate-limit and server-error banners now clear via a shared `onTileRecovered` signal (fires on any successful tile load). The rate-limit banner previously had **no hide path at all** — once shown it stayed until the next full card rebuild.
- Recovery also cancels the rate-limit path's fallback full-reinit (`_clearLayers()` + `_initRadar()` after 10s), so a loop that's already recovered isn't torn down for no reason.
- **Cross-transition precedence** (if both conditions are ever detected together): each still shows its own banner, but a confirmed 5xx suppresses the disruptive reinit fallback, since the per-tile backoff is already handling recovery and forcing a reinit would only add load to a server that's already struggling.
- `docs/data-sources.md` documents DWD's occasional flakiness, per the reporter's request.

## Tests

- `tests/fetch-abort.test.ts` — 6 new tests on the real `createFetchTile` path (502/503/504/429/statusless-CORS, via response-status mocks, not hand-copied branch logic).
- `tests/error-banners.test.ts` (new) — 11 tests on `RadarPlayer`'s banner state machine, including both cross-transition orderings.
- Full suite: 676 passing. Build clean.